### PR TITLE
Prevent `manage.sh` from killing shell accidentally

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -172,6 +172,5 @@ case $COMMAND in
        echo bash $0 compile_and_test
        echo bash $0 download_test_db
        echo bash $0 clean
-       exit 1
        ;;
 esac


### PR DESCRIPTION
Some of the `manage.sh` commands can be run with `bash` but some must
be `source`d. When using `source` and giving an unrecognized command,
the parent shell was closed. Very naughty! This bug has now been
eliminated.