### PR TITLE
Csum add option

### DIFF
--- a/invisible_cities/reco/peak_functions.py
+++ b/invisible_cities/reco/peak_functions.py
@@ -21,7 +21,10 @@ from   invisible_cities.reco.params import (S12Params,
                                             CalibratedSum,
                                             PMaps)
 
-def calibrated_pmt_sum(CWF, adc_to_pes, n_MAU=200, thr_MAU=5):
+def calibrated_pmt_sum(CWF, adc_to_pes,
+                       active_pmt_index = [],
+                       n_MAU=200,
+                       thr_MAU=5):
     """Compute the ZS calibrated sum of the PMTs
     after correcting the baseline with a MAU to suppress low frequency noise.
     input:
@@ -47,7 +50,11 @@ def calibrated_pmt_sum(CWF, adc_to_pes, n_MAU=200, thr_MAU=5):
     MAU_pmt  = np.zeros(       NWF,  dtype=np.double)
 
     MAUL = []
-    for j in range(NPMT):
+    PMT = active_pmt_index
+    if len(PMT) == 0:
+        PMT = list(range(NPMT))
+
+    for j in PMT:
         # MAU for each of the PMTs, following the waveform
         MAU_pmt = signal.lfilter(MAU, 1, CWF[j,:])
         MAUL.append(MAU_pmt)

--- a/invisible_cities/reco/peak_functions_c.pxd
+++ b/invisible_cities/reco/peak_functions_c.pxd
@@ -17,9 +17,10 @@ n_MAU:  length of the MAU window
 thr_MAU: treshold above MAU to select sample
 """
 cpdef calibrated_pmt_sum(double [:, :] CWF,
-                         double [:] adc_to_pes,
-                         int n_MAU=*,
-                         double thr_MAU=*)
+                         double [:]    adc_to_pes,
+                         list          active_pmt_index = *,
+                         int           n_MAU = *,
+                         double        thr_MAU = *)
 
 
 """

--- a/invisible_cities/reco/peak_functions_c.pyx
+++ b/invisible_cities/reco/peak_functions_c.pyx
@@ -9,10 +9,10 @@ import  numpy as np
 from scipy import signal
 
 cpdef calibrated_pmt_sum(double [:, :] CWF,
-                         double [:] adc_to_pes,
-                         int    [:] active_pmt_index = [],
-                         int      n_MAU = 200,
-                         double thr_MAU =   5):
+                         double [:]    adc_to_pes,
+                         list          active_pmt_index = [],
+                         int           n_MAU = 200,
+                         double        thr_MAU =   5):
     """
     Computes the ZS calibrated sum of the PMTs
     after correcting the baseline with a MAU to suppress low frequency noise.

--- a/invisible_cities/reco/peak_functions_c.pyx
+++ b/invisible_cities/reco/peak_functions_c.pyx
@@ -10,6 +10,7 @@ from scipy import signal
 
 cpdef calibrated_pmt_sum(double [:, :] CWF,
                          double [:] adc_to_pes,
+                         int    [:] active_pmt_index = [],
                          int      n_MAU = 200,
                          double thr_MAU =   5):
     """
@@ -36,7 +37,11 @@ cpdef calibrated_pmt_sum(double [:, :] CWF,
     cdef double [:]    csum_mau = np.zeros(      NWF , dtype=np.double)
     cdef double [:]    MAU_pmt  = np.zeros(      NWF , dtype=np.double)
 
-    for j in range(NPMT):
+    cdef list PMT = active_pmt_index
+    if len(PMT) == 0:
+        PMT = list(range(NPMT))
+
+    for j in PMT:
         # MAU for each of the PMTs, following the waveform
         MAU_pmt = signal.lfilter(MAU, 1, CWF[j,:])
 

--- a/invisible_cities/reco/peak_functions_test.py
+++ b/invisible_cities/reco/peak_functions_test.py
@@ -21,12 +21,7 @@ from   invisible_cities.core.system_of_units_c import units
 
 @fixture(scope='module')
 def csum_zs_blr_cwf(electron_RWF_file):
-    """Test that:
-     1) the calibrated sum (csum) of the BLR and the CWF is the same
-    within tolerance.
-     2) csum and zeros-supressed sum (zs) are the same
-    within tolerance
-    """
+    """Return several sums needed for test."""
 
     with tb.open_file(electron_RWF_file, 'r') as h5rwf:
         pmtrwf, pmtblr, sipmrwf = tbl.get_vectors(h5rwf)
@@ -55,24 +50,47 @@ def csum_zs_blr_cwf(electron_RWF_file):
         wfzs_ene,    wfzs_indx    = cpf.wfzs(csum_blr,    threshold=0.5)
         wfzs_ene_py, wfzs_indx_py =  pf.wfzs(csum_blr_py, threshold=0.5)
 
+        # one can also pass the list of active PMTs by index (o to 11)
+        csum_cwf2, _ =       cpf.calibrated_pmt_sum(CWF,
+                                                    adc_to_pes,
+                                                    list(range(12)),
+                                                    n_MAU = 100,
+                                                    thr_MAU =   3)
+        csum_cwf2_py, _, _ =  pf.calibrated_pmt_sum(CWF,
+                                                    adc_to_pes,
+                                                    list(range(12)),
+                                                    n_MAU = 100,
+                                                    thr_MAU =   3)
+
         from collections import namedtuple
 
         return (namedtuple('Csum',
                         """csum_cwf csum_blr csum_blr_py
                            wfzs_ene wfzs_ene_py
-                           wfzs_indx wfzs_indx_py""")
-        (csum_cwf     = csum_cwf,
-         csum_blr     = csum_blr,
-         wfzs_ene     = wfzs_ene,
-         csum_blr_py  = csum_blr_py,
-         wfzs_ene_py  = wfzs_ene_py,
-         wfzs_indx    = wfzs_indx,
-         wfzs_indx_py = wfzs_indx_py))
+                           wfzs_indx wfzs_indx_py
+                           csum_cwf2 csum_cwf2_py""")
+        (csum_cwf      = csum_cwf,
+         csum_cwf2     = csum_cwf2,
+         csum_cwf2_py  = csum_cwf2_py,
+         csum_blr      = csum_blr,
+         wfzs_ene      = wfzs_ene,
+         csum_blr_py   = csum_blr_py,
+         wfzs_ene_py   = wfzs_ene_py,
+         wfzs_indx     = wfzs_indx,
+         wfzs_indx_py  = wfzs_indx_py))
 
 
 def test_csum_cwf_close_to_csum_blr(csum_zs_blr_cwf):
     p = csum_zs_blr_cwf
     assert np.isclose(np.sum(p.csum_cwf), np.sum(p.csum_blr), rtol=0.01)
+
+def test_csum_cwf_close_to_csum_cwf_py_index_case(csum_zs_blr_cwf):
+    p = csum_zs_blr_cwf
+    assert np.isclose(np.sum(p.csum_cwf2), np.sum(p.csum_cwf2_py), rtol=0.01)
+
+def test_csum_cwf_close_to_csum_cwf_index_case(csum_zs_blr_cwf):
+    p = csum_zs_blr_cwf
+    assert np.isclose(np.sum(p.csum_cwf2), np.sum(p.csum_cwf), rtol=0.01)
 
 def test_csum_cwf_close_to_wfzs_ene(csum_zs_blr_cwf):
     p = csum_zs_blr_cwf

--- a/invisible_cities/reco/pmap_io.py
+++ b/invisible_cities/reco/pmap_io.py
@@ -1,6 +1,6 @@
 import tables as tb
 
-from   invisible_cities.reco.nh5 import S12, S2Si
+import invisible_cities.reco.nh5 as table_formats
 import invisible_cities.reco.tbl_functions as tbl
 
 
@@ -11,9 +11,9 @@ class pmap_writer:
         self._tables = _make_tables(self._hdf5_file, compression)
 
     def __call__(self, event_number, s1, s2, s2si):
-        _store_s12 (s1,   self._tables[0], event_number)
-        _store_s12 (s2,   self._tables[1], event_number)
-        _store_s2si(s2si, self._tables[2], event_number)
+        s1  .store(self._tables[0], event_number)
+        s2  .store(self._tables[1], event_number)
+        s2si.store(self._tables[2], event_number)
 
     def close(self):
         self._hdf5_file.close()
@@ -31,9 +31,9 @@ def _make_tables(hdf5_file, compression):
 
     pmaps_group = hdf5_file.create_group(hdf5_file.root, 'PMAPS')
 
-    s1   = hdf5_file.create_table(pmaps_group, 'S1'  , S12 ,   "S1 Table", c)
-    s2   = hdf5_file.create_table(pmaps_group, 'S2'  , S12 ,   "S2 Table", c)
-    s2si = hdf5_file.create_table(pmaps_group, 'S2Si', S2Si, "S2Si Table", c)
+    s1   = hdf5_file.create_table(pmaps_group, 'S1'  , S12 .table_format,   "S1 Table", c)
+    s2   = hdf5_file.create_table(pmaps_group, 'S2'  , S12 .table_format,   "S2 Table", c)
+    s2si = hdf5_file.create_table(pmaps_group, 'S2Si', S2Si.table_format, "S2Si Table", c)
 
     all_tables = (s1, s2, s2si)
 
@@ -43,26 +43,52 @@ def _make_tables(hdf5_file, compression):
     return all_tables
 
 
-def _store_s12(event, table, event_number):
-    row = table.row
-    for peak_number, (ts, Es) in event.items():
-        assert len(ts) == len(Es)
-        for t, E in zip(ts, Es):
-            row["event"] = event_number
-            row["peak"]  =  peak_number
-            row["time"]  = t
-            row["ene"]   = E
-            row.append()
+# I think that an event is made up of a collection of S1s, S2s. The 
 
+# I think that this is something like the (integrated) set of data
+# recorded by the PMTs in single event ... with two instances per
+# event: one for the S1s, one for the S2s
+class S12: # Need a better name
 
-def _store_s2si(event, table, event_number):
-    row = table.row
-    for peak_number, sipms in event.items():
-        for nsipm, Es in sipms:
-            for nsample, E in enumerate(Es):
-                row["event"]   = event_number
-                row["peak"]    =  peak_number
-                row["nsipm"]   = nsipm
-                row["nsample"] = nsample
-                row["ene"]     = E
+    def __init__(self, data):
+        # Temporary solution, can do better
+        self._data = data
+
+    # Other S12 utilities go here, for example statistical functions
+
+    table_format = table_formats.S12
+
+    def store(self, table, event_number):
+        row = table.row
+        for peak_number, (ts, Es) in self._data.items():
+            assert len(ts) == len(Es)
+            for t, E in zip(ts, Es):
+                row["event"] = event_number
+                row["peak"]  =  peak_number
+                row["time"]  = t
+                row["ene"]   = E
                 row.append()
+
+# I think that tis is something like the set of data recorded by the
+# SiPMs during a single event ... only used for S2s
+class S2Si: # Need a better name
+
+    def __init__(self, data):
+        # Temporary solution, can do better
+        self._data = data
+
+    # Other S2si utilities go here, for example statistical functions
+
+    table_format = table_formats.S2Si
+
+    def store(self, table, event_number):
+        row = table.row
+        for peak_number, sipms in self._data.items():
+            for nsipm, Es in sipms:
+                for nsample, E in enumerate(Es):
+                    row["event"]   = event_number
+                    row["peak"]    =  peak_number
+                    row["nsipm"]   = nsipm
+                    row["nsample"] = nsample
+                    row["ene"]     = E
+                    row.append()

--- a/invisible_cities/reco/pmap_io.py
+++ b/invisible_cities/reco/pmap_io.py
@@ -1,0 +1,81 @@
+from   invisible_cities.reco.nh5 import S12, S2Si
+import invisible_cities.reco.tbl_functions as tbl
+
+class PMapWriter:
+    """Write PMAPS to file. """
+    def __init__(self,
+                 pmap_file       = None,
+                 compression     = 'ZLIB4'):
+
+        if not pmap_file:
+            raise NoOutputFile('pmap file cannot be Null')
+
+        self.pmap_file   =  pmap_file
+        self.compression =  compression
+
+        self._set_pmap_tables()
+
+    def _set_pmap_tables(self):
+        """Set the output file."""
+
+        # create a group
+        pmapsgroup = self.pmap_file.create_group(
+            pmap_file.root, "PMAPS")
+
+        # create tables to store pmaps
+        self.s1t  = self.pmap_file.create_table(
+            pmapsgroup, "S1", S12, "S1 Table",
+            tbl.filters(self.compression))
+
+        self.s2t  = self.pmap_file.create_table(
+            pmapsgroup, "S2", S12, "S2 Table",
+            tbl.filters(self.compression))
+
+        self.s2sit = self.pmap_file.create_table(
+            pmapsgroup, "S2Si", S2Si, "S2Si Table",
+            tbl.filters(self.compression))
+
+        self.s1t  .cols.event.create_index()
+        self.s2t  .cols.event.create_index()
+        self.s2sit.cols.event.create_index()
+
+    def _store_s12(self, S12, st, event):
+        row = st.row
+        for i in S12:
+            time = S12[i][0]
+            ene  = S12[i][1]
+            assert len(time) == len(ene)
+            for j in range(len(time)):
+                row["event"] = event
+                row["peak"] = i
+                row["time"] = time[j]
+                row["ene"]  =  ene[j]
+                row.append()
+
+    def _store_s2si(self, S2Si, st, event):
+        row = st.row
+        for i in S2Si:
+            sipml = S2Si[i]
+            for sipm in sipml:
+                nsipm = sipm[0]
+                ene   = sipm[1]
+                for j, E in enumerate(ene):
+                    row["event"] = event
+                    row["peak"]    = i
+                    row["nsipm"]   = nsipm
+                    row["nsample"] = j
+                    row["ene"]     = E
+                    row.append()
+
+    def store_pmaps(self, event, S1, S2, S2Si):
+        """Store PMAPS."""
+
+        self._store_s12 (S1, self.s1t,  event)
+        self._store_s12 (S2, self.s2t,  event)
+        self._store_s2si(S2Si, self.s2sit, event)
+
+    def flush(self):
+        """Flush all tables"""
+        self.s1t.flush()
+        self.s2t.flush()
+        self.s2sit.flush()

--- a/invisible_cities/reco/pmap_io.py
+++ b/invisible_cities/reco/pmap_io.py
@@ -10,7 +10,7 @@ import invisible_cities.reco.tbl_functions as tbl
 def pmap_writer(filename, compression = 'ZLIB4'):
     with tb.open_file(filename, 'w') as hdf5_file:
         tables = _make_tables(hdf5_file, compression)
-        yield _writer(tables)
+        yield _WRITER(tables)
 
 
 def _make_tables(hdf5_file, compression):
@@ -63,3 +63,16 @@ def _store_s2si(event, table, event_number):
                 row["nsample"] = nsample
                 row["ene"]     = E
                 row.append()
+
+
+
+
+class _WRITER:
+
+    def __init__(self, tables):
+        self._tables = tables
+
+    def __call__(self, event_number, s1, s2, s2si):
+        _store_s12 (s1,   self._tables[0], event_number)
+        _store_s12 (s1,   self._tables[1], event_number)
+        _store_s2si(s2si, self._tables[2], event_number)

--- a/invisible_cities/reco/pmap_io.py
+++ b/invisible_cities/reco/pmap_io.py
@@ -20,7 +20,7 @@ class PMapWriter:
 
         # create a group
         pmapsgroup = self.pmap_file.create_group(
-            pmap_file.root, "PMAPS")
+            self.pmap_file.root, "PMAPS")
 
         # create tables to store pmaps
         self.s1t  = self.pmap_file.create_table(

--- a/invisible_cities/reco/pmap_io.py
+++ b/invisible_cities/reco/pmap_io.py
@@ -4,14 +4,14 @@ import invisible_cities.reco.tbl_functions as tbl
 class PMapWriter:
     """Write PMAPS to file. """
     def __init__(self,
-                 pmap_file       = None,
-                 compression     = 'ZLIB4'):
+                 pmap_file   = None,
+                 compression = 'ZLIB4'):
 
         if not pmap_file:
             raise NoOutputFile('pmap file cannot be Null')
 
-        self.pmap_file   =  pmap_file
-        self.compression =  compression
+        self.pmap_file   = pmap_file
+        self.compression = compression
 
         self._set_pmap_tables()
 
@@ -60,7 +60,7 @@ class PMapWriter:
                 nsipm = sipm[0]
                 ene   = sipm[1]
                 for j, E in enumerate(ene):
-                    row["event"] = event
+                    row["event"]   = event
                     row["peak"]    = i
                     row["nsipm"]   = nsipm
                     row["nsample"] = j
@@ -70,12 +70,12 @@ class PMapWriter:
     def store_pmaps(self, event, S1, S2, S2Si):
         """Store PMAPS."""
 
-        self._store_s12 (S1, self.s1t,  event)
-        self._store_s12 (S2, self.s2t,  event)
+        self._store_s12 (S1,   self.s1t,   event)
+        self._store_s12 (S2,   self.s2t,   event)
         self._store_s2si(S2Si, self.s2sit, event)
 
     def flush(self):
         """Flush all tables"""
-        self.s1t.flush()
-        self.s2t.flush()
+        self.s1t  .flush()
+        self.s2t  .flush()
         self.s2sit.flush()

--- a/invisible_cities/reco/pmap_io.py
+++ b/invisible_cities/reco/pmap_io.py
@@ -1,81 +1,65 @@
+from contextlib import contextmanager
+
+import tables as tb
+
 from   invisible_cities.reco.nh5 import S12, S2Si
 import invisible_cities.reco.tbl_functions as tbl
 
-class PMapWriter:
-    """Write PMAPS to file. """
-    def __init__(self,
-                 pmap_file   = None,
-                 compression = 'ZLIB4'):
 
-        if not pmap_file:
-            raise NoOutputFile('pmap file cannot be Null')
+@contextmanager
+def pmap_writer(filename, compression = 'ZLIB4'):
+    with tb.open_file(filename, 'w') as hdf5_file:
+        tables = _make_tables(hdf5_file, compression)
+        yield _writer(tables)
 
-        self.pmap_file   = pmap_file
-        self.compression = compression
 
-        self._set_pmap_tables()
+def _make_tables(hdf5_file, compression):
 
-    def _set_pmap_tables(self):
-        """Set the output file."""
+    c = tbl.filters(compression)
 
-        # create a group
-        pmapsgroup = self.pmap_file.create_group(
-            self.pmap_file.root, "PMAPS")
+    pmaps_group = hdf5_file.create_group(hdf5_file.root, 'PMAPS')
 
-        # create tables to store pmaps
-        self.s1t  = self.pmap_file.create_table(
-            pmapsgroup, "S1", S12, "S1 Table",
-            tbl.filters(self.compression))
+    s1   = hdf5_file.create_table(pmaps_group, 'S1'  , S12 ,   "S1 Table", c)
+    s2   = hdf5_file.create_table(pmaps_group, 'S2'  , S12 ,   "S2 Table", c)
+    s2si = hdf5_file.create_table(pmaps_group, 'S2Si', S2Si, "S2Si Table", c)
 
-        self.s2t  = self.pmap_file.create_table(
-            pmapsgroup, "S2", S12, "S2 Table",
-            tbl.filters(self.compression))
+    all_tables = (s1, s2, s2si)
 
-        self.s2sit = self.pmap_file.create_table(
-            pmapsgroup, "S2Si", S2Si, "S2Si Table",
-            tbl.filters(self.compression))
+    for table in all_tables:
+        table.cols.event.create_index()
 
-        self.s1t  .cols.event.create_index()
-        self.s2t  .cols.event.create_index()
-        self.s2sit.cols.event.create_index()
+    return all_tables
 
-    def _store_s12(self, S12, st, event):
-        row = st.row
-        for i in S12:
-            time = S12[i][0]
-            ene  = S12[i][1]
-            assert len(time) == len(ene)
-            for j in range(len(time)):
-                row["event"] = event
-                row["peak"] = i
-                row["time"] = time[j]
-                row["ene"]  =  ene[j]
+
+def _writer(tables):
+    s1_table, s2_table, s2si_table = tables
+    def write(event_number, s1, s2, s2si):
+        _store_s12 (s1,     s1_table, event_number)
+        _store_s12 (s2,     s2_table, event_number)
+        _store_s2si(s2si, s2si_table, event_number)
+    return write
+
+
+def _store_s12(event, table, event_number):
+    row = table.row
+    for peak_number, (ts, Es) in event.items():
+        assert len(ts) == len(Es)
+        for t, E in zip(ts, Es):
+            row["event"] = event_number
+            row["peak"]  =  peak_number
+            row["time"]  = t
+            row["ene"]   = E
+            row.append()
+
+
+def _store_s2si(event, table, event_number):
+    row = table.row
+    for peak_number, sipms in event.items():
+        for nsipm, Es in sipms:
+            for nsample, E in enumerate(Es):
+                row["event"]   = event_number
+                row["peak"]    =  peak_number
+                row["nsipm"]   = nsipm
+                row["nsample"] = nsample
+                row["ene"]     = E
                 row.append()
-
-    def _store_s2si(self, S2Si, st, event):
-        row = st.row
-        for i in S2Si:
-            sipml = S2Si[i]
-            for sipm in sipml:
-                nsipm = sipm[0]
-                ene   = sipm[1]
-                for j, E in enumerate(ene):
-                    row["event"]   = event
-                    row["peak"]    = i
-                    row["nsipm"]   = nsipm
-                    row["nsample"] = j
-                    row["ene"]     = E
-                    row.append()
-
-    def store_pmaps(self, event, S1, S2, S2Si):
-        """Store PMAPS."""
-
-        self._store_s12 (S1,   self.s1t,   event)
-        self._store_s12 (S2,   self.s2t,   event)
-        self._store_s2si(S2Si, self.s2sit, event)
-
-    def flush(self):
-        """Flush all tables"""
-        self.s1t  .flush()
-        self.s2t  .flush()
-        self.s2sit.flush()

--- a/invisible_cities/reco/pmap_io.py
+++ b/invisible_cities/reco/pmap_io.py
@@ -43,24 +43,13 @@ def _make_tables(hdf5_file, compression):
     return all_tables
 
 
-# I think that an event is made up of a collection of S1s, S2s. The 
-
-# I think that this is something like the (integrated) set of data
-# recorded by the PMTs in single event ... with two instances per
-# event: one for the S1s, one for the S2s
-class S12: # Need a better name
-
-    def __init__(self, data):
-        # Temporary solution, can do better
-        self._data = data
-
-    # Other S12 utilities go here, for example statistical functions
+class S12(dict):
 
     table_format = table_formats.S12
 
     def store(self, table, event_number):
         row = table.row
-        for peak_number, (ts, Es) in self._data.items():
+        for peak_number, (ts, Es) in self.items():
             assert len(ts) == len(Es)
             for t, E in zip(ts, Es):
                 row["event"] = event_number
@@ -69,21 +58,13 @@ class S12: # Need a better name
                 row["ene"]   = E
                 row.append()
 
-# I think that tis is something like the set of data recorded by the
-# SiPMs during a single event ... only used for S2s
-class S2Si: # Need a better name
-
-    def __init__(self, data):
-        # Temporary solution, can do better
-        self._data = data
-
-    # Other S2si utilities go here, for example statistical functions
+class S2Si(dict):
 
     table_format = table_formats.S2Si
 
     def store(self, table, event_number):
         row = table.row
-        for peak_number, sipms in self._data.items():
+        for peak_number, sipms in self.items():
             for nsipm, Es in sipms:
                 for nsample, E in enumerate(Es):
                     row["event"]   = event_number

--- a/invisible_cities/reco/pmap_io_test.py
+++ b/invisible_cities/reco/pmap_io_test.py
@@ -1,0 +1,40 @@
+"""
+code: pmap_io_test.py
+"""
+import os
+import tables as tb
+import numpy  as np
+from pytest import mark, fixture
+
+from   invisible_cities.reco.pmap_io import PMapWriter
+from invisible_cities.core.system_of_units_c import units
+from invisible_cities.core.core_functions import trange
+from invisible_cities.reco.pmaps_functions import read_pmaps
+
+
+@mark.slow
+def test_pmap_writer_mc(config_tmpdir):
+    # Check that PMAPS tables are written correctly
+
+    PMP_file = os.path.join(str(config_tmpdir),
+              'test_pmaps_mc.h5')
+
+    run_number = 0
+    S1 = {0:(np.array(trange(5), dtype=np.float),
+             np.array(trange(5), dtype=np.float))}
+    S2 = S1
+    S2Si = {0:[(1, np.array(trange(5), dtype=np.float)),
+               (2, np.array(trange(5), dtype=np.float)),
+               (3, np.array(trange(5), dtype=np.float))]}
+
+    with tb.open_file(PMP_file, "w") as pmap_file:
+        pmw = PMapWriter(pmap_file)
+        pmw.store_pmaps(0, S1, S2, S2Si)
+        pmw.flush()
+
+    s1df, s2df, s2sidf = read_pmaps(PMP_file)
+    np.testing.assert_array_equal(s1df.time.values, S1[0][0])
+    np.testing.assert_array_equal(s2df.time.values, S2[0][0])
+    dim = len(S2Si[0][0][1])
+    assert len(s2sidf) == len(S2Si[0]) * dim
+    np.testing.assert_array_equal(s2sidf.ene.values[0:dim], S2Si[0][0][1])

--- a/invisible_cities/reco/pmap_io_test.py
+++ b/invisible_cities/reco/pmap_io_test.py
@@ -4,20 +4,17 @@ code: pmap_io_test.py
 import os
 import tables as tb
 import numpy  as np
-from pytest import mark, fixture
 
-from   invisible_cities.reco.pmap_io import PMapWriter
+from invisible_cities.reco.pmap_io           import PMapWriter
 from invisible_cities.core.system_of_units_c import units
-from invisible_cities.core.core_functions import trange
-from invisible_cities.reco.pmaps_functions import read_pmaps
+from invisible_cities.core.core_functions    import trange
+from invisible_cities.reco.pmaps_functions   import read_pmaps
 
 
-@mark.slow
 def test_pmap_writer_mc(config_tmpdir):
     # Check that PMAPS tables are written correctly
 
-    PMP_file = os.path.join(str(config_tmpdir),
-              'test_pmaps_mc.h5')
+    PMP_file_name = os.path.join(str(config_tmpdir), 'test_pmaps_mc.h5')
 
     run_number = 0
     S1 = {0:(np.array(trange(5), dtype=np.float),
@@ -27,12 +24,12 @@ def test_pmap_writer_mc(config_tmpdir):
                (2, np.array(trange(5), dtype=np.float)),
                (3, np.array(trange(5), dtype=np.float))]}
 
-    with tb.open_file(PMP_file, "w") as pmap_file:
+    with tb.open_file(PMP_file_name, "w") as pmap_file:
         pmw = PMapWriter(pmap_file)
         pmw.store_pmaps(0, S1, S2, S2Si)
         pmw.flush()
 
-    s1df, s2df, s2sidf = read_pmaps(PMP_file)
+    s1df, s2df, s2sidf = read_pmaps(PMP_file_name)
     np.testing.assert_array_equal(s1df.time.values, S1[0][0])
     np.testing.assert_array_equal(s2df.time.values, S2[0][0])
     dim = len(S2Si[0][0][1])

--- a/invisible_cities/reco/pmap_io_test.py
+++ b/invisible_cities/reco/pmap_io_test.py
@@ -23,8 +23,14 @@ def test_pmap_writer_mc(config_tmpdir):
                (2, np.random.rand(5)),
                (3, np.random.rand(5))]}
 
+    # Automatic closing example
     with pmap_writer(PMP_file_name) as write:
         write(0, S1, S2, S2Si)
+
+    # Manual closing example
+    write = pmap_writer(PMP_file_name)
+    write(0, S1, S2, S2Si)
+    write.close()
 
     s1df, s2df, s2sidf = read_pmaps(PMP_file_name)
     np.testing.assert_allclose(s1df.time.values, S1[0][0])

--- a/invisible_cities/reco/pmap_io_test.py
+++ b/invisible_cities/reco/pmap_io_test.py
@@ -5,7 +5,7 @@ import os
 import tables as tb
 import numpy  as np
 
-from invisible_cities.reco.pmap_io           import pmap_writer
+from invisible_cities.reco.pmap_io           import pmap_writer, S12, S2Si
 from invisible_cities.core.system_of_units_c import units
 from invisible_cities.reco.pmaps_functions   import read_pmaps
 
@@ -16,25 +16,26 @@ def test_pmap_writer_mc(config_tmpdir):
     PMP_file_name = os.path.join(str(config_tmpdir), 'test_pmaps_mc.h5')
 
     run_number = 0
-    S1 = {0:(np.random.rand(5),
-             np.random.rand(5))}
-    S2 = S1
-    S2Si = {0:[(1, np.random.rand(5)),
-               (2, np.random.rand(5)),
-               (3, np.random.rand(5))]}
+    S1 = S12({0:(np.random.rand(5),
+                 np.random.rand(5))})
+    S2 = S12({0:(np.random.rand(5),
+                 np.random.rand(5))})
+    Si = S2Si({0:[(1, np.random.rand(5)),
+                  (2, np.random.rand(5)),
+                  (3, np.random.rand(5))]})
 
     # Automatic closing example
     with pmap_writer(PMP_file_name) as write:
-        write(0, S1, S2, S2Si)
+        write(0, S1, S2, Si)
 
     # Manual closing example
     write = pmap_writer(PMP_file_name)
-    write(0, S1, S2, S2Si)
+    write(0, S1, S2, Si)
     write.close()
 
     s1df, s2df, s2sidf = read_pmaps(PMP_file_name)
-    np.testing.assert_allclose(s1df.time.values, S1[0][0])
-    np.testing.assert_allclose(s2df.time.values, S2[0][0])
-    dim = len(S2Si[0][0][1])
-    assert len(s2sidf) == len(S2Si[0]) * dim
-    np.testing.assert_allclose(s2sidf.ene.values[0:dim], S2Si[0][0][1])
+    np.testing.assert_allclose(s1df.time.values, S1._data[0][0])
+    np.testing.assert_allclose(s2df.time.values, S2._data[0][0])
+    dim = len(Si._data[0][0][1])
+    assert len(s2sidf) == len(Si._data[0]) * dim
+    np.testing.assert_allclose(s2sidf.ene.values[0:dim], Si._data[0][0][1])

--- a/invisible_cities/reco/pmap_io_test.py
+++ b/invisible_cities/reco/pmap_io_test.py
@@ -34,8 +34,8 @@ def test_pmap_writer_mc(config_tmpdir):
     write.close()
 
     s1df, s2df, s2sidf = read_pmaps(PMP_file_name)
-    np.testing.assert_allclose(s1df.time.values, S1._data[0][0])
-    np.testing.assert_allclose(s2df.time.values, S2._data[0][0])
-    dim = len(Si._data[0][0][1])
-    assert len(s2sidf) == len(Si._data[0]) * dim
-    np.testing.assert_allclose(s2sidf.ene.values[0:dim], Si._data[0][0][1])
+    np.testing.assert_allclose(s1df.time.values, S1[0][0])
+    np.testing.assert_allclose(s2df.time.values, S2[0][0])
+    dim = len(Si[0][0][1])
+    assert len(s2sidf) == len(Si[0]) * dim
+    np.testing.assert_allclose(s2sidf.ene.values[0:dim], Si[0][0][1])

--- a/invisible_cities/reco/pmap_io_test.py
+++ b/invisible_cities/reco/pmap_io_test.py
@@ -7,7 +7,6 @@ import numpy  as np
 
 from invisible_cities.reco.pmap_io           import PMapWriter
 from invisible_cities.core.system_of_units_c import units
-from invisible_cities.core.core_functions    import trange
 from invisible_cities.reco.pmaps_functions   import read_pmaps
 
 
@@ -17,21 +16,20 @@ def test_pmap_writer_mc(config_tmpdir):
     PMP_file_name = os.path.join(str(config_tmpdir), 'test_pmaps_mc.h5')
 
     run_number = 0
-    S1 = {0:(np.array(trange(5), dtype=np.float),
-             np.array(trange(5), dtype=np.float))}
+    S1 = {0:(np.random.rand(5),
+             np.random.rand(5))}
     S2 = S1
-    S2Si = {0:[(1, np.array(trange(5), dtype=np.float)),
-               (2, np.array(trange(5), dtype=np.float)),
-               (3, np.array(trange(5), dtype=np.float))]}
+    S2Si = {0:[(1, np.random.rand(5)),
+               (2, np.random.rand(5)),
+               (3, np.random.rand(5))]}
 
     with tb.open_file(PMP_file_name, "w") as pmap_file:
         pmw = PMapWriter(pmap_file)
         pmw.store_pmaps(0, S1, S2, S2Si)
-        pmw.flush()
 
     s1df, s2df, s2sidf = read_pmaps(PMP_file_name)
-    np.testing.assert_array_equal(s1df.time.values, S1[0][0])
-    np.testing.assert_array_equal(s2df.time.values, S2[0][0])
+    np.testing.assert_allclose(s1df.time.values, S1[0][0])
+    np.testing.assert_allclose(s2df.time.values, S2[0][0])
     dim = len(S2Si[0][0][1])
     assert len(s2sidf) == len(S2Si[0]) * dim
-    np.testing.assert_array_equal(s2sidf.ene.values[0:dim], S2Si[0][0][1])
+    np.testing.assert_allclose(s2sidf.ene.values[0:dim], S2Si[0][0][1])

--- a/invisible_cities/reco/pmap_io_test.py
+++ b/invisible_cities/reco/pmap_io_test.py
@@ -5,7 +5,7 @@ import os
 import tables as tb
 import numpy  as np
 
-from invisible_cities.reco.pmap_io           import PMapWriter
+from invisible_cities.reco.pmap_io           import pmap_writer
 from invisible_cities.core.system_of_units_c import units
 from invisible_cities.reco.pmaps_functions   import read_pmaps
 
@@ -23,9 +23,8 @@ def test_pmap_writer_mc(config_tmpdir):
                (2, np.random.rand(5)),
                (3, np.random.rand(5))]}
 
-    with tb.open_file(PMP_file_name, "w") as pmap_file:
-        pmw = PMapWriter(pmap_file)
-        pmw.store_pmaps(0, S1, S2, S2Si)
+    with pmap_writer(PMP_file_name) as write:
+        write(0, S1, S2, S2Si)
 
     s1df, s2df, s2sidf = read_pmaps(PMP_file_name)
     np.testing.assert_allclose(s1df.time.values, S1[0][0])


### PR DESCRIPTION
Add option to calibrated_pmt_sum

Current version of calibrated_pmt_sum assumes that all the PMTs in the
energy plane are active. This is not necessarily true. This PR
modifies the function to allow passing  a list of active_pmt_index. Such list
specifies the indexes of active PMTs (PMT indexes run from 0 to 11). If the list is specified (e.g, not empty), only the active PMTs are considered for the sum. 
if the list is empty all 12 PMTs are considered for the sum, as before.

Tests have been expanded/updated to demonstrate the new functionality