### PR TITLE
Add numpy array creation utilities and their tests

### DIFF
--- a/invisible_cities/core/core_functions.py
+++ b/invisible_cities/core/core_functions.py
@@ -21,6 +21,23 @@ def loc_elem_1d(np1d, elem):
     return np.where(np1d==elem)[0][0]
 
 
+def np_range(start, end, stride):
+    """Syntactic sugar for np.arange() (included for consistency with
+    np_reverse_range).
+    """
+    return np.arange(start, end, stride)
+
+
+def np_reverse_range(start, end, stride):
+    """Reverse range."""
+    return np.arange(start, end, stride)[::-1]
+
+
+def np_constant(dim, value):
+    """Returns a np array of dimension dim with all elements == value."""
+    return np.ones(dim) * value
+
+
 def dict_map(func, dic):
     """Apply map to dictionary values maintaining correspondence.
 


### PR DESCRIPTION
(This is another extract from #110, with the tests that were there replaced with tests written in hypothesis.)

`np_range`, `np_reverse_range` and `np_constant`

The tests are written using hypothesis. The value of these tests is
perhaps greater from the perspective of demonstrating and exploring
hypothesis, rather their value as tests for these almost trivial
functions.

One challenge in writing the tests was the fact that a tiny step
size (as compared to the difference between start and stop) resulted
in the construction of an array with an unreasonable number of
elements, which resulted in all the available memory being eaten up
and the machine grinding to a halt. The solution uses hypothesis'
`composite` decorator to generate step sizes which can be both
positive and negative, but not too close to zero.