### PR TITLE
First version of bash completion script for manage.sh

### DIFF
--- a/bash_manage.sh
+++ b/bash_manage.sh
@@ -1,0 +1,74 @@
+manage.sh()
+{
+    local cur prev opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    prev2="${COMP_WORDS[COMP_CWORD-2]}"
+
+
+    case "${prev}" in
+        manage.sh)
+                        local opts="make_environment run_tests compile_and_test\
+                                download_test_db clean"
+            COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+            return 0
+            ;;
+        *)
+        ;;
+    esac
+
+    if [[ ${prev2} == "manage.sh" ]] ; then
+            case "${prev}" in
+                        install_and_check|install|work_in_python_version|make_environment)
+                        local versions="2.7 3.5"
+                    COMPREPLY=( $(compgen -W "${versions}" -- ${cur}) )
+                    return 0
+                    ;;
+                *)
+                ;;
+            esac
+    fi
+
+        return 0
+}
+
+
+source_manage.sh()
+{
+    local cur prev opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    prev2="${COMP_WORDS[COMP_CWORD-2]}"
+
+
+    case "${prev}" in
+        manage.sh)
+                        local opts="install_and_check install work_in_python_version \
+                                make_environment run_tests compile_and_test download_test_db clean"
+            COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+            return 0
+            ;;
+        *)
+        ;;
+    esac
+
+    if [[ ${prev2} == "manage.sh" ]] ; then
+            case "${prev}" in
+                        install_and_check|install|work_in_python_version|make_environment)
+                        local versions="2.7 3.5"
+                    COMPREPLY=( $(compgen -W "${versions}" -- ${cur}) )
+                    return 0
+                    ;;
+                *)
+                ;;
+            esac
+    fi
+
+        return 0
+}
+
+complete -F manage.sh -o bashdefault -o default bash
+complete -F source_manage.sh -o bashdefault -o default source
+complete -F source_manage.sh -o bashdefault -o default .


### PR DESCRIPTION
This is a first proposal for bash completion in manage.sh (issue #78). First you need to execute the script:

`. bash_manage.sh`

Then you it will autocomplete `bash manage.sh` or `source manage.sh` in this way:

```
$ source manage.sh [TAB][TAB]
clean                   install                 run_tests
compile_and_test        install_and_check       work_in_python_version
download_test_db        make_environment        
```

If you chose an option requiring python version it will offer you 2.7 and 3.5:

```
$ source manage.sh work_in_python_version [TAB][TAB]
2.7  3.5  
```

The only problem is that some bash options are overwrite. For instance, this will happen before executing the script:

```
$ bash --[TAB][TAB]
--debug            --help             --noprofile        --restricted
--debugger         --init-file        --norc             --verbose
--dump-po-strings  --login            --posix            --version
--dump-strings     --noediting        --rcfile     
```

While after executing the script no option will be shown in that case. It is not clear to me how to improve this behavior, comments are welcomed.