### PR TITLE
Enable concurrent test execution

### DIFF
--- a/bash_manage.sh
+++ b/bash_manage.sh
@@ -9,8 +9,13 @@ manage.sh()
 
     case "${prev}" in
         manage.sh)
-                        local opts="make_environment run_tests compile_and_test\
-                                download_test_db clean"
+                        local opts="make_environment\
+                                    run_tests\
+                                    run_tests_par\
+                                    compile_and_test\
+                                    compile_and_test_par\
+                                    download_test_db\
+                                    clean"
             COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
             return 0
             ;;
@@ -45,8 +50,16 @@ source_manage.sh()
 
     case "${prev}" in
         manage.sh)
-                        local opts="install_and_check install work_in_python_version \
-                                make_environment run_tests compile_and_test download_test_db clean"
+                        local opts="install_and_check\
+                                    install\
+                                    work_in_python_version\
+                                    make_environment\
+                                    run_tests\
+                                    run_tests_par\
+                                    compile_and_test\
+                                    compile_and_test_par\
+                                    download_test_db\
+                                    clean"
             COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
             return 0
             ;;

--- a/invisible_cities/cities/diomira_test.py
+++ b/invisible_cities/cities/diomira_test.py
@@ -15,6 +15,8 @@ from glob import glob
 import tables as tb
 import numpy as np
 
+from pytest import mark
+
 from   invisible_cities.core.configure import configure
 import invisible_cities.core.tbl_functions as tbl
 import invisible_cities.core.wfm_functions as wfm
@@ -27,6 +29,7 @@ from   invisible_cities.core.random_sampling \
      import NoiseSampler as SiPMsNoiseSampler
 
 
+@mark.serial
 def test_diomira_run(irene_diomira_chain_tmpdir):
     """Test that DIOMIRA runs on default config parameters."""
     RWF_file = str(irene_diomira_chain_tmpdir.join(
@@ -48,6 +51,7 @@ def test_diomira_run(irene_diomira_chain_tmpdir):
 
     assert nevt == nevts
 
+@mark.serial
 def test_diomira_fee_table(irene_diomira_chain_tmpdir):
     """Test that FEE table reads back correctly with expected values."""
     RWF_file = str(irene_diomira_chain_tmpdir.join(
@@ -79,6 +83,7 @@ def test_diomira_fee_table(irene_diomira_chain_tmpdir):
         assert abs(feep.CEILING - FEE.CEILING)             < eps
 
 
+@mark.serial
 def test_diomira_cwf_blr(irene_diomira_chain_tmpdir):
     """This is the most rigurous test of the suite. It reads back the
        RWF and BLR waveforms written to disk by DIOMIRA, and computes

--- a/manage.sh
+++ b/manage.sh
@@ -79,6 +79,7 @@ dependencies:
 - pip:
   - hypothesis-numpy
   - flaky
+  - pytest-xdist
 EOF
 
     conda env create -f ${YML_FILENAME}
@@ -105,6 +106,17 @@ function run_tests {
 
     # Run the test suite
     pytest -v
+}
+
+function run_tests_par {
+    # Ensure that the test database is present
+    if [ ! -f invisible_cities/database/localdb.sqlite3 ]; then
+        download_test_db
+    fi
+
+    # Run the test suite
+    pytest -v -n auto -m "not serial"
+    pytest -v         -m      serial
 }
 
 function ic_env {
@@ -168,7 +180,9 @@ case $COMMAND in
     work_in_python_version) work_in_python_version ;;
     make_environment)       make_environment ;;
     run_tests)              run_tests ;;
+    run_tests_par)          run_tests_par ;;
     compile_and_test)       compile_and_test ;;
+    compile_and_test_par)   compile_and_test_par ;;
     download_test_db)       download_test_db ;;
     clean)                  clean ;;
     show_ic_env)            show_ic_env ;;
@@ -182,7 +196,9 @@ case $COMMAND in
        echo "source $THIS work_in_python_version X.Y"
        echo "bash   $THIS make_environment X.Y"
        echo "bash   $THIS run_tests"
+       echo "bash   $THIS run_tests_par"
        echo "bash   $THIS compile_and_test"
+       echo "bash   $THIS compile_and_test_par"
        echo "bash   $THIS download_test_db"
        echo "bash   $THIS clean"
        ;;


### PR DESCRIPTION
This uses the `pytest-xdist` extension.

Running the tests concurrently
==============================

`pytest-xdist` allows the concurrent execution of tests on `N` CPUs
by adding the `-n N` option to `pytest`. Alternatively, the number of
available CPUs can be discovered automaticall with `-n auto`.

Unfortunately, some of our tests cannot be run concurrently, as they
form a chain where the outpot of one test serves as the input to
another. Such tests have been marked with `@mark.serial`. With this in
place, the concurrent testing is a two step process:

- `pytest -m "not serial"`
- `pytest -m      serial`

Two new `manage.sh` commands (`run_tests_par` and
`compile_and_test_par`) have been added to this effect.

This solution is not entirely satisfactory, and hopefully something
better can be found.

Given the small number of tests we currently have, and the fact that
about half of the test time is spent in the three, slow, serial tests,
which must be run separately, we don't see any decrease in the overall
testing time: the overhead of setting up the test on multiple
processors is high compared to the time it takes for the concurrent
tests to run.

As the number of tests increases, concurrent testing should become
more worthwhile.

Other xdist features
====================

- `--boxed` runs each test in a separate process, thus preventing a
  segfaulting test from crashing the whole test suite.

- Remote execution: the tests can be sent for execution to remote
  hosts.

- The tests can be made to execute on different versions of python.