### PR TITLE
Core devel

### DIFF
--- a/invisible_cities/cities/irene.py
+++ b/invisible_cities/cities/irene.py
@@ -393,7 +393,7 @@ class Irene:
                           n_baseline  = self.n_baseline,
                           thr_trigger = self.thr_trigger)
                         # calibrated PMT sum
-                        csum = cpf.calibrated_pmt_sum(
+                        csum, _ = cpf.calibrated_pmt_sum(
                           CWF,
                           self.adc_to_pes,
                             n_MAU = self.  n_MAU,
@@ -519,7 +519,7 @@ class Irene:
                 row.append()
                 self.runInfot.flush()
             self.pmapFile.close()
-        
+
         if self.print_empty:
             print('Energy plane empty events (skipped) = {}'.format(
                    self.empty_events))

--- a/invisible_cities/core/mpl_functions.py
+++ b/invisible_cities/core/mpl_functions.py
@@ -63,10 +63,10 @@ def plot_signal(signal_t, signal, title="signal",
 
 
 def plot_signal_vs_time_mus(signal,
-                            t_min=0,
-                            t_max=1200,
-                            signal_min=0,
-                            signal_max=200):
+                            t_min      =    0,
+                            t_max      = 1200,
+                            signal_min =    0,
+                            signal_max =  200):
     """Plot signal versus time in mus (tmin, tmax in mus). """
     tstep = 25 # in ns
     PMTWL = signal.shape[0]
@@ -74,16 +74,16 @@ def plot_signal_vs_time_mus(signal,
     ax1 = plt.subplot(1, 1, 1)
     ax1.set_xlim([t_min, t_max])
     ax1.set_ylim([signal_min, signal_max])
-    set_plot_labels(xlabel="t (mus)",
-                    ylabel="signal (pes/adc)")
+    set_plot_labels(xlabel = "t (mus)",
+                    ylabel = "signal (pes/adc)")
     plt.plot(signal_t, signal)
 
 
 def plot_pmt_signals_vs_time_mus(pmt_signals,
-                                 t_min=0,
-                                 t_max=1200,
-                                 signal_min=0,
-                                 signal_max=200):
+                                 t_min      =    0,
+                                 t_max      = 1200,
+                                 signal_min =    0,
+                                 signal_max =  200):
     """Plot all the PMT signals versus time in mus (tmin, tmax in mus)."""
 
     tstep = 25
@@ -94,8 +94,8 @@ def plot_pmt_signals_vs_time_mus(pmt_signals,
         ax1 = plt.subplot(3, 4, i+1)
         ax1.set_xlim([t_min, t_max])
         ax1.set_ylim([signal_min, signal_max])
-        set_plot_labels(xlabel="t (mus)",
-                        ylabel="signal (pes/adc)")
+        set_plot_labels(xlabel = "t (mus)",
+                        ylabel = "signal (pes/adc)")
 
         plt.plot(signal_t, pmt_signals[i])
 

--- a/invisible_cities/core/mpl_functions.py
+++ b/invisible_cities/core/mpl_functions.py
@@ -62,6 +62,44 @@ def plot_signal(signal_t, signal, title="signal",
     # plt.show()
 
 
+def plot_signal_vs_time_mus(signal,
+                            t_min=0,
+                            t_max=1200,
+                            signal_min=0,
+                            signal_max=200):
+    """Plot signal versus time in mus (tmin, tmax in mus). """
+    tstep = 25 # in ns
+    PMTWL = signal.shape[0]
+    signal_t = np.arange(0., PMTWL * tstep, tstep)/units.mus
+    ax1 = plt.subplot(1, 1, 1)
+    ax1.set_xlim([t_min, t_max])
+    ax1.set_ylim([signal_min, signal_max])
+    set_plot_labels(xlabel="t (mus)",
+                    ylabel="signal (pes/adc)")
+    plt.plot(signal_t, signal)
+
+
+def plot_pmt_signals_vs_time_mus(pmt_signals,
+                                 t_min=0,
+                                 t_max=1200,
+                                 signal_min=0,
+                                 signal_max=200):
+    """Plot all the PMT signals versus time in mus (tmin, tmax in mus)."""
+
+    tstep = 25
+    PMTWL = pmt_signals[0].shape[0]
+    signal_t = np.arange(0., PMTWL * tstep, tstep)/units.mus
+    plt.figure(figsize=(12, 12))
+    for i in range(len(pmt_signals)):
+        ax1 = plt.subplot(3, 4, i+1)
+        ax1.set_xlim([t_min, t_max])
+        ax1.set_ylim([signal_min, signal_max])
+        set_plot_labels(xlabel="t (mus)",
+                        ylabel="signal (pes/adc)")
+
+        plt.plot(signal_t, pmt_signals[i])
+
+
 def set_plot_labels(xlabel="", ylabel="", grid=True):
     """Short cut to set labels in plots."""
     plt.xlabel(xlabel)

--- a/invisible_cities/core/peak_functions.py
+++ b/invisible_cities/core/peak_functions.py
@@ -39,20 +39,20 @@ def calibrated_pmt_sum(CWF, adc_to_pes, n_MAU=200, thr_MAU=5):
 
     pmt_thr = np.zeros((NPMT, NWF), dtype=np.double)
     csum    = np.zeros(       NWF,  dtype=np.double)
+    csum_mau    = np.zeros(   NWF,  dtype=np.double)
     MAU_pmt = np.zeros(       NWF,  dtype=np.double)
 
+    MAUL=[]
     for j in range(NPMT):
         # MAU for each of the PMTs, following the waveform
         MAU_pmt = signal.lfilter(MAU, 1, CWF[j,:])
-
+        MAUL.append(MAU_pmt)
+        csum += CWF[j] * 1 / adc_to_pes[j]
         for k in range(NWF):
             if CWF[j,k] >= MAU_pmt[k] + thr_MAU: # >= not >. Found testing
                 pmt_thr[j,k] = CWF[j,k]
-
-    for j in range(NPMT):
-        for k in range(NWF):
-            csum[k] += pmt_thr[j, k] * 1 / adc_to_pes[j]
-    return csum
+        csum_mau += pmt_thr[j] * 1 / adc_to_pes[j]
+    return csum, csum_mau, np.array(MAUL)
 
 
 def wfzs(wf, threshold=0):

--- a/invisible_cities/core/peak_functions.py
+++ b/invisible_cities/core/peak_functions.py
@@ -10,35 +10,198 @@ from time import time
 import tables as tb
 import matplotlib.pyplot as plt
 
+from scipy import signal
+
 import invisible_cities.core.system_of_units as units
 import invisible_cities.sierpe.blr as blr
 import invisible_cities.core.peak_functions_c as pf
 from invisible_cities.database import load_db
 
+def calibrated_pmt_sum(CWF, adc_to_pes, n_MAU=200, thr_MAU=5):
+    """Compute the ZS calibrated sum of the PMTs
+    after correcting the baseline with a MAU to suppress low frequency noise.
+    input:
+    CWF         : Corrected waveform (passed by BLR)
+    adc_to_pes  : a vector with calibration constants
+    n_MAU       : length of the MAU window
+    thr_MAU     : treshold above MAU to select sample
+
+    NB: This function is used mainly for testing purposes. It is
+    programmed "c-style", which is not necesarily optimal in python,
+    but follows the same logic that the corresponding cython function
+    (in peak_functions_c), which runs faster and should be used
+    instead of this one for nornal calculations.
+    """
+
+    NPMT = CWF.shape[0]
+    NWF  = CWF.shape[1]
+    MAU  = np.array(np.ones(n_MAU), dtype=np.double) * (1 / n_MAU)
+
+    pmt_thr = np.zeros((NPMT, NWF), dtype=np.double)
+    csum    = np.zeros(       NWF,  dtype=np.double)
+    MAU_pmt = np.zeros(       NWF,  dtype=np.double)
+
+    for j in range(NPMT):
+        # MAU for each of the PMTs, following the waveform
+        MAU_pmt = signal.lfilter(MAU, 1, CWF[j,:])
+
+        for k in range(NWF):
+            if CWF[j,k] >= MAU_pmt[k] + thr_MAU: # >= not >. Found testing
+                pmt_thr[j,k] = CWF[j,k]
+
+    for j in range(NPMT):
+        for k in range(NWF):
+            csum[k] += pmt_thr[j, k] * 1 / adc_to_pes[j]
+    return csum
 
 
-def find_S12(wfzs, tmin=0*units.mus, tmax=1200*units.mus,
-             stride=4, lmin=8, lmax=1e+6):
-    """Find S1/S2 peaks.
+def wfzs(wf, threshold=0):
+    """Takes a waveform wf and return the values of the wf above
+    threshold: if the input waveform is of the form [e1,e2,...en],
+    where ei is the energy of sample i, then then the algorithm
+    returns a vector [e1,e2...ek], where k <=n and ei > threshold and
+    a vector of indexes [i1,i2...ik] which label the position of the
+    zswf of [e1,e2...ek]
 
-    input: a zero supressed wf
-    returns a list of waveform data frames
+    For example if the input waveform is:
+    [1,2,3,5,7,8,9,9,10,9,8,5,7,5,6,4,1] and the trhesold is 5
+    then the algoritm returns
+    a vector of amplitudes [7,8,9,9,10,9,8,7,6] and a vector of indexes
+    [4,5,6,7,8,9,10,12,14]
+
+    NB: This function is used mainly for testing purposed. It is
+    programmed "c-style", which is not necesarily optimal in python,
+    but follows the same logic that the corresponding cython function
+    (in peak_functions_c), which runs faster and should be used
+    instead of this one for nornal calculations.
+    """
+    len_wf = wf.shape[0]
+    wfzs_e = np.zeros(len_wf, dtype=np.double)
+    wfzs_i = np.zeros(len_wf, dtype=np.int32)
+    j=0
+    for i in range(len_wf):
+        if wf[i] > threshold:
+            wfzs_e[j] = wf[i]
+            wfzs_i[j] =    i
+            j += 1
+
+    wfzs_ene  = np.zeros(j, dtype=np.double)
+    wfzs_indx = np.zeros(j, dtype=np.int32)
+
+    for i in range(j):
+        wfzs_ene [i] = wfzs_e[i]
+        wfzs_indx[i] = wfzs_i[i]
+
+    return wfzs_ene, wfzs_indx
+
+
+def time_from_index(indx):
+    """Return the times (in ns) corresponding to the indexes in indx
+
+    NB: This function is used mainly for testing purposed. It is
+    programmed "c-style", which is not necesarily optimal in python,
+    but follows the same logic that the corresponding cython function
+    (in peak_functions_c), which runs faster and should be used
+    instead of this one for nornal calculations.
+    """
+    len_indx = indx.shape[0]
+    tzs = np.zeros(len_indx, dtype=np.double)
+
+    step = 25 #ns
+    for i in range(len_indx):
+        tzs[i] = step * float(indx[i])
+
+    return tzs
+
+
+def rebin_waveform(t, e, stride=40):
+    """
+    Rebin a waveform according to stride
+    The input waveform is a vector such that the index expresses time bin and the
+    contents expresses energy (e.g, in pes)
+    The function returns the rebinned T and E vectors
+
+    NB: This function is used mainly for testing purposed. It is programmed "c-style", which is not necesarily optimal
+    in python, but follows the same logic that the corresponding cython
+    function (in peak_functions_c), which runs faster and should be used
+    instead of this one for nornal calculations.
+
+    """
+
+    assert len(t) == len(e)
+
+    n = len(t) // stride
+    r = len(t) %  stride
+
+    lenb = n
+    if r > 0:
+        lenb = n+1
+
+    T = np.zeros(lenb, dtype=np.double)
+    E = np.zeros(lenb, dtype=np.double)
+
+    j = 0
+    for i in range(n):
+        esum = 0
+        tmean = 0
+        for k in range(j, j + stride):
+            esum  += e[k]
+            tmean += t[k]
+
+        tmean /= stride
+        E[i] = esum
+        T[i] = tmean
+        j += stride
+
+    if r > 0:
+        esum  = 0
+        tmean = 0
+        for k in range(j, len(t)):
+            esum  += e[k]
+            tmean += t[k]
+        tmean /= (len(t) - j)
+        E[n] = esum
+        T[n] = tmean
+
+    return T, E
+
+
+def find_S12(wfzs, index,
+             tmin = 0, tmax = 1e+6,
+             lmin = 8, lmax = 1000000,
+             stride=4, rebin=False, rebin_stride=40):
+    """
+    Find S1/S2 peaks.
+    input:
+    wfzs:   a vector containining the zero supressed wf
+    indx:   a vector of indexes
+    returns a dictionary
+
     do not interrupt the peak if next sample comes within stride
     accept the peak only if within [lmin, lmax)
     accept the peak only if within [tmin, tmax)
+    returns a dictionary of S12
+
+    NB: This function is used mainly for testing purposed. It is programmed "c-style", which is not necesarily optimal
+    in python, but follows the same logic that the corresponding cython
+    function (in peak_functions_c), which runs faster and should be used
+    instead of this one for nornal calculations.
     """
 
-    T = wfzs['time_ns'].values
-    P = wfzs['ene_pes'].values
+    P = wfzs
+    T = time_from_index(index)
 
-    S12 = {}
-    pulse_on = 1
-    j=0
+    assert len(wfzs) == len(index)
 
-    S12[0] = []
-    S12[0].append([T[0],P[0]])
+    S12  = {}
+    S12L = {}
+    s12  = []
 
-    for i in range(1, len(wfzs)):
+    S12[0] = s12
+    S12[0].append([T[0], P[0]])
+
+    j = 0
+    for i in range(1, len(wfzs)) :
 
         if T[i] > tmax:
             break
@@ -46,15 +209,32 @@ def find_S12(wfzs, tmin=0*units.mus, tmax=1200*units.mus,
         if T[i] < tmin:
             continue
 
-        if wfzs.index[i] - stride > wfzs.index[i-1]:  #new s12
+        if index[i] - stride > index[i-1]:  #new s12
             j += 1
-            S12[j] = []
-            S12[j].append([T[i], P[i]])
-        else:
-            S12[j].append([T[i], P[i]])
+            s12 = []
+            S12[j] = s12
+        S12[j].append([T[i], P[i]])
 
-    S12L=[]
-    for i in S12.keys():
-        if len(S12[i]) >= lmin and len(S12[i]) < lmax:
-            S12L.append(pd.DataFrame(S12[i], columns=['time_ns','ene_pes']))
+    # re-arrange and rebin
+    j = 0
+    for i in S12:
+        ls = len(S12[i])
+
+        if not (lmin <= ls < lmax):
+            continue
+
+        t = np.zeros(ls, dtype=np.double)
+        e = np.zeros(ls, dtype=np.double)
+
+        for k in range(ls):
+            t[k] = S12[i][k][0]
+            e[k] = S12[i][k][1]
+
+        if rebin == True:
+            TR, ER = rebin_waveform(t, e, stride = rebin_stride)
+            S12L[j] = [TR, ER]
+        else:
+            S12L[j] = [t, e]
+        j += 1
+
     return S12L

--- a/invisible_cities/core/peak_functions.py
+++ b/invisible_cities/core/peak_functions.py
@@ -37,12 +37,12 @@ def calibrated_pmt_sum(CWF, adc_to_pes, n_MAU=200, thr_MAU=5):
     NWF  = CWF.shape[1]
     MAU  = np.array(np.ones(n_MAU), dtype=np.double) * (1 / n_MAU)
 
-    pmt_thr = np.zeros((NPMT, NWF), dtype=np.double)
-    csum    = np.zeros(       NWF,  dtype=np.double)
-    csum_mau    = np.zeros(   NWF,  dtype=np.double)
-    MAU_pmt = np.zeros(       NWF,  dtype=np.double)
+    pmt_thr  = np.zeros((NPMT, NWF), dtype=np.double)
+    csum     = np.zeros(       NWF,  dtype=np.double)
+    csum_mau = np.zeros(       NWF,  dtype=np.double)
+    MAU_pmt  = np.zeros(       NWF,  dtype=np.double)
 
-    MAUL=[]
+    MAUL = []
     for j in range(NPMT):
         # MAU for each of the PMTs, following the waveform
         MAU_pmt = signal.lfilter(MAU, 1, CWF[j,:])

--- a/invisible_cities/core/peak_functions_c.pyx
+++ b/invisible_cities/core/peak_functions_c.pyx
@@ -31,10 +31,10 @@ cpdef calibrated_pmt_sum(double [:, :] CWF,
 
 
     # CWF if above MAU threshold
-    cdef double [:, :] pmt_thr = np.zeros((NPMT,NWF), dtype=np.double)
-    cdef double [:]    csum = np.zeros(         NWF , dtype=np.double)
-    cdef double [:]    csum_mau = np.zeros(     NWF , dtype=np.double)
-    cdef double [:]    MAU_pmt = np.zeros(      NWF , dtype=np.double)
+    cdef double [:, :] pmt_thr  = np.zeros((NPMT,NWF), dtype=np.double)
+    cdef double [:]    csum     = np.zeros(      NWF , dtype=np.double)
+    cdef double [:]    csum_mau = np.zeros(      NWF , dtype=np.double)
+    cdef double [:]    MAU_pmt  = np.zeros(      NWF , dtype=np.double)
 
     for j in range(NPMT):
         # MAU for each of the PMTs, following the waveform

--- a/invisible_cities/core/peak_functions_c.pyx
+++ b/invisible_cities/core/peak_functions_c.pyx
@@ -40,7 +40,7 @@ cpdef calibrated_pmt_sum(double [:, :] CWF,
         MAU_pmt = signal.lfilter(MAU, 1, CWF[j,:])
 
         for k in range(NWF):
-            if CWF[j,k] > MAU_pmt[k] + thr_MAU:
+            if CWF[j,k] >= MAU_pmt[k] + thr_MAU: # >= not >: found testing!
                 pmt_thr[j,k] = CWF[j,k]
 
     for j in range(NPMT):
@@ -177,10 +177,10 @@ cpdef find_S12(double [:] wfzs,  int [:] index,
 
 cpdef rebin_waveform(double [:] t, double[:] e, int stride = 40):
     """
-    rebins the a waveform according to stride
+    Rebin a waveform according to stride
     The input waveform is a vector such that the index expresses time bin and the
     contents expresses energy (e.g, in pes)
-    The function returns a DataFrame. The time bins and energy are rebinned according to stride
+    The function returns the rebinned T& E vectors.
     """
 
     assert len(t) == len(e)

--- a/invisible_cities/core/peak_functions_c.pyx
+++ b/invisible_cities/core/peak_functions_c.pyx
@@ -32,7 +32,8 @@ cpdef calibrated_pmt_sum(double [:, :] CWF,
 
     # CWF if above MAU threshold
     cdef double [:, :] pmt_thr = np.zeros((NPMT,NWF), dtype=np.double)
-    cdef double [:]       csum = np.zeros(      NWF , dtype=np.double)
+    cdef double [:]    csum = np.zeros(         NWF , dtype=np.double)
+    cdef double [:]    csum_mau = np.zeros(     NWF , dtype=np.double)
     cdef double [:]    MAU_pmt = np.zeros(      NWF , dtype=np.double)
 
     for j in range(NPMT):
@@ -45,8 +46,10 @@ cpdef calibrated_pmt_sum(double [:, :] CWF,
 
     for j in range(NPMT):
         for k in range(NWF):
-            csum[k] += pmt_thr[j, k] * 1 / adc_to_pes[j]
-    return np.asarray(csum)
+            csum_mau[k] += pmt_thr[j, k] * 1 / adc_to_pes[j]
+            csum[k] += CWF[j, k] * 1 / adc_to_pes[j]
+
+    return np.asarray(csum), np.asarray(csum_mau)
 
 
 cpdef wfzs(double [:] wf, double threshold=0):

--- a/invisible_cities/core/peak_functions_test.py
+++ b/invisible_cities/core/peak_functions_test.py
@@ -68,18 +68,13 @@ def test_csum_python_cython():
     with tb.open_file(RWF_file, 'r') as h5rwf:
         pmtrwf, pmtblr, sipmrwf = tbl.get_vectors(h5rwf)
         for event in range(10):
-            csum_blr = cpf.calibrated_pmt_sum(pmtblr[event].astype(np.float64),
-                                              adc_to_pes,
-                                              n_MAU=100, thr_MAU=3)
-
-            csum_blr_py = pf.calibrated_pmt_sum(pmtblr[event],
-                                                adc_to_pes,
-                                                n_MAU=100, thr_MAU=3)
+            csum_blr    = cpf.calibrated_pmt_sum(pmtblr[event].astype(np.float64), adc_to_pes, n_MAU=100, thr_MAU=3)
+            csum_blr_py =  pf.calibrated_pmt_sum(pmtblr[event].astype(np.float64), adc_to_pes, n_MAU=100, thr_MAU=3)
 
             assert abs(np.sum(csum_blr) - np.sum(csum_blr_py)) < 1e-4
 
-            wfzs_ene, wfzs_indx = cpf.wfzs(csum_blr, threshold=0.5)
-            wfzs_ene_py, wfzs_indx_py = pf.wfzs(csum_blr_py, threshold=0.5)
+            wfzs_ene,    wfzs_indx    = cpf.wfzs(csum_blr,    threshold=0.5)
+            wfzs_ene_py, wfzs_indx_py =  pf.wfzs(csum_blr_py, threshold=0.5)
 
             assert abs(np.sum(wfzs_ene) - np.sum(wfzs_ene_py)) < 1e-4
             assert abs(np.sum(wfzs_ene) - np.sum(wfzs_ene_py)) < 1e-4

--- a/invisible_cities/core/peak_functions_test.py
+++ b/invisible_cities/core/peak_functions_test.py
@@ -37,11 +37,15 @@ def test_csum_zs_blr_cwf():
 
         for event in range(10):
             CWF = blr.deconv_pmt(pmtrwf[event], coeff_c, coeff_blr)
-            csum_cwf = cpf.calibrated_pmt_sum(CWF, adc_to_pes,
-                                              n_MAU=100, thr_MAU=3)
-            csum_blr = cpf.calibrated_pmt_sum(pmtblr[event].astype(np.float64),
-                                              adc_to_pes,
-                                              n_MAU=100, thr_MAU=3)
+            csum_cwf, _ = cpf.calibrated_pmt_sum(
+                             CWF,
+                             adc_to_pes,
+                             n_MAU=100, thr_MAU=3)
+
+            csum_blr, _ = cpf.calibrated_pmt_sum(
+                             pmtblr[event].astype(np.float64),
+                             adc_to_pes,
+                             n_MAU=100, thr_MAU=3)
 
             diff = csum_cwf - csum_blr
             norm = np.sum(csum_blr)
@@ -68,8 +72,14 @@ def test_csum_python_cython():
     with tb.open_file(RWF_file, 'r') as h5rwf:
         pmtrwf, pmtblr, sipmrwf = tbl.get_vectors(h5rwf)
         for event in range(10):
-            csum_blr    = cpf.calibrated_pmt_sum(pmtblr[event].astype(np.float64), adc_to_pes, n_MAU=100, thr_MAU=3)
-            csum_blr_py =  pf.calibrated_pmt_sum(pmtblr[event].astype(np.float64), adc_to_pes, n_MAU=100, thr_MAU=3)
+            csum_blr, _  =      cpf.calibrated_pmt_sum(
+                                   pmtblr[event].astype(np.float64),
+                                   adc_to_pes,
+                                   n_MAU=100, thr_MAU=3)
+            csum_blr_py, _, _ = pf.calibrated_pmt_sum(
+                                   pmtblr[event].astype(np.float64),
+                                   adc_to_pes,
+                                   n_MAU=100, thr_MAU=3)
 
             assert abs(np.sum(csum_blr) - np.sum(csum_blr_py)) < 1e-4
 
@@ -118,7 +128,7 @@ def test_csum_zs_s12():
     npmt = 10
     vsum = v * npmt
     CWF, adc_to_pes = toy_cwf_and_adc(v, npmt=npmt)
-    csum = cpf.calibrated_pmt_sum(CWF, adc_to_pes, n_MAU=1, thr_MAU=0)
+    csum, _ = cpf.calibrated_pmt_sum(CWF, adc_to_pes, n_MAU=1, thr_MAU=0)
     npt.assert_allclose(vsum, csum)
 
     vsum_zs = vsum_zsum(vsum, threshold=10)
@@ -145,7 +155,7 @@ def test_csum_zs_s12():
              tmin = 0, tmax = 1e+6,
              lmin = 0, lmax = 1000000,
              stride=4, rebin=False, rebin_stride=40)
-    
+
     for i in S12L1:
         t1 = S12L1[i][0]
         e1 = S12L1[i][1]

--- a/invisible_cities/core/peak_functions_test.py
+++ b/invisible_cities/core/peak_functions_test.py
@@ -98,12 +98,9 @@ def toy_pmt_signal():
     return pmt
 
 
-def toy_pmt_sum(v, npmt = 10):
-    """Return the sum of npmt waveforms"""
-    vsum = np.zeros(v.shape[0])
-    for i in range(npmt):
-        vsum = np.add(vsum, v)
-    return vsum
+def toy_pmt_scale(v, npmt = 10):
+    """Scale v by pmt"""
+    return npmt * v
 
 
 def toy_cwf_and_adc(v, npmt=10):
@@ -128,7 +125,7 @@ def test_csum_zs_s12():
     5) test that find_S12 is the same in python and cython functions.
     """
     v = toy_pmt_signal()
-    vsum = toy_pmt_sum(v, npmt=10)
+    vsum = toy_pmt_scale(v, npmt=10)
     CWF, adc_to_pes = toy_cwf_and_adc(v, npmt=10)
     csum = cpf.calibrated_pmt_sum(CWF, adc_to_pes, n_MAU=1, thr_MAU=0)
     npt.assert_allclose(vsum, csum)

--- a/invisible_cities/core/peak_functions_test.py
+++ b/invisible_cities/core/peak_functions_test.py
@@ -1,0 +1,187 @@
+from __future__ import absolute_import
+
+from pytest import mark
+import sys, os
+
+import pandas as pd
+import numpy as np
+import numpy.testing as npt
+import tables as tb
+
+from   invisible_cities.database import load_db
+import invisible_cities.sierpe.blr as blr
+import invisible_cities.core.tbl_functions as tbl
+import invisible_cities.core.peak_functions_c as cpf
+import invisible_cities.core.peak_functions as pf
+import invisible_cities.core.sensor_functions as sf
+import invisible_cities.core.core_functions as cf
+
+
+def test_csum_zs_blr_cwf():
+    """Test that:
+     1) the calibrated sum (csum) of the BLR and the CWF is the same
+    within tolerance.
+     2) csum and zeros-supressed sum (zs) are the same
+    within tolerance
+    """
+
+    RWF_file = (os.environ['ICDIR']
+               + '/database/test_data/electrons_40keV_z250_RWF.h5')
+
+    with tb.open_file(RWF_file, 'r') as h5rwf:
+        pmtrwf, pmtblr, sipmrwf = tbl.get_vectors(h5rwf)
+        DataPMT = load_db.DataPMT()
+        coeff_c    = abs(DataPMT.coeff_c.values)
+        coeff_blr  = abs(DataPMT.coeff_blr.values)
+        adc_to_pes = abs(DataPMT.adc_to_pes.values)
+
+        for event in range(10):
+            CWF = blr.deconv_pmt(pmtrwf[event], coeff_c, coeff_blr)
+            csum_cwf = cpf.calibrated_pmt_sum(CWF, adc_to_pes,
+                                              n_MAU=100, thr_MAU=3)
+            csum_blr = cpf.calibrated_pmt_sum(pmtblr[event].astype(np.float64),
+                                              adc_to_pes,
+                                              n_MAU=100, thr_MAU=3)
+
+            diff = csum_cwf - csum_blr
+            norm = np.sum(csum_blr)
+            DIFF = np.sum(diff) / norm
+            assert DIFF < 0.1
+
+            wfzs_ene, wfzs_indx = cpf.wfzs(csum_cwf, threshold=0.5)
+            dff = abs(np.sum(csum_cwf) - np.sum(wfzs_ene))
+            norm = np.sum(csum_cwf)
+            DIFF = dff / norm
+            assert DIFF < 0.1
+
+@mark.slow
+def test_csum_python_cython():
+    """Test that python and cython functions yield the same result for csum
+    """
+
+    RWF_file = (os.environ['ICDIR']
+               + '/database/test_data/electrons_40keV_z250_RWF.h5')
+
+    DataPMT = load_db.DataPMT()
+    adc_to_pes = abs(DataPMT.adc_to_pes.values)
+
+    with tb.open_file(RWF_file, 'r') as h5rwf:
+        pmtrwf, pmtblr, sipmrwf = tbl.get_vectors(h5rwf)
+        for event in range(10):
+            csum_blr = cpf.calibrated_pmt_sum(pmtblr[event].astype(np.float64),
+                                              adc_to_pes,
+                                              n_MAU=100, thr_MAU=3)
+
+            csum_blr_py = pf.calibrated_pmt_sum(pmtblr[event],
+                                                adc_to_pes,
+                                                n_MAU=100, thr_MAU=3)
+
+            assert abs(np.sum(csum_blr) - np.sum(csum_blr_py)) < 1e-4
+
+            wfzs_ene, wfzs_indx = cpf.wfzs(csum_blr, threshold=0.5)
+            wfzs_ene_py, wfzs_indx_py = pf.wfzs(csum_blr_py, threshold=0.5)
+
+            assert abs(np.sum(wfzs_ene) - np.sum(wfzs_ene_py)) < 1e-4
+            assert abs(np.sum(wfzs_ene) - np.sum(wfzs_ene_py)) < 1e-4
+            npt.assert_array_equal(wfzs_indx, wfzs_indx_py)
+
+
+def toy_pmt_signal():
+    """ Mimick a PMT waveform."""
+    v0 = cf.np_constant(200, 1)
+    v1 = cf.np_range(1.1, 2.1, 0.1)
+    v2 = cf.np_constant(10, 2)
+    v3 = cf.np_reverse_range(1.1, 2.1, 0.1)
+
+    v   = np.concatenate((v0, v1, v2, v3, v0))
+    pmt = np.concatenate((v, v, v))
+    return pmt
+
+
+def toy_pmt_sum(v, npmt = 10):
+    """Return the sum of npmt waveforms"""
+    vsum = np.zeros(v.shape[0])
+    for i in range(npmt):
+        vsum = np.add(vsum, v)
+    return vsum
+
+
+def toy_cwf_and_adc(v, npmt=10):
+    """Return CWF and adc_to_pes for toy example"""
+    CWF = [v] * npmt
+    adc_to_pes = np.ones(v.shape[0])
+    return np.array(CWF), adc_to_pes
+
+
+def vsum_zsum(vsum, threshold=10):
+    """Compute ZS over vsum"""
+    return vsum[vsum > threshold]
+
+
+def test_csum_zs_s12():
+    """Several sequencial tests:
+    1) Test that csum (the object of the test) and vsum (sum of toy pmt
+    waveforms) yield the same result.
+    2) Same for ZS sum
+    3) Test that time_from_index is the same in python and cython functions.
+    4) test that rebin is the same in python and cython functions.
+    5) test that find_S12 is the same in python and cython functions.
+    """
+    v = toy_pmt_signal()
+    vsum = toy_pmt_sum(v, npmt=10)
+    CWF, adc_to_pes = toy_cwf_and_adc(v, npmt=10)
+    csum = cpf.calibrated_pmt_sum(CWF, adc_to_pes, n_MAU=1, thr_MAU=0)
+    npt.assert_allclose(vsum, csum)
+
+    vsum_zs = vsum_zsum(vsum, threshold=10)
+    wfzs_ene, wfzs_indx = cpf.wfzs(csum, threshold=10)
+    npt.assert_allclose(vsum_zs, wfzs_ene)
+
+    t1 = pf.time_from_index(wfzs_indx)
+    t2 = cpf.time_from_index(wfzs_indx)
+    npt.assert_allclose(t1, t2)
+
+    t = pf.time_from_index(wfzs_indx)
+    e = wfzs_ene
+    t1, e1  = pf.rebin_waveform(t, e, stride=10)
+    t2, e2 = cpf.rebin_waveform(t, e, stride=10)
+    npt.assert_allclose(t1, t2)
+    npt.assert_allclose(e1, e2)
+
+    S12L1 = pf.find_S12(wfzs_ene, wfzs_indx,
+             tmin = 0, tmax = 1e+6,
+             lmin = 0, lmax = 1000000,
+             stride=4, rebin=False, rebin_stride=40)
+
+    S12L2 = cpf.find_S12(wfzs_ene, wfzs_indx,
+             tmin = 0, tmax = 1e+6,
+             lmin = 0, lmax = 1000000,
+             stride=4, rebin=False, rebin_stride=40)
+    
+    for i in S12L1:
+        t1 = S12L1[i][0]
+        e1 = S12L1[i][1]
+        t2 = S12L2[i][0]
+        e2 = S12L2[i][1]
+        npt.assert_allclose(t1, t2)
+        npt.assert_allclose(e1, e2)
+
+    # toy yields 3 idential vectors of energy
+    E = np.array([ 11,  12,  13,  14,  15,  16,  17,  18,  19,  20,
+                   20,  20,  20,  20,  20,  20,  20,  20,  20,  20,
+                   20,  19,  18,  17,  16,  15,  14,  13,  12,  11])
+    for i in S12L2.keys():
+        e = S12L2[i][1]
+        npt.assert_allclose(e,E)
+
+    # rebin
+    S12L2 = cpf.find_S12(wfzs_ene, wfzs_indx,
+             tmin = 0, tmax = 1e+6,
+             lmin = 0, lmax = 1000000,
+             stride=10, rebin=True, rebin_stride=10)
+
+    E = np.array([155,  200,  155])
+
+    for i in S12L2.keys():
+        e = S12L2[i][1]
+        npt.assert_allclose(e, E)

--- a/invisible_cities/core/peak_functions_test.py
+++ b/invisible_cities/core/peak_functions_test.py
@@ -98,11 +98,6 @@ def toy_pmt_signal():
     return pmt
 
 
-def toy_pmt_scale(v, npmt = 10):
-    """Scale v by pmt"""
-    return npmt * v
-
-
 def toy_cwf_and_adc(v, npmt=10):
     """Return CWF and adc_to_pes for toy example"""
     CWF = [v] * npmt
@@ -125,8 +120,9 @@ def test_csum_zs_s12():
     5) test that find_S12 is the same in python and cython functions.
     """
     v = toy_pmt_signal()
-    vsum = toy_pmt_scale(v, npmt=10)
-    CWF, adc_to_pes = toy_cwf_and_adc(v, npmt=10)
+    npmt = 10
+    vsum = v * npmt
+    CWF, adc_to_pes = toy_cwf_and_adc(v, npmt=npmt)
     csum = cpf.calibrated_pmt_sum(CWF, adc_to_pes, n_MAU=1, thr_MAU=0)
     npt.assert_allclose(vsum, csum)
 

--- a/invisible_cities/core/pmaps_functions.py
+++ b/invisible_cities/core/pmaps_functions.py
@@ -11,6 +11,7 @@ import tables as tb
 import matplotlib.pyplot as plt
 import invisible_cities.core.system_of_units as units
 import invisible_cities.core.pmaps_functions_c as cpm
+import invisible_cities.core.core_functions as cf
 from   invisible_cities.database import load_db
 from   invisible_cities.core.mpl_functions import circles
 
@@ -44,15 +45,15 @@ def s12df_select_event(S12df, event):
     return S12df.loc[lambda df: df.event.values == event, :]
 
 
-def S12df_to_dict_select_peak(S12df, peak):
+def s12df_select_peak(S12df, peak):
     """Return a copy of the s12df for peak."""
     return S12df.loc[lambda df: S12df.peak.values == peak, :]
 
 
 def s12df_get_wvfm(S12df, event, peak):
     """Return the waveform for event, peak."""
-    s12t = S12_select_event(S12df, event)
-    s12p = S12_select_peak(s12t, peak=peak)
+    s12t = s12df_select_event(S12df, event)
+    s12p = s12df_select_peak(s12t, peak)
     return s12p.time.values, s12p.ene.values
 
 
@@ -62,9 +63,8 @@ def s12df_plot_waveforms(S12df, nmin=0, nmax=16, x=4, y=4):
 
     for i in range(nmin, nmax):
         plt.subplot(y, y, i+1)
-        T, E = S12_get_wvfm(S12df, event=i, peak=0)
+        T, E = s12df_get_wvfm(S12df, event=i, peak=0)
         plt.plot(T, E)
-    plt.show()
 
 def sipm_s2(dSIPM, S2, thr=5*units.pes):
     """Given a vector with SIPMs (energies above threshold), return a list
@@ -199,8 +199,11 @@ def s12_features(S12L, peak=0, max_events=100):
     input: S1L
     returns a S1F object for specific peak
     """
-    nk = np.array(S12L.keys())
-    evt_max = np.max(nk)  # max event: but notice that some events may be missing
+    nk = np.array(list(S12L.keys()))
+
+    # max event: but notice that some events may be missing
+    evt_max = np.max(nk)
+
     n = min(evt_max+1, max_events)
     print('required {} events; found in dict {} events'
           .format(max_events, evt_max+1))
@@ -220,7 +223,7 @@ def s12_features(S12L, peak=0, max_events=100):
 
         s1f.w[i] = T[-1] - T[0]
         s1f.emax[i] = np.max(E)
-        i_t = npf.np_loc1d(E, s1f.emax[i])
+        i_t = cf.loc_elem_1d(E, s1f.emax[i])
         s1f.tmax[i] = T[i_t]
         s1f.etot[i] = np.sum(E)
 

--- a/invisible_cities/core/pmaps_functions.py
+++ b/invisible_cities/core/pmaps_functions.py
@@ -16,17 +16,16 @@ from   invisible_cities.core.mpl_functions import circles
 
 
 
-def read_pmaps(path, pmap_file):
+def read_pmaps(PMP_file):
     """Return the PMAPS as PD DataFrames."""
+    with tb.open_file(PMP_file, 'r') as h5f:
+        s1t = h5f.root.PMAPS.S1
+        s2t = h5f.root.PMAPS.S2
+        s2sit = h5f.root.PMAPS.S2Si
 
-    h5f = tb.open_file(path + pmap_file, 'r+')
-    s1t = h5f.root.PMAPS.S1
-    s2t = h5f.root.PMAPS.S2
-    s2sit = h5f.root.PMAPS.S2Si
-
-    return (pd.DataFrame.from_records(s1t  .read()),
-            pd.DataFrame.from_records(s2t  .read()),
-            pd.DataFrame.from_records(s2sit.read()))
+        return (pd.DataFrame.from_records(s1t  .read()),
+                pd.DataFrame.from_records(s2t  .read()),
+                pd.DataFrame.from_records(s2sit.read()))
 
 
 def s12df_to_s12l(s12df, evt_max=10):

--- a/invisible_cities/core/wfm_to_df_functions.py
+++ b/invisible_cities/core/wfm_to_df_functions.py
@@ -189,12 +189,8 @@ def find_S12(wfzs, tmin=0*units.mus, tmax=1200*units.mus,
     S12[0] = [(T[0], P[0])]
 
     for i in range(1, len(wfzs)):
-
-        if T[i] > tmax:
-            break
-
-        if T[i] < tmin:
-            continue
+        if T[i] > tmax: break
+        if T[i] < tmin: continue
 
         if wfzs.index[i] - stride > wfzs.index[i-1]:  #new s12
             j += 1

--- a/invisible_cities/core/wfm_to_df_functions.py
+++ b/invisible_cities/core/wfm_to_df_functions.py
@@ -200,10 +200,10 @@ def find_S12(wfzs, tmin=0*units.mus, tmax=1200*units.mus,
             j += 1
             S12[j] = [(T[i], P[i])]
         else:
-            S12[j].append((T[i], P[i])
+            S12[j].append((T[i], P[i]))
 
     S12L = []
     for s in S12:
-        if lmin <= and len(s) < lmax:
+        if lmin <= len(s) < lmax:
             S12L.append(pd.DataFrame(s, columns=['time_ns','ene_pes']))
     return S12L

--- a/invisible_cities/core/wfm_to_df_functions.py
+++ b/invisible_cities/core/wfm_to_df_functions.py
@@ -167,3 +167,43 @@ def zero_suppression(waveforms, thresholds, to_mus=None):
         thresholds = np.ones(waveforms.shape[0]) * thresholds
     zsdata = map(zs_wf, waveforms, thresholds)
     return {i: df for i, df in enumerate(zsdata) if df is not None}
+
+def find_S12(wfzs, tmin=0*units.mus, tmax=1200*units.mus,
+             stride=4, lmin=8, lmax=1e+6):
+    """Find S1/S2 peaks.
+
+    input: a zero supressed wf
+    returns a list of waveform data frames
+    do not interrupt the peak if next sample comes within stride
+    accept the peak only if within [lmin, lmax)
+    accept the peak only if within [tmin, tmax)
+    """
+
+    T = wfzs['time_ns'].values
+    P = wfzs['ene_pes'].values
+
+    S12 = {}
+    pulse_on = 1
+    j = 0
+
+    S12[0] = [(T[0], P[0])]
+
+    for i in range(1, len(wfzs)):
+
+        if T[i] > tmax:
+            break
+
+        if T[i] < tmin:
+            continue
+
+        if wfzs.index[i] - stride > wfzs.index[i-1]:  #new s12
+            j += 1
+            S12[j] = [(T[i], P[i])]
+        else:
+            S12[j].append((T[i], P[i])
+
+    S12L = []
+    for s in S12:
+        if lmin <= and len(s) < lmax:
+            S12L.append(pd.DataFrame(s, columns=['time_ns','ene_pes']))
+    return S12L

--- a/invisible_cities/core/wfm_to_df_functions.py
+++ b/invisible_cities/core/wfm_to_df_functions.py
@@ -48,7 +48,7 @@ def get_energy_of_waveform_for_event_list_as_df(pmtea, event_list=[0]):
     for i in event_list:
         epmt = np.zeros(NPMT)
         for j in range(NPMT):
-            epmt[j] = np.sum(pmtea[i, j])
+            epmt[j] = 2 # np.sum(pmtea[i, j])
         EPMT.append(epmt)
 
     return pd.DataFrame(EPMT)


### PR DESCRIPTION
Add new test suite

A new test suite (peak_functions_test.py) has been added. The module
runs several exahustive tests over peak_functions, including:

1. Comparison of BLR and CWF waveforms.
2. Comparison of python and cython functions (for this purpose the
python version of several existing cython functions have been added
to peak_functions.py)
3. Analysis of a toy model.

In addition, a few utility functions (needed for the test toy model) have
been added to core_functions (together with their corresponding test
in core_functions_test).

Some minor refactoring has been carried out along with the addition of this
module (moving an obsolete function out of peak_functions.py).

Also, some minor modifications (mostly cosmetic) have been added to several core modules.

The main ideas on the test suite are illustrated here:

https://anaconda.org/nexticw/peak_functions_test

