### PR TITLE
Replaced MySQLdb with pymysql

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - conda update conda
 
   # Install dependencies
-  - conda create -n icenv python=2.7 numpy scipy pandas cython pytest pytest-cov pytables mysql-python
+  - conda create -n icenv python=2.7 numpy scipy pandas cython pytest pytest-cov pytables pymysql
   - source activate icenv
   - pip install coveralls hypothesis-numpy flaky
   - python $ICDIR/Database/download.py

--- a/Database/download.py
+++ b/Database/download.py
@@ -1,5 +1,7 @@
 import sqlite3
-import MySQLdb
+import pymysql
+import pymysql as MySQLdb
+pymysql.install_as_MySQLdb()
 import os
 from base64 import b64decode as dec
 


### PR DESCRIPTION
MySQLdb presents us with two problems:

1. it cannot be installed on OS X with conda

2. it is not available for Python 3

Replacing MySQLdb with pymysql is a quick solution that allows us to develop both in Python 3 and on Macs, even if in the long run we might prefer a different alternative.