### PR TITLE
Add function to create dictionaries from S2Si dataframes

### DIFF
--- a/invisible_cities/reco/pmaps_functions.py
+++ b/invisible_cities/reco/pmaps_functions.py
@@ -4,17 +4,14 @@ JJGC December 2016
 """
 from __future__ import print_function, division, absolute_import
 
-import math
 import numpy as np
 import pandas as pd
 import tables as tb
 import matplotlib.pyplot as plt
-import invisible_cities.core.system_of_units as units
-from   invisible_cities.reco.pmaps_functions_c import df_to_pmaps_dict
+from   invisible_cities.reco.pmaps_functions_c import df_to_pmaps_dict, df_to_s2si_dict
 import invisible_cities.core.core_functions as cf
 from   invisible_cities.database import load_db
 from   invisible_cities.core.mpl_functions import circles
-
 
 
 def read_pmaps(PMP_file):
@@ -27,6 +24,7 @@ def read_pmaps(PMP_file):
         return (pd.DataFrame.from_records(s1t  .read()),
                 pd.DataFrame.from_records(s2t  .read()),
                 pd.DataFrame.from_records(s2sit.read()))
+
 
 def s12df_select_event(S12df, event):
     """Return a copy of the s12df for event."""

--- a/invisible_cities/reco/pmaps_functions_c.pxd
+++ b/invisible_cities/reco/pmaps_functions_c.pxd
@@ -6,3 +6,4 @@ cimport numpy as np
 import numpy as np
 
 cpdef df_to_pmaps_dict(df, max_events=?)
+cpdef dict df_to_s2si_dict(df, max_events=?)

--- a/invisible_cities/reco/pmaps_functions_c.pyx
+++ b/invisible_cities/reco/pmaps_functions_c.pyx
@@ -38,3 +38,43 @@ cpdef df_to_pmaps_dict(df, max_events=None):
             current_event[peak_number] = Peak(np.array(t), np.array(E))
 
     return all_events
+
+
+cpdef dict df_to_s2si_dict(df, max_events=None):
+    cdef dict  all_events = {}
+    cdef dict  current_event
+    cdef dict  current_peak
+    cdef tuple current_sipm
+
+    cdef int   [:] event   = df.event  .values
+    cdef char  [:] peak    = df.peak   .values
+    cdef short [:] nsipm   = df.nsipm  .values
+    cdef short [:] nsample = df.nsample.values
+    cdef float [:] ene     = df.ene    .values
+
+    cdef int  df_size = len(df.index)
+    cdef long limit = np.iinfo(int).max if max_events is None or max_events < 0 else max_events
+
+    cdef int i
+    for i in range(df_size):
+        if event[i] >= limit: break
+
+        current_event = all_events   .setdefault(event[i],  {}     )
+        current_peak  = current_event.setdefault( peak[i],  {}     )
+        current_sipm  = current_peak .setdefault(nsipm[i], ([], []))
+        current_sipm[0].append(nsample[i])
+        current_sipm[1].append(    ene[i])
+
+    cdef int  ID
+    cdef list sample
+    cdef list energy
+    # Postprocessing: Turn lists to numpy arrays before returning and fill
+    # empty slices with zeros
+    for current_event in all_events.values():
+        for current_peak in current_event.values():
+            for ID, (sample, energy) in current_peak.items():
+                maxsample                = np.max(sample) + 1
+                current_peak[ID]         = np.zeros(maxsample)
+                current_peak[ID][sample] = energy
+
+    return all_events

--- a/invisible_cities/reco/pmaps_functions_test.py
+++ b/invisible_cities/reco/pmaps_functions_test.py
@@ -10,8 +10,8 @@ parametrize = mark.parametrize
 
 
 import invisible_cities.reco.pmaps_functions   as pmapf
-import invisible_cities.reco.pmaps_functions_c as pmapf_c
-from   invisible_cities.reco.pmaps_functions import df_to_pmaps_dict
+from   invisible_cities.reco.pmaps_functions import df_to_pmaps_dict, df_to_s2si_dict
+
 
 @fixture(scope='module')
 def KrMC_pmaps():
@@ -19,37 +19,44 @@ def KrMC_pmaps():
     test_file = os.path.expandvars("$ICDIR/database/test_data/KrMC_pmaps.h5")
     S1_evts   = [1, 2, 4, 6, 12, 14, 15, 16, 17, 18, 19, 21, 22, 23, 24]
     S2_evts   = list(range(50, 100))
+    S2Si_evts = list(S2_evts)
+    for i in [56, 60, 64, 68, 69, 71, 80, 83, 85, 94, 95]:
+        S2Si_evts.pop(S2Si_evts.index(i))
     s1s, s2s, s2sis = pmapf.read_pmaps(test_file)
-    return (s1s, s2s, s2sis), (S1_evts, S2_evts)
+    return (s1s, s2s, s2sis), (S1_evts, S2_evts, S2Si_evts)
+
 
 def test_df_to_pmaps_dict_limit_events(KrMC_pmaps):
     max_events = 10
-    (s1s, s2s, s2sis), (S1_evts, _) = KrMC_pmaps
+    (s1s, s2s, s2sis), (S1_evts, _, _) = KrMC_pmaps
     s1dict = df_to_pmaps_dict(s1s, max_events)
     s2dict = df_to_pmaps_dict(s2s, max_events)
     assert sorted(s1dict.keys()) == S1_evts[:4]
     assert sorted(s2dict.keys()) == []
 
+
 def test_df_to_pmaps_dict_take_all_events_if_limit_too_high(KrMC_pmaps):
     max_events_is_more_than_available = 10000
-    (s1s, s2s, s2sis), (S1_evts, S2_evts) = KrMC_pmaps
+    (s1s, s2s, s2sis), (S1_evts, S2_evts, _) = KrMC_pmaps
     s1dict = df_to_pmaps_dict(s1s, max_events_is_more_than_available)
     s2dict = df_to_pmaps_dict(s2s, max_events_is_more_than_available)
     assert sorted(s1dict.keys()) == S1_evts
     assert sorted(s2dict.keys()) == S2_evts
 
+
 def test_df_to_pmaps_dict_default_number_of_events(KrMC_pmaps):
     # Read all events
-    (s1s, s2s, s2sis), (S1_evts, S2_evts) = KrMC_pmaps
+    (s1s, s2s, s2sis), (S1_evts, S2_evts, _) = KrMC_pmaps
     s1dict = df_to_pmaps_dict(s1s)
     s2dict = df_to_pmaps_dict(s2s)
     assert sorted(s1dict.keys()) == S1_evts
     assert sorted(s2dict.keys()) == S2_evts
 
+
 def test_df_to_pmaps_dict_negative_limit_takes_all_events(KrMC_pmaps):
     # Read all events
     negative_max_events = -23
-    (s1s, s2s, s2sis), (S1_evts, S2_evts) = KrMC_pmaps
+    (s1s, s2s, s2sis), (S1_evts, S2_evts, _) = KrMC_pmaps
     s1dict = df_to_pmaps_dict(s1s, negative_max_events)
     s2dict = df_to_pmaps_dict(s2s, negative_max_events)
     assert sorted(list(s1dict.keys())) == S1_evts
@@ -71,16 +78,19 @@ def s12_dataframe_converted(request):
     ))
     return df_to_pmaps_dict(df), df
 
+
 def test_df_to_pmaps_dict_one_entry_per_event(s12_dataframe_converted):
     converted, original = s12_dataframe_converted
     number_of_events_in_original = len(set(original.event))
     assert len(converted) == number_of_events_in_original
+
 
 def test_df_to_pmaps_dict_event_numbers_should_be_keys(s12_dataframe_converted):
     converted, original = s12_dataframe_converted
     event_numbers_in_original = set(original.event)
     for event_number in event_numbers_in_original:
         assert event_number in converted
+
 
 def test_df_to_pmaps_dict_structure(s12_dataframe_converted):
     converted, _ = s12_dataframe_converted
@@ -91,12 +101,14 @@ def test_df_to_pmaps_dict_structure(s12_dataframe_converted):
             assert hasattr(peak_data, 't')
             assert hasattr(peak_data, 'E')
 
+
 def test_df_to_pmaps_dict_events_contain_peaks(s12_dataframe_converted):
     converted, _ = s12_dataframe_converted
     # Multiple peaks in one event ...
     # In event no 0, there are two peaks; evt 3 has one peak
     assert len(converted[0]) == 2
     assert len(converted[3]) == 1
+
 
 def test_df_to_pmaps_dict_events_data_correct(s12_dataframe_converted):
     converted, original = s12_dataframe_converted
@@ -110,3 +122,100 @@ def test_df_to_pmaps_dict_events_data_correct(s12_dataframe_converted):
 
     assert (converted_time == original.time).all()
     assert (converted_ene  == original.ene ).all()
+
+
+###############################################################
+###############################################################
+def test_df_to_s2si_dict_limit_events(KrMC_pmaps):
+    max_events = 10
+    (_, _, s2sis), (_, _, S2Si_evts) = KrMC_pmaps
+    S2Sidict = df_to_s2si_dict(s2sis, max_events)
+    assert sorted(S2Sidict.keys()) == []
+
+
+
+def test_df_to_s2si_dict_take_all_events_if_limit_too_high(KrMC_pmaps):
+    max_events_is_more_than_available = 10000
+    (_, _, s2sis), (_, _, S2Si_evts) = KrMC_pmaps
+    S2Sidict = df_to_s2si_dict(s2sis, max_events_is_more_than_available)
+    assert sorted(S2Sidict.keys()) == S2Si_evts
+
+
+def test_df_to_s2si_dict_default_number_of_events(KrMC_pmaps):
+    # Read all events
+    (_, _, s2sis), (_, _, S2Si_evts) = KrMC_pmaps
+    S2Sidict = df_to_s2si_dict(s2sis)
+    assert sorted(S2Sidict.keys()) == S2Si_evts
+
+
+def test_df_to_s2si_dict_negative_limit_takes_all_events(KrMC_pmaps):
+    # Read all events
+    negative_max_events = -23
+    (_, _, s2sis), (_, _, S2Si_evts) = KrMC_pmaps
+    S2Sidict = df_to_s2si_dict(s2sis, negative_max_events)
+    assert sorted(S2Sidict.keys()) == S2Si_evts
+
+
+@fixture(scope='module')
+def s2si_dataframe_converted(request):
+    evs  = [    0,     0,     0,     0,     0,     3,     3]
+    peak = [    0,     0,     1,     1,     1,     0,     0]
+    sipm = [    1,     2,     3,     4,     5,     5,     6]
+    samp = [    0,     2,     0,     1,     2,     3,     4]
+    ene  = [123.4, 140.8, 730.0, 734.2, 732.7, 400.0, 420.3]
+    df = DF.from_dict(dict(
+        event   = Series(evs , dtype=np.int32),
+        evtDaq  = evs,
+        peak    = Series(peak, dtype=np.int8),
+        nsipm   = Series(sipm, dtype=np.int16),
+        nsample = Series(samp, dtype=np.int16),
+        ene     = Series(ene , dtype=np.float32),
+    ))
+    return df_to_s2si_dict(df), df
+
+
+def test_df_to_s2si_dict_one_entry_per_event(s2si_dataframe_converted):
+    converted, original = s2si_dataframe_converted
+    number_of_events_in_original = len(set(original.event))
+    assert len(converted) == number_of_events_in_original
+
+
+def test_df_to_s2si_dict_event_numbers_should_be_keys(s2si_dataframe_converted):
+    converted, original = s2si_dataframe_converted
+    event_numbers_in_original = set(original.event)
+    for event_number in event_numbers_in_original:
+        assert event_number in converted
+
+
+def test_df_to_s2si_dict_structure(s2si_dataframe_converted):
+    converted, _ = s2si_dataframe_converted
+    # Each event number is mapped to a subdict ...
+    for event_no, subdict in converted.items():
+        # in which peak numbers are mapped to a subdict ...
+        for peak_no, peak_data in subdict.items():
+            # in which SiPMs IDs are mapped to  a t, E pair
+            for sipm_no, sipm in peak_data.items():
+                assert type(sipm) is np.ndarray
+
+
+def test_df_to_s2si_dict_events_contain_peaks(s2si_dataframe_converted):
+    converted, _ = s2si_dataframe_converted
+    # Multiple peaks in one event ...
+    # In event no 0, there are two peaks; evt 3 has one peak
+    assert len(converted[0]) == 2
+    assert len(converted[3]) == 1
+
+
+def test_df_to_s2si_dict_events_data_correct(s2si_dataframe_converted):
+    converted, original = s2si_dataframe_converted
+
+    all_sipms = [ (sipm[0], sipm[1])
+                  for event in sorted(converted)
+                  for peak  in sorted(converted[event])
+                  for sipm  in sorted(converted[event][peak].items()) ]
+
+    converted_sipm = np.array      (list(map(itemgetter(0), all_sipms)))
+    converted_ene  = np.concatenate(list(map(itemgetter(1), all_sipms)))
+
+    assert (converted_sipm                            == original.nsipm).all()
+    assert (converted_ene[np.nonzero(converted_ene)]  == original.ene  ).all()


### PR DESCRIPTION
I have made a new cython function `df_to_namedtuples` to convert S2Si dataframes to python dictionaries. It has been implemented in the same fashion as `df_to_pmaps_dict`. The output contains the following structure:
- Dictionary with event numbers as keys and dictionaries as values.
- Inner dictionaries have peak numbers as keys and lists as values.
- The lists contain instances of the SiPM namedtuple defined in `reco/params.py`.
- The SiPM namedtuple contains three attributes:
  1. ID (int)
  2. sample (np.array)
  3. ene (np.array)

I have extended the test suite so this new function is tested against the same kind of problems as `df_to_pmaps_dict`.

Check [my fork](https://github.com/gonzaponte/IC/tree/S2Sidicts) for the implementation details.

To be discussed:
1. Do we like this structure? Another possibility is to have the dicts (evt) holding dicts (peak) holding dicts (sipms) with SiPMs numbers as keys and namedtuples (with just "sample" and "E" as attributes) as values. I rather use the latter, but IIRC, @jjgomezcadenas prefers the current implementation. Please comment on that.

2. Name of the function is probably not very good. Suggestions? What about df_to_s2si_dict?
