### PR TITLE
Keeping an eye on Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,12 @@ matrix:
   fast_finish: true
   allow_failures:
   - os: osx
+  - env: IC_PYTHON_VERSION=3.6
+
 env:
   - IC_PYTHON_VERSION=2.7
   - IC_PYTHON_VERSION=3.5
+  - IC_PYTHON_VERSION=3.6
 
 os:
   - linux


### PR DESCRIPTION
Added Python 3.6 as an allowed failure to the Travis build
matrix. Like this we will know when all our dependencies are available
on conda in Python 3.6.