### PR TITLE
Mark as slow all tests that take more than 0.8 sec to run

### DIFF
--- a/invisible_cities/cities/diomira_test.py
+++ b/invisible_cities/cities/diomira_test.py
@@ -224,6 +224,7 @@ def config_file_spec_with_tmpdir(tmpdir):
 # TODO refactor to factor out config file creation: most of this test
 # is noise; duplication of something that also happens in the above
 # test
+@mark.slow
 def test_command_line_diomira(config_tmpdir):
 
     config_file_spec = config_file_spec_with_tmpdir(config_tmpdir)

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -288,6 +288,7 @@ def config_file_spec_with_tmpdir(tmpdir):
 # TODO refactor to factor out config file creation: most of this test
 # is noise; duplication of something that also happens in the above
 # test
+@mark.slow
 def test_command_line_irene(config_tmpdir):
 
     config_file_spec = config_file_spec_with_tmpdir(config_tmpdir)
@@ -299,6 +300,8 @@ def test_command_line_irene(config_tmpdir):
 
     IRENE(['IRENE', '-c', conf_file_name])
 
+    
+@mark.slow
 def test_read_data(irene_diomira_chain_tmpdir):
     """Test Irene on a file containing an empty event."""
 

--- a/invisible_cities/cities/isidora_test.py
+++ b/invisible_cities/cities/isidora_test.py
@@ -130,6 +130,8 @@ def test_isidora_no_input():
 # TODO refactor to factor out config file creation: most of this test
 # is noise; duplication of something that also happens in the above
 # test
+
+@mark.slow
 def test_command_line_isidora(config_tmpdir):
 
     config_file_spec = config_file_spec_with_tmpdir(config_tmpdir)

--- a/invisible_cities/core/peak_functions_test.py
+++ b/invisible_cities/core/peak_functions_test.py
@@ -16,7 +16,7 @@ import invisible_cities.core.peak_functions as pf
 import invisible_cities.core.sensor_functions as sf
 import invisible_cities.core.core_functions as cf
 
-
+@mark.slow
 def test_csum_zs_blr_cwf():
     """Test that:
      1) the calibrated sum (csum) of the BLR and the CWF is the same

--- a/invisible_cities/core/wfm_functions_test.py
+++ b/invisible_cities/core/wfm_functions_test.py
@@ -4,6 +4,7 @@ from os import path
 from hypothesis import given, assume
 from hypothesis.strategies import lists, integers, floats
 from hypothesis.extra.numpy import arrays
+from pytest import mark
 
 from . import wfm_functions as wfm
 import invisible_cities.core.peak_functions_c as cpf
@@ -47,6 +48,7 @@ def test_rebin_wf2(t):
     np.testing.assert_allclose(np.sum(e), np.sum(E), rtol=1e-5, atol=1e-5)
 
 
+@mark.slow
 def test_compare_cwf_blr():
     """Test functions cwf_from_rwf() and compare_cwf_blr().
     The test:


### PR DESCRIPTION
At the moment the next slowest test takes 0.24 sec to run

Using pytest -m "not slow" now runs the majority of our tests in 2 seconds rather than 30 seconds for the full set. This significantly speeds up development and in case you didn't know, root is hell. 