### PR TITLE
Adding hypothesis to dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   # Install dependencies
   - conda create -n icenv python=2.7 numpy scipy pandas cython pytest pytest-cov pytables mysql-python
   - source activate icenv
-  - pip install coveralls
+  - pip install coveralls hypothesis-numpy
 
 script:
     - pytest --cov

--- a/Core/wfmFunctions_test.py
+++ b/Core/wfmFunctions_test.py
@@ -1,0 +1,9 @@
+from hypothesis import given
+from hypothesis.extra.numpy import arrays, np
+
+from wfmFunctions import subtract_baseline
+
+@given(arrays(float, (10,20)))
+def test_subtract_baseline(waveforms):
+    subtract_baseline(waveforms)
+    assert 'Did not crash'


### PR DESCRIPTION
Installed hypothesis and its numpy strategies extension in travis.yml.

Created a *very* basic test that uses both of these features, which can serve as a starting point for anyone wanting to write a property-based test using hypothesis.