### PR TITLE
Replace brackets and quotes with a dot

### DIFF
--- a/invisible_cities/cities/diomira.py
+++ b/invisible_cities/cities/diomira.py
@@ -194,16 +194,16 @@ def DIOMIRA(argv=sys.argv):
 
     CFP = configure(argv)
     fpp = Diomira()
-    files_in = glob(CFP['FILE_IN'])
+    files_in = glob(CFP.FILE_IN)
     files_in.sort()
     fpp.set_input_files(files_in)
-    fpp.set_output_file(CFP['FILE_OUT'])
-    fpp.set_compression(compression=CFP['COMPRESSION'])
-    fpp.set_print(nprint=CFP['NPRINT'])
+    fpp.set_output_file(CFP.FILE_OUT)
+    fpp.set_compression(compression=CFP.COMPRESSION)
+    fpp.set_print(nprint=CFP.NPRINT)
 
-    fpp.set_sipm_noise_cut(noise_cut = CFP["NOISE_CUT"])
+    fpp.set_sipm_noise_cut(noise_cut = CFP.NOISE_CUT)
 
-    nevts = CFP['NEVENTS'] if not CFP['RUN_ALL'] else -1
+    nevts = CFP.NEVENTS if not CFP.RUN_ALL else -1
     t0 = time()
     nevt = fpp.run(nmax=nevts)
     t1 = time()

--- a/invisible_cities/cities/diomira_test.py
+++ b/invisible_cities/cities/diomira_test.py
@@ -38,13 +38,13 @@ def test_diomira_fee_table():
 
     with tb.open_file(RWF_file, 'r') as e40rwf:
         fee = tbl.read_FEE_table(e40rwf.root.MC.FEE)
-        feep = fee['fee_param']
+        feep = fee.fee_param
         eps = 1e-04
         # Ignoring PEP8 to imrpove readability by making symmetry explicit.
-        assert len(fee['adc_to_pes'])    == e40rwf.root.RD.pmtrwf.shape[1]
-        assert len(fee['coeff_blr'])     == e40rwf.root.RD.pmtrwf.shape[1]
-        assert len(fee['coeff_c'])       == e40rwf.root.RD.pmtrwf.shape[1]
-        assert len(fee['pmt_noise_rms']) == e40rwf.root.RD.pmtrwf.shape[1]
+        assert len(fee.adc_to_pes)    == e40rwf.root.RD.pmtrwf.shape[1]
+        assert len(fee.coeff_blr)     == e40rwf.root.RD.pmtrwf.shape[1]
+        assert len(fee.coeff_c)       == e40rwf.root.RD.pmtrwf.shape[1]
+        assert len(fee.pmt_noise_rms) == e40rwf.root.RD.pmtrwf.shape[1]
         assert feep.NBITS == FEE.NBITS
         assert abs(feep.FEE_GAIN - FEE.FEE_GAIN)           < eps
         assert abs(feep.LSB - FEE.LSB)                     < eps

--- a/invisible_cities/cities/irene.py
+++ b/invisible_cities/cities/irene.py
@@ -298,60 +298,60 @@ def IRENE(argv = sys.argv):
     CFP = configure(argv)
 
     # parameters for s1 searches
-    s1par = S12P(tmin   = CFP['S1_TMIN'] * units.mus,
-                 tmax   = CFP['S1_TMAX'] * units.mus,
-                 stride = CFP['S1_STRIDE'],
-                 lmin   = CFP['S1_LMIN'],
-                 lmax   = CFP['S1_LMAX'],
+    s1par = S12P(tmin   = CFP.S1_TMIN * units.mus,
+                 tmax   = CFP.S1_TMAX * units.mus,
+                 stride = CFP.S1_STRIDE,
+                 lmin   = CFP.S1_LMIN,
+                 lmax   = CFP.S1_LMAX,
                  rebin  = False)
 
     # parameters for s2 searches
-    s2par = S12P(tmin   = CFP['S2_TMIN'] * units.mus,
-                 tmax   = CFP['S2_TMAX'] * units.mus,
-                 stride = CFP['S2_STRIDE'],
-                 lmin   = CFP['S2_LMIN'],
-                 lmax   = CFP['S2_LMAX'],
+    s2par = S12P(tmin   = CFP.S2_TMIN * units.mus,
+                 tmax   = CFP.S2_TMAX * units.mus,
+                 stride = CFP.S2_STRIDE,
+                 lmin   = CFP.S2_LMIN,
+                 lmax   = CFP.S2_LMAX,
                  rebin  = True)
 
     #class instance
-    irene = Irene(run_number=CFP['RUN_NUMBER'])
+    irene = Irene(run_number=CFP.RUN_NUMBER)
 
     # input files
     # TODO detect non existing files and raise sensible message
-    files_in = glob(CFP['FILE_IN'])
+    files_in = glob(CFP.FILE_IN)
     files_in.sort()
     irene.set_input_files(files_in)
 
     # output file
-    irene.set_output_file(CFP['FILE_OUT'])
-    irene.set_compression(CFP['COMPRESSION'])
+    irene.set_output_file(CFP.FILE_OUT)
+    irene.set_compression(CFP.COMPRESSION)
     # print frequency
-    irene.set_print(nprint=CFP['NPRINT'])
+    irene.set_print(nprint=CFP.NPRINT)
 
     # parameters of BLR
-    irene.set_blr(n_baseline  = CFP['NBASELINE'],
-                  thr_trigger = CFP['THR_TRIGGER'] * units.adc)
+    irene.set_blr(n_baseline  = CFP.NBASELINE,
+                  thr_trigger = CFP.THR_TRIGGER * units.adc)
 
     # parameters of calibrated sums
-    irene.set_csum(n_MAU = CFP['NMAU'],
-                   thr_MAU = CFP['THR_MAU'] * units.adc,
-                   thr_csum_s1 =CFP['THR_CSUM_S1'] * units.pes,
-                   thr_csum_s2 =CFP['THR_CSUM_S2'] * units.pes)
+    irene.set_csum(n_MAU = CFP.NMAU,
+                   thr_MAU = CFP.THR_MAU * units.adc,
+                   thr_csum_s1 =CFP.THR_CSUM_S1 * units.pes,
+                   thr_csum_s2 =CFP.THR_CSUM_S2 * units.pes)
 
     # MAU and thresholds for SiPms
-    irene.set_sipm(n_MAU_sipm= CFP['NMAU_SIPM'],
-                   thr_sipm=CFP['THR_SIPM'])
+    irene.set_sipm(n_MAU_sipm= CFP.NMAU_SIPM,
+                   thr_sipm=CFP.THR_SIPM)
 
     # parameters for PMAP searches
     irene.set_pmap_params(s1_params   = s1par,
                           s2_params   = s2par,
-                          thr_sipm_s2 = CFP['THR_SIPM_S2'])
+                          thr_sipm_s2 = CFP.THR_SIPM_S2)
 
 
     t0 = time()
-    nevts = CFP['NEVENTS'] if not CFP['RUN_ALL'] else -1
+    nevts = CFP.NEVENTS if not CFP.RUN_ALL else -1
     # run
-    nevt = irene.run(nmax=nevts, print_empty=CFP['PRINT_EMPTY_EVENTS'])
+    nevt = irene.run(nmax=nevts, print_empty=CFP.PRINT_EMPTY_EVENTS)
     t1 = time()
     dt = t1 - t0
 

--- a/invisible_cities/cities/isidora.py
+++ b/invisible_cities/cities/isidora.py
@@ -129,22 +129,22 @@ def ISIDORA(argv = sys.argv):
     """ISIDORA DRIVER"""
     CFP = configure(argv)
 
-    files_in    = glob(CFP['FILE_IN'])
+    files_in    = glob(CFP.FILE_IN)
     files_in.sort()
 
 
-    fpp = Isidora(run_number  = CFP['RUN_NUMBER'],
+    fpp = Isidora(run_number  = CFP.RUN_NUMBER,
                   files_in    = files_in,
-                  n_baseline  = CFP['NBASELINE'],
-                  thr_trigger = CFP['THR_TRIGGER'] * units.adc)
+                  n_baseline  = CFP.NBASELINE,
+                  thr_trigger = CFP.THR_TRIGGER * units.adc)
 
     #fpp.set_input_files(files_in)
-    fpp.set_output_file(CFP['FILE_OUT'])
-    fpp.set_compression(CFP['COMPRESSION'])
-    fpp.set_print(nprint = CFP['NPRINT'])
+    fpp.set_output_file(CFP.FILE_OUT)
+    fpp.set_compression(CFP.COMPRESSION)
+    fpp.set_print(nprint = CFP.NPRINT)
 
     t0 = time()
-    nevts = CFP['NEVENTS'] if not CFP['RUN_ALL'] else -1
+    nevts = CFP.NEVENTS if not CFP.RUN_ALL else -1
     nevt = fpp.run(nmax=nevts)
     t1 = time()
     dt = t1 - t0

--- a/invisible_cities/cities/maurilia.py
+++ b/invisible_cities/cities/maurilia.py
@@ -83,11 +83,11 @@ def MAURILIA(argv=sys.argv):
 
     CFP = configure(argv)
     fpp = Maurilia()
-    files_in = glob(CFP['FILE_IN'])
+    files_in = glob(CFP.FILE_IN)
     files_in.sort()
     fpp.set_input_files(files_in)
-    fpp.set_output_file(CFP['FILE_OUT'])
-    fpp.set_compression(CFP['COMPRESSION'])
+    fpp.set_output_file(CFP.FILE_OUT)
+    fpp.set_compression(CFP.COMPRESSION)
 
     t0 = time()
     fpp.run()

--- a/invisible_cities/core/configure_test.py
+++ b/invisible_cities/core/configure_test.py
@@ -195,7 +195,7 @@ def test_configure(config_tmpdir, spec):
 
     # Check that all options have the expected values
     for option in this_configuration:
-        assert CFP[option] == this_configuration[option], 'option = ' + option
+        assert getattr(CFP, option) == this_configuration[option], 'option = ' + option
 
 
 

--- a/invisible_cities/reco/tbl_functions.py
+++ b/invisible_cities/reco/tbl_functions.py
@@ -15,7 +15,7 @@ from __future__ import print_function, division, absolute_import
 import numpy as np
 import tables as tb
 import pandas as pd
-
+from argparse import Namespace
 
 def filters(name):
     """Return the filter corresponding to a given key.
@@ -67,12 +67,12 @@ def read_FEE_table(fee_t):
                          "C1", "C2", "ZIN", "DAQ_GAIN", "NBITS", "LSB",
                          "NOISE_I", "NOISE_DAQ", "t_sample", "f_sample",
                          "f_mc", "f_LPF1", "f_LPF2"])
-    FEE = {}
-    FEE["fee_param"] = F
-    FEE["coeff_c"]       = np.array(fa[0][18], dtype=np.double)
-    FEE["coeff_blr"]     = np.array(fa[0][19], dtype=np.double)
-    FEE["adc_to_pes"]    = np.array(fa[0][20], dtype=np.double)
-    FEE["pmt_noise_rms"] = np.array(fa[0][21], dtype=np.double)
+    FEE = Namespace()
+    FEE.fee_param     = F
+    FEE.coeff_c       = np.array(fa[0][18], dtype=np.double)
+    FEE.coeff_blr     = np.array(fa[0][19], dtype=np.double)
+    FEE.adc_to_pes    = np.array(fa[0][20], dtype=np.double)
+    FEE.pmt_noise_rms = np.array(fa[0][21], dtype=np.double)
     return FEE
 
 


### PR DESCRIPTION
Work in progress: there may be more places where this should/could be done.

The interface `foo.bar` is much cleaner than `foo['bar']`. The former is the natural interface presented by `argparse` and yet `config.py` insists on turning this convenient interface into the uglier one. These changes reverse this choice.

A similar change is made in `read_FEE_table`.
