### PR TITLE
Make manage.sh clean take care of .pyc files

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -165,20 +165,21 @@ function compile_and_test {
 
 function clean {
     echo "Cleaning IC generated files:"
-    C_FILES=`find . -name '*.c'`
-    SOFILES=`find . -name '*.so'`
-    REMOVE="$C_FILES $SOFILES"
-    if [ ! -z "${REMOVE// }" ]
-    then
-        for FILE in $REMOVE
-        do
-            COMMAND="rm $FILE"
-            echo $COMMAND
-            $COMMAND
-        done
-    else
-        echo Nothing found to clean
-    fi
+    FILETYPES='*.c *.so *.pyc __pycache__'
+    for TYPE in $FILETYPES
+    do
+		echo Cleaning $TYPE files
+        REMOVE=`find . -name $TYPE`
+        if [ ! -z "${REMOVE// }" ]
+        then
+            for FILE in $REMOVE
+            do
+               rm -rf $FILE
+            done
+        else
+            echo Nothing found to clean in $TYPE
+        fi
+    done
 }
 
 ## Main command dispatcher


### PR DESCRIPTION
Before accepting this PR, I would like it to be improved. The current implementation makes too much noise: it mentions every single `.pyc` file in the `__pycache__` directories.

@jmbenlloch please check that I'm not doing something dangerously stupid.

Feel free to add an improvement which is less noisy. I'll get around to doing it myself eventually, but the need for this functionality arose in the middle of doing something else, so I've done the bare minimum, for now.