### PR TITLE
Minimal port to Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 
 python:
 - 2.7
+- 3.5
 
 install:
   # Install conda
@@ -15,7 +16,7 @@ install:
   - conda update conda
 
   # Install dependencies
-  - conda create -n icenv python=2.7 numpy scipy pandas cython pytest pytest-cov pytables pymysql
+  - conda create -n icenv python=$TRAVIS_PYTHON_VERSION numpy scipy pandas cython pytest pytest-cov pytables pymysql
   - source activate icenv
   - pip install coveralls hypothesis-numpy flaky
   - python $ICDIR/Database/download.py

--- a/Core/wfmFunctions_test.py
+++ b/Core/wfmFunctions_test.py
@@ -1,7 +1,7 @@
 from hypothesis import given
 from hypothesis.extra.numpy import arrays, np
 
-from wfmFunctions import subtract_baseline
+from .wfmFunctions import subtract_baseline
 
 @given(arrays(float, (10,20)))
 def test_subtract_baseline(waveforms):

--- a/Database/loadDB.py
+++ b/Database/loadDB.py
@@ -3,6 +3,14 @@ import numpy as np
 import pandas as pd
 import os
 
+import sys
+if sys.version_info < (3,):
+    from future_builtins import map
+
+
+def tmap(*args):
+    return tuple(map(*args))
+
 # Run to take always the same calibration constant, etc for MC files
 # 3012 was the first SiPM calibration after remapping.
 runNumberForMC = 3012
@@ -69,21 +77,21 @@ where MinRun <= {0} and (MaxRun >= {0} or MaxRun is NULL)
 order by SensorID;'''.format(run_number)
     cursor.execute(sqlbaseline)
     data = cursor.fetchall()
-    baselines = np.array(map(lambda s: s[0], data))
+    baselines = np.array(tmap(lambda s: s[0], data))
 
     sqlnoisebins = '''select Energy from SipmNoiseBins
 where MinRun <= {0} and (MaxRun >= {0} or MaxRun is NULL)
 order by Bin;'''.format(run_number)
     cursor.execute(sqlnoisebins)
     data = cursor.fetchall()
-    noise_bins = np.array(map(lambda s: s[0], data))
+    noise_bins = np.array(tmap(lambda s: s[0], data))
 
     sqlnoise = '''select * from SipmNoise
 where MinRun <= {0} and (MaxRun >= {0} or MaxRun is NULL)
 order by SensorID;'''.format(run_number)
     cursor.execute(sqlnoise)
     data = cursor.fetchall()
-    data = map(lambda l: l[3:], data)
+    data = tmap(lambda l: l[3:], data)
     noise = np.array(data).reshape(1792, 300)
 
     return noise, noise_bins, baselines


### PR DESCRIPTION
The tests pass both in python 2.7 and python 3.5. .travis.yml has been updated to run the builds and tests automatically in both of these environments.

The required changes were mainly

1. An explicit relative import
2. dealing with a change in the behaviour of map

Of course, it is entirely possible that a whole lot of things for which there are no tests are broken, but the few tests that exist all pass.

