### PR TITLE
Reinstate serial mark on `test_diomira_cwf_blr`

### DIFF
--- a/invisible_cities/cities/diomira_test.py
+++ b/invisible_cities/cities/diomira_test.py
@@ -83,6 +83,7 @@ def test_diomira_fee_table(irene_diomira_chain_tmpdir):
         assert abs(feep.CEILING - FEE.CEILING)             < eps
 
 
+@mark.serial
 def test_diomira_cwf_blr(irene_diomira_chain_tmpdir):
     """This is the most rigurous test of the suite. It reads back the
        RWF and BLR waveforms written to disk by DIOMIRA, and computes


### PR DESCRIPTION
This test cannot be run in parallel with some of the other, as it
needs the temporatry file `electrons_40keV_z250_RWF.h5`.

The mark seems to have been removed mistakenly in #98.