### PR TITLE
Move from miniconda2 to miniconda3

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -47,7 +47,7 @@ function install_conda {
         echo Conda already installed. Skipping conda installation.
     else
         echo Installing conda for $CONDA_OS
-        wget http://repo.continuum.io/miniconda/Miniconda-latest-${CONDA_OS}-x86_64.sh -O miniconda.sh
+        wget http://repo.continuum.io/miniconda/Miniconda3-latest-${CONDA_OS}-x86_64.sh -O miniconda.sh
         bash miniconda.sh -b -p $HOME/miniconda
         export PATH="$HOME/miniconda/bin:$PATH"
         echo Prepended $HOME/miniconda/bin to your PATH. Please add it to your shell profile for future sessions.


### PR DESCRIPTION
We were using miniconda2, which is based on Python 2. Given that our
primary version of IC is the Python 3 one, we might as well use
miniconda3 and save ourselves the need to drag down two Python
installations (one for conda and one for IC) in the primary version.