### PR TITLE
FEE_test is much less flaky

### DIFF
--- a/Sierpe/FEE_test.py
+++ b/Sierpe/FEE_test.py
@@ -73,7 +73,7 @@ def test_spe_to_adc():
     assert 23 < adc_to_pes     < 23.1
     assert 24 < adc_to_pes_lpf < 24.1
 
-@flaky(max_runs=10, min_passes=5)
+@flaky(max_runs=3, min_passes=1)
 @pytest.mark.feetest
 def test_FEE():
     """
@@ -98,4 +98,4 @@ def test_FEE():
     energy_in  = np.sum(signal_i[0:11000] * FE.i_to_adc())
     diff = 1000 * abs((energy_in - energy_mea) / energy_in)
 
-    assert diff < 0.5
+    assert diff < 0.2


### PR DESCRIPTION
Presumably as a consequence of JJ's removal of find_baseline from the
chain, or some other change (perhaps in the Py3 work) that reduces the
abundance of NaNs.

Reduced max_runs, min_passes from 10,5 to 3,1

Also reduced the diff cutoff from 0.5 to 0.2

This will speed up the test suite ever so slightly.