### PR TITLE
Silenced FutureWarning

### DIFF
--- a/Sierpe/FEE.py
+++ b/Sierpe/FEE.py
@@ -397,4 +397,4 @@ def daq_decimator(f_sample1, f_sample2, signal_in):
     """
 
     scale = int(f_sample1/f_sample2)
-    return signal.decimate(signal_in, scale, ftype='fir')
+    return signal.decimate(signal_in, scale, ftype='fir', zero_phase=False)


### PR DESCRIPTION
The warning was:

FutureWarning:  Note: Decimate's zero_phase keyword argument will default to True in a future release. Until then, decimate defaults to one-way filtering for backwards compatibility. Ideally, always set this argument explicitly.