### PR TITLE
Replace reinvented wheel (float near-equality)

### DIFF
--- a/invisible_cities/cities/diomira_test.py
+++ b/invisible_cities/cities/diomira_test.py
@@ -93,7 +93,6 @@ def test_diomira_cwf_blr(irene_diomira_chain_tmpdir):
        CWF (using deconvoution algorithm), then checks that the CWF match
        the BLR within 1 %.
     """
-    eps = 1
     RWF_file = str(irene_diomira_chain_tmpdir.join(
                    'electrons_40keV_z250_RWF.h5'))
     with tb.open_file(RWF_file, 'r') as e40rwf:
@@ -112,10 +111,10 @@ def test_diomira_cwf_blr(irene_diomira_chain_tmpdir):
                                  n_baseline=28000,
                                  thr_trigger=5)
 
+
             for i in range(len(CWF)):
-                diff = abs(np.sum(BLR[i][5000:5100]) - np.sum(CWF[i][5000:5100]))
-                diff = 100. * diff / np.sum(BLR[i])
-                assert diff < eps
+                assert np.isclose(np.sum(BLR[i][5000:5100]),
+                                  np.sum(CWF[i][5000:5100]), rtol=0.01)
 
 
 @mark.slow

--- a/invisible_cities/core/peak_functions_test.py
+++ b/invisible_cities/core/peak_functions_test.py
@@ -48,16 +48,11 @@ def test_csum_zs_blr_cwf():
                              adc_to_pes,
                              n_MAU=100, thr_MAU=3)
 
-            diff = csum_cwf - csum_blr
-            norm = np.sum(csum_blr)
-            DIFF = np.sum(diff) / norm
-            assert DIFF < 0.1
-
             wfzs_ene, wfzs_indx = cpf.wfzs(csum_cwf, threshold=0.5)
-            dff = abs(np.sum(csum_cwf) - np.sum(wfzs_ene))
-            norm = np.sum(csum_cwf)
-            DIFF = dff / norm
-            assert DIFF < 0.1
+
+            assert np.isclose(np.sum(csum_cwf), np.sum(csum_blr), rtol=0.01)
+            assert np.isclose(np.sum(csum_cwf), np.sum(wfzs_ene), rtol=0.1)
+
 
 @mark.slow
 def test_csum_python_cython():

--- a/invisible_cities/core/wfm_functions.py
+++ b/invisible_cities/core/wfm_functions.py
@@ -200,8 +200,8 @@ def cwf_from_rwf(pmtrwf, event_list, run_number=0,
 
 
 def compare_cwf_blr(cwf, pmtblr, event_list, window_size=500):
-    """ Return differences between the area of the CWF and the
-    in a given window, for a list of events.
+    """Return differences between the area of the CWF and the in a given
+    window, for a list of events, expressed as a percentage.
     """
     DIFF = []
     for event in event_list:

--- a/invisible_cities/sierpe/fee_test.py
+++ b/invisible_cities/sierpe/fee_test.py
@@ -92,6 +92,7 @@ def test_FEE():
     signal_out_cf = FE.signal_clean(fee, signal_out, -1)
     signal_r2, acum = deconv_simple(signal_out_cf*FE.v_to_adc(),
                                 coef=fee.freq_LHPFd*np.pi)
-    energy_mea2=np.sum(signal_r2[1000:11000])
-    energy_in2=np.sum(signal_i*FE.i_to_adc())
-    diff = np.abs(100.*((energy_in2-energy_mea2)/energy_in2))
+    energy_mea2 = np.sum(signal_r2[1000:11000])
+    energy_in2  = np.sum(signal_i*FE.i_to_adc())
+    assert np.isclose(energy_in2, energy_mea2, rtol=5e-5)
+


### PR DESCRIPTION
Comparison of floats for near equality is not a new problem we need to
solve ourselves. Many (well-tested, high-levl) utilities for doing
this already exist.

In this case, `numpy.isclose` is used to replace hand-written
reinventions of this particular wheel.