### PR TITLE
Bug.test core dump

### DIFF
--- a/invisible_cities/core/core_functions_test.py
+++ b/invisible_cities/core/core_functions_test.py
@@ -6,8 +6,6 @@ import sys, os
 from . import core_functions as core
 import pandas as pd
 import numpy as np
-import matplotlib.pyplot as plt
-
 
 def test_lrange():
     assert core.lrange(10) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
@@ -41,12 +39,10 @@ def test_farray_from_string():
 def test_rebin_array():
     core.rebin_array(core.lrange(100), 5)[0] == 10
 
-@mark.skipif(os.getenv('DISPLAY') is None,
-             reason = "Core dumps in headless environment")
 def test_define_window():
     mu, sigma = 100, 0.2 # mean and standard deviation
     sgn = np.random.normal(mu, sigma, 10000)
-    n, bins, patches = plt.hist(sgn, 50)
+    n, _ = np.histogram(sgn, 50)
     n0, n1 = core.define_window(n, window_size=10)
     peak = core.loc_elem_1d(n, np.max(n))
     assert n0 == peak - 10

--- a/invisible_cities/core/core_functions_test.py
+++ b/invisible_cities/core/core_functions_test.py
@@ -41,8 +41,8 @@ def test_farray_from_string():
 def test_rebin_array():
     core.rebin_array(core.lrange(100), 5)[0] == 10
 
-@mark.skipif(sys.platform.startswith('linux') and os.getenv('TRAVIS') == 'true',
-             reason = "Core dumps on Travis linux")
+@mark.skipif(os.getenv('DISPLAY') is None,
+             reason = "Core dumps in headless environment")
 def test_define_window():
     mu, sigma = 100, 0.2 # mean and standard deviation
     sgn = np.random.normal(mu, sigma, 10000)


### PR DESCRIPTION
Use `np.histogram` instead of `plt.hist` and fix #95

`test_define_window` was core dumping in headless environments (for
us, this meant Linux-on-Travis). This was caused by the use of
`matplotlib.pyplot.hist` in order to *calculate* a histogram inside
the test. Because `plt.hist` tries to *display* the histogram, it's
not surprising that it crashed on systems that did not have displays.

As the test had no real need to actually display the histogram, merely
to calculate it, this problem was easily solved by using
`numpy.histogram` which performs the same calculation, without the
(pointless and damaging) displaying side-effect.

Moral of the story: don't use drawing functions to perform pure
calculations!

(I am leaving the first commit unsquashed, in order to leave a record of the `skipif` condition for headless environments, in case anyone needs it in the future.)