### PR TITLE
Ease making a number of temporary, shared test files

### DIFF
--- a/invisible_cities/cities/conftest.py
+++ b/invisible_cities/cities/conftest.py
@@ -1,0 +1,5 @@
+import pytest
+
+@pytest.fixture(scope='session')
+def irene_diomira_chain_tmpdir(tmpdir_factory):
+    return tmpdir_factory.mktemp('irene_diomira_tests')

--- a/invisible_cities/cities/diomira_test.py
+++ b/invisible_cities/cities/diomira_test.py
@@ -15,8 +15,6 @@ from glob import glob
 import tables as tb
 import numpy as np
 
-import pytest
-
 from   invisible_cities.core.configure import configure
 import invisible_cities.core.tbl_functions as tbl
 import invisible_cities.core.wfm_functions as wfm
@@ -28,17 +26,12 @@ from   invisible_cities.cities.diomira import Diomira
 from   invisible_cities.core.random_sampling \
      import NoiseSampler as SiPMsNoiseSampler
 
-@pytest.fixture(scope='session')
-def electrons_40keV_z250_RWF_h5(tmpdir_factory):
-    return (str(tmpdir_factory
-                .mktemp('diomira_tests')
-                .join('electrons_40keV_z250_RWF.h5')))
 
-def test_diomira_run(electrons_40keV_z250_RWF_h5):
+def test_diomira_run(irene_diomira_chain_tmpdir):
     """Test that DIOMIRA runs on default config parameters."""
-
+    RWF_file = str(irene_diomira_chain_tmpdir.join('electrons_40keV_z250_RWF.h5'))
     conf_file = os.environ['ICDIR'] + '/config/diomira.conf'
-    CFP = configure(['DIOMIRA','-c', conf_file, '-o', electrons_40keV_z250_RWF_h5])
+    CFP = configure(['DIOMIRA','-c', conf_file, '-o', RWF_file])
     fpp = Diomira()
     files_in = glob(CFP['FILE_IN'])
     files_in.sort()
@@ -54,10 +47,10 @@ def test_diomira_run(electrons_40keV_z250_RWF_h5):
 
     assert nevt == nevts
 
-def test_diomira_fee_table(electrons_40keV_z250_RWF_h5):
+def test_diomira_fee_table(irene_diomira_chain_tmpdir):
     """Test that FEE table reads back correctly with expected values."""
-
-    with tb.open_file(electrons_40keV_z250_RWF_h5, 'r+') as e40rwf:
+    RWF_file = str(irene_diomira_chain_tmpdir.join('electrons_40keV_z250_RWF.h5'))
+    with tb.open_file(RWF_file, 'r+') as e40rwf:
         fee = tbl.read_FEE_table(e40rwf.root.MC.FEE)
         feep = fee['fee_param']
         eps = 1e-04
@@ -84,14 +77,15 @@ def test_diomira_fee_table(electrons_40keV_z250_RWF_h5):
         assert abs(feep.CEILING - FEE.CEILING)             < eps
 
 
-def test_diomira_cwf_blr(electrons_40keV_z250_RWF_h5):
+def test_diomira_cwf_blr(irene_diomira_chain_tmpdir):
     """This is the most rigurous test of the suite. It reads back the
        RWF and BLR waveforms written to disk by DIOMIRA, and computes
        CWF (using deconvoution algorithm), then checks that the CWF match
        the BLR within 1 %.
     """
     eps = 1
-    with tb.open_file(electrons_40keV_z250_RWF_h5, 'r+') as e40rwf:
+    RWF_file = str(irene_diomira_chain_tmpdir.join('electrons_40keV_z250_RWF.h5'))
+    with tb.open_file(RWF_file, 'r+') as e40rwf:
 
         pmtrwf = e40rwf.root.RD.pmtrwf
         pmtblr = e40rwf.root.RD.pmtblr
@@ -113,7 +107,7 @@ def test_diomira_cwf_blr(electrons_40keV_z250_RWF_h5):
                 assert diff < eps
 
 
-def test_diomira_sipm(electrons_40keV_z250_RWF_h5):
+def test_diomira_sipm(irene_diomira_chain_tmpdir):
     """This test checks that the number of SiPms surviving a hard energy
         cut (50 pes) is always small (<10). The test exercises the full
        construction of the SiPM vectors as well as the noise suppression.

--- a/invisible_cities/cities/diomira_test.py
+++ b/invisible_cities/cities/diomira_test.py
@@ -2,9 +2,10 @@
 code: diomira_test.py
 description: test suite for diomira
 author: J.J. Gomez-Cadenas
-IC core team: Jacek Generowicz, JJGC, G. Martinez, J.A. Hernando, J.M Benlloch
+IC core team: Jacek Generowicz, JJGC,
+G. Martinez, J.A. Hernando, J.M Benlloch
 package: invisible cities. See release notes and licence
-last changed: 09-11-2017
+last changed: 01-12-2017
 """
 from __future__ import print_function
 from __future__ import absolute_import

--- a/invisible_cities/cities/irene.py
+++ b/invisible_cities/cities/irene.py
@@ -9,7 +9,7 @@ import tables as tb
 import matplotlib.pyplot as plt
 
 from invisible_cities.core.nh5 import RunInfo, EventInfo
-from invisible_cities.core.Nh5 import S12, S2Si
+from invisible_cities.core.nh5 import S12, S2Si
 import invisible_cities.core.mpl_functions as mpl
 import invisible_cities.core.wfm_functions as wfm
 import invisible_cities.core.peak_functions as pf
@@ -31,195 +31,199 @@ class Irene:
     The city of IRENE performs a fast processing directly
     from raw data (pmtrwf and sipmrwf) to PMAPS.
     It is optimized for speed (use of CYTHON functions) and intended
-    for fast processing of data
-
+    for fast processing of data.
     """
     def __init__(self, run_number=0):
         """
-        Inits the machine with the run number
-        loads the data base to access calibration and geometry
-        sets all switches to default value (False most of the time)
+        Init the machine with the run number.
+        Load the data base to access calibration and geometry.
+        Sets all switches to default value
         """
+        # NB: following JCK-1 convention
         self.run_number = run_number
-        DataPMT = load_db.DataPMT(run_number)
-        DataSiPM = load_db.DataSiPM(run_number)
 
-        self.adc_to_pes = abs(DataPMT.adc_to_pes.values).astype(np.double)
-        self.sipm_adc_to_pes = DataSiPM.adc_to_pes.values.astype(np.double)
-        self.coeff_c = DataPMT.coeff_c.values.astype(np.double)
-        self.coeff_blr = DataPMT.coeff_blr.values.astype(np.double)
-        self.xs = DataSiPM.X.values
-        self.ys = DataSiPM.Y.values
+        # calibration an geometry constants from DB
+        DataPMT         = load_db.DataPMT(run_number)
+        DataSiPM        = load_db.DataSiPM(run_number)
 
-        self.setFiles = False
-        self.setPmapStore = False
+        self.xs              = DataSiPM.X.values
+        self.ys              = DataSiPM.Y.values
+        self.adc_to_pes      = (
+            abs(DataPMT.adc_to_pes.values).astype(np.double))
+        self.sipm_adc_to_pes = (
+            DataSiPM.adc_to_pes.values.astype(np.double))
+        self.coeff_c         = (
+            DataPMT.coeff_c.values.astype(np.double))
+        self.coeff_blr       = (
+            DataPMT.coeff_blr.values.astype(np.double))
 
         # BLR default values (override with set_BLR)
-        self.n_baseline = 28000
-        self.thr_trigger = 5*units.adc
+        self.n_baseline   = 28000
+        self.thr_trigger  = 5*units.adc
 
         # MAU default values (override with set_MAU)
-        self.n_MAU =  100
-        self.thr_MAU = thr_MAU=3*units.adc
+        self.n_MAU        = 100
+        self.thr_MAU      = thr_MAU=3*units.adc
 
         # CSUM default values (override with set_CSUM)
-        self.thr_csum= 1*units.pes
+        self.thr_csum     = 1*units.pes
 
-        self.setS1 = False
-        self.setS2 = False
-        self.setSiPM = False
-
-        self.plot_csum = False
+        # set switches
+        self.setFiles     = False
+        self.setPmapStore = False
+        self.setS1        = False
+        self.setS2        = False
+        self.setSiPM      = False
+        self.plot_csum    = False
         self.plot_csum_S1 = False
-        self.plot_s1 = False
-        self.plot_s2 = False
-        self.plot_sipm = False
-        self.plot_sipmzs = False
-        self.plot_simap = False
+        self.plot_s1      = False
+        self.plot_s2      = False
+        self.plot_sipm    = False
+        self.plot_sipmzs  = False
+        self.plot_simap   = False
 
-        self.nprint = 1000000
-        self.signal_start=0
-        self.signal_end=1200
-        self.ymax = 200
-        self.S1_start=100
-        self.S1_end=100.5
-        self.S1_ymax = 5
+        # defaul parameters
+        self.nprint       = 1000000
+        self.signal_start = 0
+        self.signal_end   = 1200
+        self.ymax         = 200
+        self.S1_start     = 100
+        self.S1_end       = 100.5
+        self.S1_ymax      = 5
 
-
-    def set_plot(self, plot_csum=False, plot_csum_S1=False,
-                 plot_s1=False, plot_s2=False,
-                 plot_sipm=False, plot_sipmzs=False, plot_simap=False,
+    def set_plot(self,
+                 plot_csum=False,
+                 plot_csum_S1=False,
+                 plot_s1=False,
+                 plot_s2=False,
+                 plot_sipm=False,
+                 plot_sipmzs=False,
+                 plot_simap=False,
                  signal_start=0, signal_end=1200, ymax = 200,
                  S1_start=100, S1_end=100.5, S1_ymax=5):
         """Decide what to plot."""
 
-        self.plot_csum = plot_csum
+        self.plot_csum    = plot_csum
         self.plot_csum_S1 = plot_csum_S1
-        self.plot_s1 = plot_s1
-        self.plot_s2 = plot_s2
-        self.plot_sipm = plot_sipm
-        self.plot_sipmzs = plot_sipmzs
-        self.plot_simap = plot_simap
+        self.plot_s1      = plot_s1
+        self.plot_s2      = plot_s2
+        self.plot_sipm    = plot_sipm
+        self.plot_sipmzs  = plot_sipmzs
+        self.plot_simap   = plot_simap
         self.signal_start = signal_start
-        self.signal_end = signal_end
-        self.ymax = ymax
-        self.S1_start = S1_start
-        self.S1_end = S1_end
-        self.S1_ymax = S1_ymax
-
+        self.signal_end   = signal_end
+        self.ymax         = ymax
+        self.S1_start     = S1_start
+        self.S1_end       = S1_end
+        self.S1_ymax      = S1_ymax
 
     def set_print(self, nprint=10):
         """Print frequency."""
         self.nprint = nprint
 
-
     def set_input_files(self, input_files):
         """Set the input files."""
         self.input_files = input_files
-        self.setFiles = True
-
+        self.setFiles    = True
 
     def set_pmap_store(self, pmap_file, compression='ZLIB4'):
         """Set the input files."""
-        filename = pmap_file
-        self.pmapFile = tb.open_file(filename, "w",
-                          filters=tbl.filters(compression))
+        # open pmap store
+        self.pmapFile = tb.open_file(
+            pmap_file, "w", filters=tbl.filters(compression))
 
-        pmapsgroup = self.pmapFile.create_group(self.pmapFile.root,
-                                                "PMAPS")
+        # create a group
+        pmapsgroup = self.pmapFile.create_group(
+            self.pmapFile.root, "PMAPS")
 
         # create tables to store pmaps
-        self.s1t = self.pmapFile.create_table(pmapsgroup,
-                                                 "S1", S12,
-                                                 "S1 Table",
-                                                 tbl.filters(compression))
+        self.s1t  = self.pmapFile.create_table(
+            pmapsgroup, "S1", S12, "S1 Table",
+            tbl.filters(compression))
 
-        self.s2t = self.pmapFile.create_table(pmapsgroup,
-                                                 "S2", S12,
-                                                 "S2 Table",
-                                                 tbl.filters(compression))
+        self.s2t  = self.pmapFile.create_table(
+            pmapsgroup, "S2", S12, "S2 Table",
+            tbl.filters(compression))
 
-        self.s2sit = self.pmapFile.create_table(pmapsgroup,
-                                                 "S2Si", S2Si,
-                                                 "S2Si Table",
-                                                 tbl.filters(compression))
+        self.s2sit = self.pmapFile.create_table(
+            pmapsgroup, "S2Si", S2Si, "S2Si Table",
+            tbl.filters(compression))
+
         self.s1t.cols.event.create_index()
         self.s2t.cols.event.create_index()
         self.s2sit.cols.event.create_index()
 
         # Create group for run info
         if self.run_number >0:
-            rungroup = self.pmapFile.create_group(self.pmapFile.root, "Run")
+            rungroup     = self.pmapFile.create_group(
+               self.pmapFile.root, "Run")
 
-            self.runInfot = self.pmapFile.create_table(rungroup,"runInfo",
-                                                   RunInfo, "runInfo",
-                                                   tbl.filters(compression))
-            self.evtInfot= self.pmapFile.create_table(rungroup, "events",
-                                                  EventInfo, "events",
-                                                  tbl.filters(compression))
+            self.runInfo = self.pmapFile.create_table(
+                rungroup, "runInfo", RunInfo, "runInfo",
+                tbl.filters(compression))
+
+            self.evtInfot = self.pmapFile.create_table(
+                rungroup, "events", EventInfo, "events",
+                tbl.filters(compression))
 
         self.setPmapStore = True
 
     def set_BLR(self, n_baseline=38000, thr_trigger=5*units.adc):
         """Parameters of the BLR."""
-        self.n_baseline = n_baseline
+        self.n_baseline  = n_baseline
         self.thr_trigger = thr_trigger
 
     def set_MAU(self, n_MAU=100, thr_MAU=3*units.adc):
         """Parameters of the MAU used to remove low frequency noise."""
-        self.n_MAU =  n_MAU
+        self.n_MAU   =  n_MAU
         self.thr_MAU = thr_MAU
 
     def set_CSUM(self, thr_csum=1*units.pes):
         """Parameter for ZS in the calibrated sum."""
-        self.thr_csum= thr_csum
+        self.thr_csum = thr_csum
 
     def set_S1(self, tmin=0*units.mus, tmax=590*units.mus,
                stride=4, lmin=4, lmax=20):
         """Parameters for S1 search."""
-        self.tmin_s1 = tmin
-        self.tmax_s1 = tmax
+        self.tmin_s1   = tmin
+        self.tmax_s1   = tmax
         self.stride_s1 = stride
-        self.lmin_s1 = lmin
-        self.lmax_s1 = lmax
-        self.setS1 = True
+        self.lmin_s1   = lmin
+        self.lmax_s1   = lmax
+        self.setS1     = True
 
     def set_S2(self, tmin=590*units.mus, tmax=620*units.mus,
                stride=40, lmin=100, lmax=1000000):
         """Parameters for S2 search."""
-        self.tmin_s2 = tmin
-        self.tmax_s2 = tmax
+        self.tmin_s2   = tmin
+        self.tmax_s2   = tmax
         self.stride_s2 = stride
-        self.lmin_s2 = lmin
-        self.lmax_s2 = lmax
-        self.setS2 = True
-
+        self.lmin_s2   = lmin
+        self.lmax_s2   = lmax
+        self.setS2     = True
 
     def set_SiPM(self, thr_zs=5*units.pes, thr_sipm_s2=50*units.pes):
         """Parameters for SiPM analysis."""
-        self.thr_zs = thr_zs
+        self.thr_zs      = thr_zs
         self.thr_sipm_s2 = thr_sipm_s2
-        self.setSiPM = True
-
+        self.setSiPM     = True
 
     def store_pmaps(self, event, evt, S1, S2, S2Si):
         """Store PMAPS."""
         if self.run_number >0:
             # Event info
-            row = self.evtInfot.row
+            row     = self.evtInfot.row
             evtInfo = self.eventsInfo[evt]
 
             row['evt_number'] = evtInfo[0]
-            row['timestamp'] = evtInfo[1]
+            row['timestamp']  = evtInfo[1]
             row.append()
             self.evtInfot.flush()
-
         #S1
         row = self.s1t.row
-
         for i in S1.keys():
             time = S1[i][0]
-            ene = S1[i][1]
+            ene  = S1[i][1]
             assert(len(time) == len(ene))
             for j in range(len(time)):
                 row["event"] = event
@@ -230,17 +234,14 @@ class Irene:
                     row["evtDaq"] = event
                 row["peak"] = i
                 row["time"] = time[j]
-                row["ene"] = ene[j]
+                row["ene"]  = ene[j]
                 row.append()
-
         self.s1t.flush()
-
         #S2
         row = self.s2t.row
-
         for i in S2.keys():
             time = S2[i][0]
-            ene = S2[i][1]
+            ene  = S2[i][1]
             assert(len(time) == len(ene))
             for j in range(len(time)):
                 row["event"] = event
@@ -251,19 +252,16 @@ class Irene:
                     row["evtDaq"] = event
                 row["peak"] = i
                 row["time"] = time[j]
-                row["ene"] = ene[j]
+                row["ene"]  = ene[j]
                 row.append()
-
         self.s2t.flush()
-
-        # S2
+        # S2Si
         row = self.s2sit.row
-
         for i in S2Si.keys():
             sipml = S2Si[i]
             for sipm in sipml:
                 nsipm = sipm[0]
-                ene = sipm[1]
+                ene   = sipm[1]
                 for j in range(len(ene)):
                     if ene[j] > 0:
                         row["event"] = event
@@ -272,21 +270,18 @@ class Irene:
                             row["evtDaq"] = evtInfo[0]
                         else:
                             row["evtDaq"] = event
-                        row["peak"] = i
-                        row["nsipm"] = nsipm
+                        row["peak"]    = i
+                        row["nsipm"]   = nsipm
                         row["nsample"] = j
-                        row["ene"] = ene[j]
+                        row["ene"]     = ene[j]
                         row.append()
-
         self.s2t.flush()
-
 
     def plot_ene_sipm(self, S2Si, radius=3):
         """
         plots the reconstructed energy of the SiPMs
         input: sipm dictionary
         """
-
         r = np.ones(len(self.xs)) * radius
         col = np.zeros(len(self.xs))
         for i in S2Si.keys():
@@ -300,7 +295,6 @@ class Irene:
         plt.subplot(aspect="equal")
         mpl.circles(self.xs, self.ys, r, c=col, alpha=0.5, ec="none")
         plt.colorbar()
-
         plt.xlim(-198, 198)
         plt.ylim(-198, 198)
 
@@ -311,20 +305,18 @@ class Irene:
         store_pmaps decides whether to store pmaps or not
         """
         n_events_tot = 0
-
-        if self.setFiles == False:
-            raise IOError('must set files before running')
+        # check the state of the machine
         if len(self.input_files) == 0:
             raise IOError('input file list is empty')
 
-
-        if self.setS1 == False:
+        if self.setFiles == False:
+            raise IOError('must set files before running')
+        if self.setS1    == False:
             raise IOError('must set S1 parameters before running')
-        if self.setS2 == False:
+        if self.setS2    == False:
             raise IOError('must set S2 parameters before running')
-        if self.setSiPM == False:
+        if self.setSiPM  == False:
             raise IOError('must set Sipm parameters before running')
-
 
         print("""
                  IRENE will run a max of {} events
@@ -360,25 +352,22 @@ class Irene:
         # loop over input files
         first=False
         for ffile in self.input_files:
-
             print("Opening", ffile, end="... ")
             filename = ffile
-
             try:
                 with tb.open_file(filename, "r+") as h5in:
-                    pmtrwf = h5in.root.RD.pmtrwf
+                    # access RWF
+                    pmtrwf  = h5in.root.RD.pmtrwf
                     sipmrwf = h5in.root.RD.sipmrwf
 
                     if self.run_number > 0:
                         self.eventsInfo = h5in.root.Run.events
 
-                    NEVT, NPMT, PMTWL = pmtrwf.shape
+                    NEVT, NPMT, PMTWL   = pmtrwf.shape
                     NEVT, NSIPM, SIPMWL = sipmrwf.shape
-
                     print("Events in file = {}".format(NEVT))
 
                     if first == False:
-
                         print_configuration({"# PMT": NPMT,
                                              "PMT WL": PMTWL,
                                              "# SiPM": NSIPM,
@@ -386,85 +375,98 @@ class Irene:
 
                         self.signal_t = np.arange(0., PMTWL * 25, 25)
                         first = True
-
+                    # loop over all events in file unless reach nmax
                     for evt in range(NEVT):
                         # deconvolve
-                        CWF = blr.deconv_pmt(pmtrwf[evt],
-                                             self.coeff_c, self.coeff_blr,
-                                             n_baseline=self.n_baseline,
-                                             thr_trigger=self.thr_trigger)
-
+                        CWF = blr.deconv_pmt(
+                          pmtrwf[evt], self.coeff_c, self.coeff_blr,
+                          n_baseline=self.n_baseline,
+                          thr_trigger=self.thr_trigger)
                         # calibrated PMT sum
-                        csum = cpf.calibrated_pmt_sum(CWF,
-                                                      self.adc_to_pes,
-                                                      n_MAU=self.n_MAU,
-                                                      thr_MAU=self.thr_MAU)
+                        csum = cpf.calibrated_pmt_sum(
+                          CWF, self.adc_to_pes,
+                          n_MAU=self.n_MAU,
+                          thr_MAU=self.thr_MAU)
+                        # plots
                         if self.plot_csum:
-                            mpl.plot_signal(self.signal_t/units.mus,
-                                            csum, title="calibrated sum, ZS",
-                                            signal_start=self.signal_start,
-                                            signal_end=self.signal_end,
-                                            ymax = self.ymax,
-                                            t_units='mus', units="pes")
+                            mpl.plot_signal(
+                               self.signal_t/units.mus, csum,
+                               title="calibrated sum, ZS",
+                               signal_start=self.signal_start,
+                               signal_end=self.signal_end,
+                               ymax = self.ymax,
+                               t_units='mus',
+                               units="pes")
 
                         if self.plot_csum_S1:
-                            mpl.plot_signal(self.signal_t/units.mus,
-                                            csum, title="calibrated sum, S1",
-                                            signal_start=self.S1_start,
-                                            signal_end=self.S1_end,
-                                            ymax = self.S1_ymax,
-                                            t_units='mus', units="pes")
-
+                            mpl.plot_signal(
+                               self.signal_t/units.mus, csum, title="calibrated sum, S1",
+                               signal_start=self.S1_start,
+                               signal_end=self.S1_end,
+                               ymax = self.S1_ymax,
+                               t_units='mus',
+                               units="pes")
                             plt.show()
                             raw_input('->')
-
+                        # SiPMs
                         # Supress samples below threshold (in pes)
-                        wfzs_ene, wfzs_indx = cpf.wfzs(csum,
-                                                       threshold=self.thr_csum)
-
-                    #wfzs_t = cpf.time_from_index(wfzs_indx)
-
-                        # find S1 and S2
-                        S1 = cpf.find_S12(wfzs_ene, wfzs_indx,
-                                         tmin=self.tmin_s1,
-                                         tmax=self.tmax_s1,
-                                         lmin=self.lmin_s1, lmax=self.lmax_s1,
-                                         stride=self.stride_s1,
-                                         rebin=False)
-
-                        S2 = cpf.find_S12(wfzs_ene, wfzs_indx,
-                                         tmin=self.tmin_s2,
-                                         tmax=self.tmax_s2,
-                                         lmin=self.lmin_s2, lmax=self.lmax_s2,
-                                         stride=self.stride_s2,
-                                         rebin=True,
-                                         rebin_stride=self.stride_s2)
-
+                        wfzs_ene, wfzs_indx = cpf.wfzs(
+                            csum, threshold=self.thr_csum)
+                        # find S1
+                        S1 = cpf.find_S12(wfzs_ene,
+                                          wfzs_indx,
+                                          tmin=self.tmin_s1,
+                                          tmax=self.tmax_s1,
+                                          lmin=self.lmin_s1,
+                                          lmax=self.lmax_s1,
+                                          stride=self.stride_s1,
+                                          rebin=False)
+                        # find S2
+                        S2 = cpf.find_S12(wfzs_ene,
+                                          wfzs_indx,
+                                          tmin=self.tmin_s2,
+                                          tmax=self.tmax_s2,
+                                          lmin=self.lmin_s2,
+                                          lmax=self.lmax_s2,
+                                          stride=self.stride_s2,
+                                          rebin=True,
+                                          rebin_stride=self.stride_s2)
+                        #plot S1 & S2
                         if self.plot_s1:
                             pf.scan_S12(S1)
                         if self.plot_s2:
                             pf.scan_S12(S2)
-
-                        # sipms
-
+                        # plot sipms
                         if self.plot_sipm:
-                            mpl.plot_sipm(sipmrwf[evt], nmin=0, nmax=16, x=4, y=4)
-
-                        sipmzs = cpf.signal_sipm(sipmrwf[evt],
-                                                 self.sipm_adc_to_pes,
-                                                 thr=self.thr_zs,
-                                                 n_MAU=self.n_MAU)
-                        if self.plot_sipmzs:
-                            mpl.plot_sipm(sipmzs, nmin=0, nmax=16, x=4, y=4)
+                            mpl.plot_sipm(sipmrwf[evt],
+                                          nmin=0,
+                                          nmax=16,
+                                          x=4, y=4)
                             plt.show()
                             raw_input('->')
-
+                        # SiPMs zero suppression
+                        sipmzs = cpf.signal_sipm(
+                            sipmrwf[evt], self.sipm_adc_to_pes,
+                            thr=self.thr_zs,
+                            n_MAU=self.n_MAU)
+                        # plot
+                        if self.plot_sipmzs:
+                            mpl.plot_sipm(sipmzs,
+                                          nmin=0,
+                                          nmax=16,
+                                          x=4, y=4)
+                            plt.show()
+                            raw_input('->')
+                        # select SIPM ZS and create S2Si
                         SIPM = cpf.select_sipm(sipmzs)
-                        S2Si = pf.sipm_S2_dict(SIPM, S2, thr=self.thr_sipm_s2)
+                        S2Si = pf.sipm_S2_dict(SIPM,
+                                               S2,
+                                               thr=self.thr_sipm_s2)
 
                         if store_pmaps == True:
                             if self.setPmapStore == False:
-                                raise IOError('must set PMAPS before storing')
+                                raise IOError(
+                                  'must set PMAPS before storing')
                             self.store_pmaps(n_events_tot, evt,
                                              S1, S2, S2Si)
 
@@ -479,7 +481,9 @@ class Irene:
                               format(evt, n_events_tot))
 
                         if n_events_tot >= nmax and nmax > -1:
-                            print('reached maximum number of events (={})'.format(nmax))
+                            print(
+                              'reached max nof of events (={})'.format(
+                                 nmax))
                             break
 
 

--- a/invisible_cities/cities/irene.py
+++ b/invisible_cities/cities/irene.py
@@ -1,4 +1,3 @@
-
 from __future__ import print_function
 import sys
 
@@ -37,7 +36,7 @@ class Irene:
         """
         Init the machine with the run number.
         Load the data base to access calibration and geometry.
-        Sets all switches to default value
+        Sets all switches to default value.
         """
         # NB: following JCK-1 convention
         self.run_number = run_number
@@ -59,14 +58,14 @@ class Irene:
 
         # BLR default values (override with set_BLR)
         self.n_baseline   = 28000
-        self.thr_trigger  = 5*units.adc
+        self.thr_trigger  = 5 * units.adc
 
         # MAU default values (override with set_MAU)
         self.n_MAU        = 100
-        self.thr_MAU      = thr_MAU=3*units.adc
+        self.thr_MAU      = thr_MAU = 3 * units.adc
 
         # CSUM default values (override with set_CSUM)
-        self.thr_csum     = 1*units.pes
+        self.thr_csum     = 1 * units.pes
 
         # set switches
         self.setFiles     = False
@@ -92,15 +91,19 @@ class Irene:
         self.S1_ymax      = 5
 
     def set_plot(self,
-                 plot_csum=False,
-                 plot_csum_S1=False,
-                 plot_s1=False,
-                 plot_s2=False,
-                 plot_sipm=False,
-                 plot_sipmzs=False,
-                 plot_simap=False,
-                 signal_start=0, signal_end=1200, ymax = 200,
-                 S1_start=100, S1_end=100.5, S1_ymax=5):
+                 plot_csum    = False,
+                 plot_csum_S1 = False,
+                 plot_s1      = False,
+                 plot_s2      = False,
+                 plot_sipm    = False,
+                 plot_sipmzs  = False,
+                 plot_simap   = False,
+                 signal_start =    0,
+                 signal_end   = 1200,
+                 ymax         =  200,
+                 S1_start     =  100,
+                 S1_end       =  100.5,
+                 S1_ymax      =    5):
         """Decide what to plot."""
 
         self.plot_csum    = plot_csum
@@ -149,8 +152,8 @@ class Irene:
             pmapsgroup, "S2Si", S2Si, "S2Si Table",
             tbl.filters(compression))
 
-        self.s1t.cols.event.create_index()
-        self.s2t.cols.event.create_index()
+        self.s1t  .cols.event.create_index()
+        self.s2t  .cols.event.create_index()
         self.s2sit.cols.event.create_index()
 
         # Create group for run info
@@ -168,21 +171,21 @@ class Irene:
 
         self.setPmapStore = True
 
-    def set_BLR(self, n_baseline=38000, thr_trigger=5*units.adc):
+    def set_BLR(self, n_baseline=38000, thr_trigger=5 * units.adc):
         """Parameters of the BLR."""
         self.n_baseline  = n_baseline
         self.thr_trigger = thr_trigger
 
-    def set_MAU(self, n_MAU=100, thr_MAU=3*units.adc):
+    def set_MAU(self, n_MAU=100, thr_MAU=3 * units.adc):
         """Parameters of the MAU used to remove low frequency noise."""
-        self.n_MAU   =  n_MAU
+        self.n_MAU   =   n_MAU
         self.thr_MAU = thr_MAU
 
-    def set_CSUM(self, thr_csum=1*units.pes):
+    def set_CSUM(self, thr_csum=1 * units.pes):
         """Parameter for ZS in the calibrated sum."""
         self.thr_csum = thr_csum
 
-    def set_S1(self, tmin=0*units.mus, tmax=590*units.mus,
+    def set_S1(self, tmin=0 * units.mus, tmax=590 * units.mus,
                stride=4, lmin=4, lmax=20):
         """Parameters for S1 search."""
         self.tmin_s1   = tmin
@@ -192,7 +195,7 @@ class Irene:
         self.lmax_s1   = lmax
         self.setS1     = True
 
-    def set_S2(self, tmin=590*units.mus, tmax=620*units.mus,
+    def set_S2(self, tmin=590 * units.mus, tmax=620 * units.mus,
                stride=40, lmin=100, lmax=1000000):
         """Parameters for S2 search."""
         self.tmin_s2   = tmin
@@ -202,7 +205,7 @@ class Irene:
         self.lmax_s2   = lmax
         self.setS2     = True
 
-    def set_SiPM(self, thr_zs=5*units.pes, thr_sipm_s2=50*units.pes):
+    def set_SiPM(self, thr_zs=5 * units.pes, thr_sipm_s2=50 * units.pes):
         """Parameters for SiPM analysis."""
         self.thr_zs      = thr_zs
         self.thr_sipm_s2 = thr_sipm_s2
@@ -219,9 +222,10 @@ class Irene:
             row['timestamp']  = evtInfo[1]
             row.append()
             self.evtInfot.flush()
+
         #S1
         row = self.s1t.row
-        for i in S1.keys():
+        for i in S1:
             time = S1[i][0]
             ene  = S1[i][1]
             assert(len(time) == len(ene))
@@ -234,9 +238,10 @@ class Irene:
                     row["evtDaq"] = event
                 row["peak"] = i
                 row["time"] = time[j]
-                row["ene"]  = ene[j]
+                row["ene"]  =  ene[j]
                 row.append()
         self.s1t.flush()
+
         #S2
         row = self.s2t.row
         for i in S2.keys():
@@ -255,6 +260,7 @@ class Irene:
                 row["ene"]  = ene[j]
                 row.append()
         self.s2t.flush()
+
         # S2Si
         row = self.s2sit.row
         for i in S2Si.keys():
@@ -328,8 +334,8 @@ class Irene:
                  S1 parameters
                  tmin = {} mus tmax = {} mus stride = {}
                  lmin = {} lmax = {}
-                          """.format(self.tmin_s1/units.mus,
-                                     self.tmax_s1/units.mus,
+                          """.format(self.tmin_s1 / units.mus,
+                                     self.tmax_s1 / units.mus,
                                      self.stride_s1,
                                      self.lmin_s1,
                                      self.lmax_s1))
@@ -337,20 +343,19 @@ class Irene:
                  S2 parameters
                  tmin = {} mus tmax = {} mus stride = {}
                  lmin = {} lmax = {}
-                          """.format(self.tmin_s2/units.mus,
-                                     self.tmax_s2/units.mus,
+                          """.format(self.tmin_s2 / units.mus,
+                                     self.tmax_s2 / units.mus,
                                      self.stride_s2,
                                      self.lmin_s2,
                                      self.lmax_s2))
         print("""
                  S2Si parameters
-                 threshold min charge per SiPM = {} pes
-                 threshold min charge in S2 = {} pes
-                          """.format(self.thr_zs,
-                                     self.thr_sipm_s2))
+                 threshold min charge per SiPM = {s.thr_zs} pes
+                 threshold min charge in  S2   = {s.thr_sipm_s2} pes
+                          """.format(s=self))
 
         # loop over input files
-        first=False
+        first = False
         for ffile in self.input_files:
             print("Opening", ffile, end="... ")
             filename = ffile
@@ -390,22 +395,23 @@ class Irene:
                         # plots
                         if self.plot_csum:
                             mpl.plot_signal(
-                               self.signal_t/units.mus, csum,
-                               title="calibrated sum, ZS",
-                               signal_start=self.signal_start,
-                               signal_end=self.signal_end,
-                               ymax = self.ymax,
-                               t_units='mus',
-                               units="pes")
+                                self.signal_t/units.mus, csum,
+                                title        = "calibrated sum, ZS",
+                                signal_start = self.signal_start,
+                                signal_end   = self.signal_end,
+                                ymax         = self.ymax,
+                                t_units      = 'mus',
+                                units        = 'pes')
 
                         if self.plot_csum_S1:
                             mpl.plot_signal(
-                               self.signal_t/units.mus, csum, title="calibrated sum, S1",
-                               signal_start=self.S1_start,
-                               signal_end=self.S1_end,
-                               ymax = self.S1_ymax,
-                               t_units='mus',
-                               units="pes")
+                                self.signal_t / units.mus, csum,
+                                title        = "calibrated sum, S1",
+                                signal_start = self.S1_start,
+                                signal_end   = self.S1_end,
+                                ymax         = self.S1_ymax,
+                                t_units      = 'mus',
+                                units        = "pes")
                             plt.show()
                             raw_input('->')
                         # SiPMs
@@ -415,22 +421,22 @@ class Irene:
                         # find S1
                         S1 = cpf.find_S12(wfzs_ene,
                                           wfzs_indx,
-                                          tmin=self.tmin_s1,
-                                          tmax=self.tmax_s1,
-                                          lmin=self.lmin_s1,
-                                          lmax=self.lmax_s1,
-                                          stride=self.stride_s1,
-                                          rebin=False)
+                                          tmin   = self.tmin_s1,
+                                          tmax   = self.tmax_s1,
+                                          lmin   = self.lmin_s1,
+                                          lmax   = self.lmax_s1,
+                                          stride = self.stride_s1,
+                                          rebin  = False)
                         # find S2
                         S2 = cpf.find_S12(wfzs_ene,
                                           wfzs_indx,
-                                          tmin=self.tmin_s2,
-                                          tmax=self.tmax_s2,
-                                          lmin=self.lmin_s2,
-                                          lmax=self.lmax_s2,
-                                          stride=self.stride_s2,
-                                          rebin=True,
-                                          rebin_stride=self.stride_s2)
+                                          tmin         = self.tmin_s2,
+                                          tmax         = self.tmax_s2,
+                                          lmin         = self.lmin_s2,
+                                          lmax         = self.lmax_s2,
+                                          stride       = self.stride_s2,
+                                          rebin        = True,
+                                          rebin_stride = self.stride_s2)
                         #plot S1 & S2
                         if self.plot_s1:
                             pf.scan_S12(S1)
@@ -439,21 +445,21 @@ class Irene:
                         # plot sipms
                         if self.plot_sipm:
                             mpl.plot_sipm(sipmrwf[evt],
-                                          nmin=0,
-                                          nmax=16,
+                                          nmin = 0,
+                                          nmax = 16,
                                           x=4, y=4)
                             plt.show()
                             raw_input('->')
                         # SiPMs zero suppression
                         sipmzs = cpf.signal_sipm(
                             sipmrwf[evt], self.sipm_adc_to_pes,
-                            thr=self.thr_zs,
-                            n_MAU=self.n_MAU)
+                            thr   = self.thr_zs,
+                            n_MAU = self.n_MAU)
                         # plot
                         if self.plot_sipmzs:
                             mpl.plot_sipm(sipmzs,
-                                          nmin=0,
-                                          nmax=16,
+                                          nmin = 0,
+                                          nmax = 16,
                                           x=4, y=4)
                             plt.show()
                             raw_input('->')
@@ -461,14 +467,13 @@ class Irene:
                         SIPM = cpf.select_sipm(sipmzs)
                         S2Si = pf.sipm_S2_dict(SIPM,
                                                S2,
-                                               thr=self.thr_sipm_s2)
+                                               thr = self.thr_sipm_s2)
 
                         if store_pmaps == True:
                             if self.setPmapStore == False:
                                 raise IOError(
                                   'must set PMAPS before storing')
-                            self.store_pmaps(n_events_tot, evt,
-                                             S1, S2, S2Si)
+                            self.store_pmaps(n_events_tot, evt, S1, S2, S2Si)
 
                         if self.plot_simap:
                             self.plot_ene_sipm(S2Si)
@@ -481,9 +486,8 @@ class Irene:
                               format(evt, n_events_tot))
 
                         if n_events_tot >= nmax and nmax > -1:
-                            print(
-                              'reached max nof of events (={})'.format(
-                                 nmax))
+                            print('reached max nof of events (={})'
+                                  .format(nmax))
                             break
 
 
@@ -501,31 +505,35 @@ class Irene:
         return n_events_tot
 
 
-def IRENE(argv=sys.argv):
+def IRENE(argv = sys.argv):
     """IRENE DRIVER"""
     CFP = configure(argv)
 
-    fpp = Irene(run_number=CFP['RUN_NUMBER'])
+    fpp = Irene(run_number = CFP['RUN_NUMBER'])
 
     files_in = glob(CFP['FILE_IN'])
     files_in.sort()
     fpp.set_input_files(files_in)
     fpp.set_pmap_store(CFP['FILE_OUT'],
-                       compression=CFP['COMPRESSION'])
-    fpp.set_print(nprint=CFP['NPRINT'])
+                       compression = CFP['COMPRESSION'])
+    fpp.set_print(nprint = CFP['NPRINT'])
 
-    fpp.set_BLR(n_baseline=CFP['NBASELINE'],
-                thr_trigger=CFP['THR_TRIGGER']*units.adc)
-    fpp.set_MAU(n_MAU=CFP['NMAU'], thr_MAU=CFP['THR_MAU']*units.adc)
-    fpp.set_CSUM(thr_csum=CFP['THR_CSUM']*units.pes)
-    fpp.set_S1(tmin=CFP['S1_TMIN']*units.mus, tmax=CFP['S1_TMAX']*units.mus,
-               stride=CFP['S1_STRIDE'], lmin=CFP['S1_LMIN'],
-               lmax=CFP['S1_LMAX'])
-    fpp.set_S2(tmin=CFP['S2_TMIN']*units.mus, tmax=CFP['S2_TMAX']*units.mus,
-               stride=CFP['S2_STRIDE'], lmin=CFP['S2_LMIN'],
-               lmax=CFP['S2_LMAX'])
-    fpp.set_SiPM(thr_zs=CFP['THR_ZS']*units.pes,
-                 thr_sipm_s2=CFP['THR_SIPM_S2']*units.pes)
+    fpp.set_BLR(n_baseline  = CFP['NBASELINE'],
+                thr_trigger = CFP['THR_TRIGGER'] * units.adc)
+    fpp.set_MAU(  n_MAU = CFP['NMAU'],
+                thr_MAU = CFP['THR_MAU'] * units.adc)
+    fpp.set_CSUM(thr_csum = CFP['THR_CSUM'] * units.pes)
+    fpp.set_S1(tmin   = CFP['S1_TMIN'] * units.mus,
+               tmax   = CFP['S1_TMAX'] * units.mus,
+               lmax   = CFP['S1_LMAX'],
+               lmin   = CFP['S1_LMIN'],
+               stride = CFP['S1_STRIDE'])
+    fpp.set_S2(tmin   = CFP['S2_TMIN'] * units.mus,
+               tmax   = CFP['S2_TMAX'] * units.mus,
+               stride = CFP['S2_STRIDE'], lmin=CFP['S2_LMIN'],
+               lmax   = CFP['S2_LMAX'])
+    fpp.set_SiPM(thr_zs      = CFP['THR_ZS']      * units.pes,
+                 thr_sipm_s2 = CFP['THR_SIPM_S2'] * units.pes)
 
     t0 = time()
     nevts = CFP['NEVENTS'] if not CFP['RUN_ALL'] else -1

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -32,7 +32,6 @@ from   invisible_cities.core.random_sampling \
 
 def test_diomira_and_irene_run():
     """Test that Diomira & Irene runs on default config parameters."""
-    Diomira
     conf_file = os.environ['ICDIR'] + '/config/diomira.conf'
     CFP = configure(['DIOMIRA','-c', conf_file])
     fpp = Diomira()
@@ -40,9 +39,9 @@ def test_diomira_and_irene_run():
     files_in.sort()
     fpp.set_input_files(files_in)
     fpp.set_output_file(CFP['FILE_OUT'],
-                        compression=CFP['COMPRESSION'])
-    fpp.set_print(nprint=CFP['NPRINT'])
-    fpp.set_sipm_noise_cut(noise_cut=CFP["NOISE_CUT"])
+                        compression = CFP['COMPRESSION'])
+    fpp.set_print(nprint = CFP['NPRINT'])
+    fpp.set_sipm_noise_cut(noise_cut = CFP["NOISE_CUT"])
 
     nevts = CFP['NEVENTS'] if not CFP['RUN_ALL'] else -1
     nevt = fpp.run(nmax=nevts)
@@ -50,7 +49,7 @@ def test_diomira_and_irene_run():
 
     # Irene
     conf_file = os.environ['ICDIR'] + '/config/irene.conf'
-    CFP = configure(['IRENE','-c', conf_file])
+    CFP = configure(['IRENE', '-c', conf_file])
 
     fpp = Irene(run_number=CFP['RUN_NUMBER'])
 
@@ -58,35 +57,36 @@ def test_diomira_and_irene_run():
     files_in.sort()
     fpp.set_input_files(files_in)
     fpp.set_pmap_store(CFP['FILE_OUT'],
-                       compression=CFP['COMPRESSION'])
+                       compression = CFP['COMPRESSION'])
     fpp.set_print(nprint=CFP['NPRINT'])
 
-    fpp.set_BLR(n_baseline=CFP['NBASELINE'],
-                thr_trigger=CFP['THR_TRIGGER']*units.adc)
+    fpp.set_BLR(n_baseline  = CFP['NBASELINE'],
+                thr_trigger = CFP['THR_TRIGGER'] * units.adc)
 
-    fpp.set_MAU(n_MAU=CFP['NMAU'],
-                thr_MAU=CFP['THR_MAU']*units.adc)
+    fpp.set_MAU(  n_MAU = CFP['NMAU'],
+                thr_MAU = CFP['THR_MAU'] * units.adc)
 
-    fpp.set_CSUM(thr_csum=CFP['THR_CSUM']*units.pes)
+    fpp.set_CSUM(thr_csum=CFP['THR_CSUM'] * units.pes)
 
-    fpp.set_S1(tmin=CFP['S1_TMIN']*units.mus,
-               tmax=CFP['S1_TMAX']*units.mus,
-               stride=CFP['S1_STRIDE'],
-               lmin=CFP['S1_LMIN'],
-               lmax=CFP['S1_LMAX'])
+    fpp.set_S1(tmin   = CFP['S1_TMIN'] * units.mus,
+               tmax   = CFP['S1_TMAX'] * units.mus,
+               stride = CFP['S1_STRIDE'],
+               lmin   = CFP['S1_LMIN'],
+               lmax   = CFP['S1_LMAX'])
 
-    fpp.set_S2(tmin=CFP['S2_TMIN']*units.mus,
-               tmax=CFP['S2_TMAX']*units.mus,
-               stride=CFP['S2_STRIDE'],
-               lmin=CFP['S2_LMIN'],
-               lmax=CFP['S2_LMAX'])
+    fpp.set_S2(tmin   = CFP['S2_TMIN'] * units.mus,
+               tmax   = CFP['S2_TMAX'] * units.mus,
+               stride = CFP['S2_STRIDE'],
+               lmin   = CFP['S2_LMIN'],
+               lmax   = CFP['S2_LMAX'])
 
-    fpp.set_SiPM(thr_zs=CFP['THR_ZS']*units.pes,
-                 thr_sipm_s2=CFP['THR_SIPM_S2']*units.pes)
+    fpp.set_SiPM(thr_zs=CFP['THR_ZS'] * units.pes,
+                 thr_sipm_s2=CFP['THR_SIPM_S2'] * units.pes)
 
     nevts = CFP['NEVENTS'] if not CFP['RUN_ALL'] else -1
     nevt = fpp.run(nmax=nevts, store_pmaps=True)
     assert nevt == nevts
 
+    # This leads to the dark side !
     os.system('rm $ICDIR/database/test_data/electrons_40keV_z250_RWF.h5')
     os.system('rm $ICDIR/database/test_data/electrons_40keV_z250_PMP.h5')

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -1,0 +1,92 @@
+"""
+code: irene_test.py
+description: test suite for irene
+author: J.J. Gomez-Cadenas
+IC core team: Jacek Generowicz, JJGC,
+G. Martinez, J.A. Hernando, J.M Benlloch
+package: invisible cities. See release notes and licence
+last changed: 01-12-2017
+"""
+from __future__ import print_function
+from __future__ import absolute_import
+
+import os
+from glob import glob
+import tables as tb
+import numpy as np
+
+import pytest
+
+from   invisible_cities.core.configure import configure
+import invisible_cities.core.tbl_functions as tbl
+import invisible_cities.core.wfm_functions as wfm
+import invisible_cities.core.system_of_units as units
+from   invisible_cities.sierpe import fee as FEE
+import invisible_cities.sierpe.blr as blr
+from   invisible_cities.database import load_db
+from   invisible_cities.cities.diomira import Diomira
+from   invisible_cities.cities.irene import Irene
+from   invisible_cities.core.random_sampling \
+     import NoiseSampler as SiPMsNoiseSampler
+
+
+def test_diomira_and_irene_run():
+    """Test that Diomira & Irene runs on default config parameters."""
+    Diomira
+    conf_file = os.environ['ICDIR'] + '/config/diomira.conf'
+    CFP = configure(['DIOMIRA','-c', conf_file])
+    fpp = Diomira()
+    files_in = glob(CFP['FILE_IN'])
+    files_in.sort()
+    fpp.set_input_files(files_in)
+    fpp.set_output_file(CFP['FILE_OUT'],
+                        compression=CFP['COMPRESSION'])
+    fpp.set_print(nprint=CFP['NPRINT'])
+    fpp.set_sipm_noise_cut(noise_cut=CFP["NOISE_CUT"])
+
+    nevts = CFP['NEVENTS'] if not CFP['RUN_ALL'] else -1
+    nevt = fpp.run(nmax=nevts)
+    assert nevt == nevts
+
+    # Irene
+    conf_file = os.environ['ICDIR'] + '/config/irene.conf'
+    CFP = configure(['IRENE','-c', conf_file])
+
+    fpp = Irene(run_number=CFP['RUN_NUMBER'])
+
+    files_in = glob(CFP['FILE_IN'])
+    files_in.sort()
+    fpp.set_input_files(files_in)
+    fpp.set_pmap_store(CFP['FILE_OUT'],
+                       compression=CFP['COMPRESSION'])
+    fpp.set_print(nprint=CFP['NPRINT'])
+
+    fpp.set_BLR(n_baseline=CFP['NBASELINE'],
+                thr_trigger=CFP['THR_TRIGGER']*units.adc)
+
+    fpp.set_MAU(n_MAU=CFP['NMAU'],
+                thr_MAU=CFP['THR_MAU']*units.adc)
+
+    fpp.set_CSUM(thr_csum=CFP['THR_CSUM']*units.pes)
+
+    fpp.set_S1(tmin=CFP['S1_TMIN']*units.mus,
+               tmax=CFP['S1_TMAX']*units.mus,
+               stride=CFP['S1_STRIDE'],
+               lmin=CFP['S1_LMIN'],
+               lmax=CFP['S1_LMAX'])
+
+    fpp.set_S2(tmin=CFP['S2_TMIN']*units.mus,
+               tmax=CFP['S2_TMAX']*units.mus,
+               stride=CFP['S2_STRIDE'],
+               lmin=CFP['S2_LMIN'],
+               lmax=CFP['S2_LMAX'])
+
+    fpp.set_SiPM(thr_zs=CFP['THR_ZS']*units.pes,
+                 thr_sipm_s2=CFP['THR_SIPM_S2']*units.pes)
+
+    nevts = CFP['NEVENTS'] if not CFP['RUN_ALL'] else -1
+    nevt = fpp.run(nmax=nevts, store_pmaps=True)
+    assert nevt == nevts
+
+    os.system('rm $ICDIR/database/test_data/electrons_40keV_z250_RWF.h5')
+    os.system('rm $ICDIR/database/test_data/electrons_40keV_z250_PMP.h5')

--- a/invisible_cities/config/diomira.conf
+++ b/invisible_cities/config/diomira.conf
@@ -11,7 +11,7 @@ COMPRESSION ZLIB4
 NPRINT 1
 
 # set sipm noise cut (in pes)
-NOISE_CUT 5
+NOISE_CUT 10
 
 #run
 NEVENTS 10

--- a/invisible_cities/config/irene.conf
+++ b/invisible_cities/config/irene.conf
@@ -1,20 +1,20 @@
 #set_input_files
-PATH_IN /home/jmbenlloch/next/dataic/3112
-FILE_IN run_3112.gdcsnext.00[0-2].next1el_3112.root.h5
+PATH_IN $ICDIR/database/test_data/
+FILE_IN electrons_40keV_z250_RWF.h5
 
 #set_pmap_store
-PATH_OUT /home/jmbenlloch/next/dataic
-FILE_OUT pmaps_3112.h5
+PATH_OUT $ICDIR/database/test_data/
+FILE_OUT electrons_40keV_z250_PMP.h5
 COMPRESSION ZLIB4
 
 #irene
-RUN_NUMBER 3112
+RUN_NUMBER 0
 
 #set_print
-NPRINT 10
+NPRINT 1
 
 #set_blr
-NBASELINE 38000
+NBASELINE 28000
 THR_TRIGGER 5
 
 #set_mau
@@ -39,9 +39,9 @@ S2_LMIN 100
 S2_LMAX 100000
 
 #set_sipm
-THR_ZS 5
-THR_SIPM_S2 25
+THR_ZS 10
+THR_SIPM_S2 30
 
 #run
-NEVENTS 20
-RUN_ALL True
+NEVENTS 10
+RUN_ALL False


### PR DESCRIPTION
The pytest tempfile-generating fixture has been:

- Moved out of `cities/diomira_test.py` into `cities/conftest.py`. In
  this way it can be used by any test in `cities`. If it needs to be
  shared by tests in distinct directories, this can be achieved by
  moving the `conftest.py` file higher up the directory structure into
  a common parent.

- Changed to produce a temporary directory rather than a single
  file. Multiple test output files can now be placed in that directory
  and shared by the tests.

This is so much better than writing these files in the project
directory because

- Tests for different versions of Python can now run concurrently on
  the same machine

- If the tests crash, there won't be any rubbish left lying around in
  the source directory

- There is no danger of anyone accidentally adding these files to the
  repo.
