### PR TITLE
Using environment.yml to manage conda/pip envs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,19 +10,13 @@ install:
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
-  - export ICDIR=`pwd`
-  - export PYTHONPATH=$ICDIR:$PYTHONPATH
   - conda config --set always_yes yes --set changeps1 no
   - conda update conda
 
   # Install dependencies
-  - conda create -n icenv python=$TRAVIS_PYTHON_VERSION numpy scipy pandas cython pytest pytest-cov pytables pymysql
-  - source activate icenv
-  - pip install coveralls hypothesis-numpy flaky
-  - python $ICDIR/Database/download.py
+  - conda env create -f environment.yml
+  - source activate IC
+  - source env.sh
 
 script:
-    - pytest --cov
-
-after_success:
-  - coveralls
+    - pytest

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,3 @@
+export ICDIR=`pwd`
+export PYTHONPATH=$ICDIR:$PYTHONPATH
+python $ICDIR/Database/download.py

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,14 @@
+name: IC
+dependencies:
+- cython
+- numpy
+- pandas
+- pymysql
+- pytables
+- pytest
+- scipy
+- pip:
+  - hypothesis-numpy
+  - flaky
+
+


### PR DESCRIPTION
Things which need to be installed by conda and pip are specified in `environments.yml` instead of `.travis.yml`. That way, anyone who wants to work on the project won't have to inspect `.travis.yml` to find out what needs to be installed: the required conda env can now be created with 

    conda env create -f environment.yml

(This still needs improving, to make it easy to create different conda envs for python 2/3 development.)

Besides the conda environment, there are a few things that need to be set outside of conda. These have been gathered into `env.sh` and should be activated using

    source env.sh
