### PR TITLE
Avoid repetition of namedtuple name

### DIFF
--- a/invisible_cities/core/params.py
+++ b/invisible_cities/core/params.py
@@ -1,8 +1,19 @@
+import sys
 from collections import namedtuple
 
-S12Params       = namedtuple('S12Params', 'tmin tmax stride lmin lmax rebin')
-SensorParams    = namedtuple('SensorParam', 'NPMT PMTWL NSIPM SIPMWL')
-ThresholdParams = namedtuple('ThresholdParams',
-                             'thr_s1 thr_s2 thr_MAU thr_sipm thr_SIPM')
-CalibratedSum   = namedtuple('CalibratedSum', 'csum csum_mau')
-PMaps           = namedtuple('PMaps', 'S1 S2 S2Si')
+this_module = sys.modules[__name__]
+
+def _add_namedtuple_in_this_module(name, attribute_names):
+    new_nametuple = namedtuple(name, attribute_names)
+    setattr(this_module, name, new_nametuple)
+
+for name, attrs in (
+        ('S12Params'      , 'tmin tmax stride lmin lmax rebin'),
+        ('SensorParams'   , 'NPMT PMTWL NSIPM SIPMWL'),
+        ('ThresholdParams', 'thr_s1 thr_s2 thr_MAU thr_sipm thr_SIPM'),
+        ('CalibratedSum'  , 'csum csum_mau'),
+        ('PMaps'          , 'S1 S2 S2Si')):
+    _add_namedtuple_in_this_module(name, attrs)
+
+# Leave nothing but the namedtuple types in the namespace of this module
+del name, namedtuple, sys, this_module, _add_namedtuple_in_this_module


### PR DESCRIPTION
Standard usage of namedtuples violates the DRY (Do not Repeat
Yourself) principle:

    Name = namedtuple('Name', 'a b c d')

requires the repetition of `Name`.

With isolated uses of `namedtuple` it is not worth worrying about this
too much, but in `core/params.py` we create a whole bunch of
`namedtuple`s in succession, and expect more in the future.

So we get rid of the name repetition with a little metaprogramming:
specify the name and the attributes of the `namedtuple` and loop over
these specs to create them and bind them to the module.

Note that the original code already contained a mismatch in the
repeated information for SensorParam(s)!