### PR TITLE
Added OS X to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,21 @@
-sudo: false
-language: python
+language: generic
+sudo:     false
 
-python:
-- 2.7
-- 3.5
+env:
+  - IC_PYTHON_VERSION=2.7
+  - IC_PYTHON_VERSION=3.5
+
+os:
+  - linux
+  - osx
+
+
+before_install:
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CONDA_OS=MacOSX; else export CONDA_OS=Linux; fi
 
 install:
   # Install conda
-  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - wget http://repo.continuum.io/miniconda/Miniconda-latest-${CONDA_OS}-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda config --set always_yes yes --set changeps1 no
@@ -15,7 +23,7 @@ install:
 
   # Install dependencies
   #- conda env create -f environment.yml
-  - conda create -n IC python=$TRAVIS_PYTHON_VERSION numpy scipy pandas cython pytest pytables pymysql
+  - conda create -n IC python=$IC_PYTHON_VERSION numpy scipy pandas cython pytest pytables pymysql
   - source activate IC
   - pip install hypothesis-numpy
   - pip install flaky


### PR DESCRIPTION
This commit runs four builds on Travis:

   linux & Python 2.7
   linux & Python 3.5
   OS X  & Python 2.7
   OS X  & Python 3.5

The Travis OS X servers do not provide Python installations, but this is
not a big problem for us, given that we use a conda installation of
Python rather than the Travis one anyway. I have switched the Travis
language from Python to generic, to make the OS X and linux procedures
as similar as possible. This should also bring the slight advantage of
making the Linux builds slightly faster, as we do not waste time on
installing the Travis Python, which we then do not use.

There are two small downsides to this, entirely related to Travis:

1. There aren't many Travis OS X servers, and there is sometimes quite a
   backlog of jobs for them. Expect the OS X builds to spend some time
   waiting in a queue before starting to run. In getting this set up I
   observed queue times from around 2 minutes, to 15 minutes.

2. The build takes about twice as long to execute on the OS X servers as
   compared to the Linux servers.

This takes the total execution time up to about 10 minutes (from about 4
minutes), and I think that there is a limit of 50 minutes. So there's
no danger of our jobs being cut short any time soon.

In short, this commit results in needing to wait longer (sometimes as
much as 20 minutes as opposed to 2 minutes) before getting official
Travis confirmation that a push is OK.

Of course, unofficial feedback from the two linux builds is available
just as quickly as it was before (about 2 minutes).

The upside is that we get automatic feedback of breakages on OS X. We
also get confirmation that it *DOES* work on OS X, so JJ doesn't have an
excuse for switching off all sorts of useful features and breaking all
sorts of code, just because his machine is misconfigured :-)