### PR TITLE
Marking the OS X builds al allowed failures in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: generic
 sudo:     false
 
+matrix:
+  fast_finish: true
+  allow_failures:
+  - os: osx
 env:
   - IC_PYTHON_VERSION=2.7
   - IC_PYTHON_VERSION=3.5


### PR DESCRIPTION
The OS X builds are sometimes very slow. This can significantly delay approval of pull requests. So they have been marked as allowed failures and the fast_build option has been switched on. This allowes pull requests to be merged as soon as the Linux builds pass