### PR TITLE
Remove .coveragrc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,0 @@
-[report]
-omit =
-    */python?.?/*
-	*tests/*


### PR DESCRIPTION
We decided not to use automatic coverage checking, so this file is now
obsolete.