### PR TITLE
Test and fix cast

### DIFF
--- a/invisible_cities/core/configure.py
+++ b/invisible_cities/core/configure.py
@@ -102,24 +102,18 @@ def cast(value):
     Parameters
     ----------
     value : string
-        Token to be casted.
+        Token to be cast.
 
     Returns
     -------
-    casted_value : variable
-        Python variable of the guessed type.
+    cast_value : object
+        Python object of the guessed type.
     """
-    if value == "True":
-        return True
-    if value == "False":
-        return False
-    if value.isdigit():
-        return int(value)
-    if value.replace(".", "").isdigit():
-        return float(value)
-    if "$" in value:
-        value = os.path.expandvars(value)
-    return value
+    if value in ('True', 'False'): return eval(value)
+    for parse in (int, float):
+        try:                       return parse(value)
+        except ValueError: pass
+    else:                          return os.path.expandvars(value)
 
 
 def read_config_file(cfile):

--- a/invisible_cities/core/configure_test.py
+++ b/invisible_cities/core/configure_test.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 from os import getenv, path
 from pytest import mark
+from hypothesis import given, example
+from hypothesis.strategies import integers, floats, one_of, none
 
 import invisible_cities.core.configure as conf
 
@@ -194,3 +196,26 @@ def test_configure(config_tmpdir, spec):
     # Check that all options have the expected values
     for option in this_configuration:
         assert CFP[option] == this_configuration[option], 'option = ' + option
+
+
+
+@given(one_of(integers(),
+              floats(allow_nan=False, allow_infinity=False)),
+       none())
+@example(True,  True)
+@example(False, False)
+@example(    '$PWD',          getenv('PWD'))
+@example('xxx/$PWD', 'xxx/' + getenv('PWD'))
+@example('astring', 'astring')
+@example('spa ace', 'spa ace')
+def test_cast(i,o):
+    # `given` generates integers or floats as input: their string
+    # representation needs to be seen by `cast`.
+    input  = str(i)
+    # `given` generates `None` as the correct answer, signalling to
+    # the test that the answer should be obtained by evaluating the
+    # input; `example` passes in the exact correct answer, signalling
+    # that that is the value we should use in the assertion.
+    output = eval(input) if o is None else o
+
+    assert conf.cast(input) == output


### PR DESCRIPTION
A hypothesis-based test was added, to catch the obvious (and maybe
some not so obvious) failures in `configure.cast`.

The original implementation tried to recognize ints and floats with an
extremely naive hand-written parser. The new implementation uses
Python's build-in parsers for floats and ints: their constructors.