### PR TITLE
Stop treating Python 3.6 as an allowed failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ matrix:
   fast_finish: true
   allow_failures:
   - os: osx
-  - env: IC_PYTHON_VERSION=3.6
 
 env:
   - IC_PYTHON_VERSION=2.7

--- a/bash_manage.sh
+++ b/bash_manage.sh
@@ -26,7 +26,7 @@ manage.sh()
     if [[ ${prev2} == "manage.sh" ]] ; then
             case "${prev}" in
                         install_and_check|install|work_in_python_version|make_environment)
-                        local versions="2.7 3.5"
+                        local versions="2.7 3.5 3.6"
                     COMPREPLY=( $(compgen -W "${versions}" -- ${cur}) )
                     return 0
                     ;;
@@ -70,7 +70,7 @@ source_manage.sh()
     if [[ ${prev2} == "manage.sh" ]] ; then
             case "${prev}" in
                         install_and_check|install|work_in_python_version|make_environment)
-                        local versions="2.7 3.5"
+                        local versions="2.7 3.5 3.6"
                     COMPREPLY=( $(compgen -W "${versions}" -- ${cur}) )
                     return 0
                     ;;


### PR DESCRIPTION
It seems that all our dependencies are now available on conda for
Python 3.6.