### PR TITLE
Exclude documentation branches from Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ os:
   - linux
   - osx
 
+branches:
+  except:
+    - /^docs\..*$/
+
 install:
   - source manage.sh install ${IC_PYTHON_VERSION}
 


### PR DESCRIPTION
There is absolutely no point in triggering travis builds on branches
which do not modify any source code. One obvious example of such
branches would be those which work on documntation only.

Thus we instruct Travis not to build branches whose names start with
`docs.` (note the dot at the end).

Henceforth, if you are going to work on documentation, do so in a
branch whose name starts with `docs.`.

Note that you can instruct Travis to skip the build for *any* commit
by including `[skip ci]` or `[ci skip]` in the commit message.