### PR TITLE
Remove wfm from irene and irene_test

### DIFF
--- a/invisible_cities/cities/irene.py
+++ b/invisible_cities/cities/irene.py
@@ -10,7 +10,6 @@ import matplotlib.pyplot as plt
 from   invisible_cities.core.nh5 import RunInfo, EventInfo
 from   invisible_cities.core.nh5 import S12, S2Si
 import invisible_cities.core.mpl_functions as mpl
-import invisible_cities.core.wfm_functions as wfm
 import invisible_cities.core.peak_functions as pf
 import invisible_cities.core.tbl_functions as tbl
 from   invisible_cities.core.configure \

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -19,7 +19,6 @@ import pytest
 
 from   invisible_cities.core.configure import configure
 import invisible_cities.core.tbl_functions as tbl
-import invisible_cities.core.wfm_functions as wfm
 import invisible_cities.core.system_of_units as units
 from   invisible_cities.sierpe import fee as FEE
 import invisible_cities.sierpe.blr as blr


### PR DESCRIPTION
This is a minor change in both Irene and Irene_test, removing an unneeded dependency with wmf_functions