### PR TITLE
Add ICDIR fixture

### DIFF
--- a/invisible_cities/cities/diomira_test.py
+++ b/invisible_cities/cities/diomira_test.py
@@ -31,9 +31,9 @@ def conf_file_name(config_tmpdir):
     return conf_file_name
 
 
-def test_diomira_fee_table():
+def test_diomira_fee_table(ICDIR):
     """Test that FEE table reads back correctly with expected values."""
-    RWF_file = os.path.join(os.environ['ICDIR'],
+    RWF_file = os.path.join(ICDIR,
                             'database/test_data/electrons_40keV_z250_RWF.h5')
 
     with tb.open_file(RWF_file, 'r') as e40rwf:
@@ -93,7 +93,7 @@ def test_diomira_cwf_blr(electron_RWF_file):
 
 
 @mark.slow
-def test_diomira_sipm(irene_diomira_chain_tmpdir):
+def test_diomira_sipm(irene_diomira_chain_tmpdir, ICDIR):
     """This test checks that the number of SiPms surviving a hard energy
         cut (50 pes) is always small (<10). The test exercises the full
        construction of the SiPM vectors as well as the noise suppression.
@@ -104,7 +104,7 @@ def test_diomira_sipm(irene_diomira_chain_tmpdir):
     sipm_noise_cut = 20 # in pes. Should kill essentially all background
 
     max_sipm_with_signal = 10
-    infile = os.path.join(os.environ['ICDIR'],
+    infile = os.path.join(ICDIR,
                           'database/test_data/electrons_40keV_z250_MCRD.h5')
     with tb.open_file(infile, 'r') as e40rd:
 
@@ -138,7 +138,7 @@ def test_diomira_sipm(irene_diomira_chain_tmpdir):
             assert n_sipm < max_sipm_with_signal
 
 
-def test_diomira_identify_bug():
+def test_diomira_identify_bug(ICDIR):
     """Read a one-event file in which the energy of PMTs is equal to zero and
     asset it must be son. This test would fail for a normal file where there
     is always some energy in the PMTs. It's purpose is to provide an automaic
@@ -151,7 +151,7 @@ def test_diomira_identify_bug():
     The same event is later processed with Irene (where a protection
     that skips empty events has been added) to ensure that no crash occur."""
 
-    infile = os.path.join(os.environ['ICDIR'],
+    infile = os.path.join(ICDIR,
                           'database/test_data/irene_bug_Kr_ACTIVE_7bar_MCRD.h5')
     with tb.open_file(infile, 'r') as h5in:
 

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -42,12 +42,12 @@ def conf_file_name_data(config_tmpdir):
 
 
 @mark.slow
-def test_command_line_irene_electrons_40keV(conf_file_name_mc, config_tmpdir):
+def test_command_line_irene_electrons_40keV(conf_file_name_mc, config_tmpdir, ICDIR):
     # NB: avoid taking defaults for PATH_IN and PATH_OUT
     # since they are in general test-specific
     # NB: avoid taking defaults for run number (test-specific)
 
-    PATH_IN = os.path.join(os.environ['ICDIR'],
+    PATH_IN = os.path.join(ICDIR,
               'database/test_data/',
               'electrons_40keV_z250_RWF.h5')
     PATH_OUT = os.path.join(str(config_tmpdir),
@@ -62,8 +62,8 @@ def test_command_line_irene_electrons_40keV(conf_file_name_mc, config_tmpdir):
         assert nrequired == nactual
 
 @mark.slow
-def test_command_line_irene_run_2983(conf_file_name_data, config_tmpdir):
-    PATH_IN = os.path.join(os.environ['ICDIR'],
+def test_command_line_irene_run_2983(conf_file_name_data, config_tmpdir, ICDIR):
+    PATH_IN = os.path.join(ICDIR,
               'database/test_data/',
               'run_2983.h5')
     PATH_OUT = os.path.join(str(config_tmpdir),
@@ -78,9 +78,9 @@ def test_command_line_irene_run_2983(conf_file_name_data, config_tmpdir):
         assert nrequired == nactual
 
 @mark.serial
-def test_command_line_irene_runinfo_run_2983(config_tmpdir):
+def test_command_line_irene_runinfo_run_2983(config_tmpdir, ICDIR):
     # Check events numbers & timestamp are copied properly
-    PATH_IN = os.path.join(os.environ['ICDIR'],
+    PATH_IN = os.path.join(ICDIR,
               'database/test_data/',
               'run_2983.h5')
     PATH_OUT = os.path.join(str(config_tmpdir),
@@ -96,9 +96,9 @@ def test_command_line_irene_runinfo_run_2983(config_tmpdir):
             assert h5in .root.Run.runInfo[0] == h5out.root.Run.runInfo[0]
 
 
-def test_empty_events_issue_81(conf_file_name_mc, config_tmpdir):
+def test_empty_events_issue_81(conf_file_name_mc, config_tmpdir, ICDIR):
     # NB: explicit PATH_OUT
-    PATH_IN = os.path.join(os.environ['ICDIR'],
+    PATH_IN = os.path.join(ICDIR,
            'database/test_data/',
            'irene_bug_Kr_ACTIVE_7bar_RWF.h5')
     PATH_OUT = os.path.join(str(config_tmpdir),
@@ -113,9 +113,9 @@ def test_empty_events_issue_81(conf_file_name_mc, config_tmpdir):
     assert empty == 1
 
 @mark.slow
-def test_pmaps_store_issue_151(config_tmpdir):
+def test_pmaps_store_issue_151(config_tmpdir, ICDIR):
     # Check that PMAPS tables are written correctly
-    PATH_IN = os.path.join(os.environ['ICDIR'],
+    PATH_IN = os.path.join(ICDIR,
               'database/test_data/',
               'run_2983.h5')
     PATH_OUT = os.path.join(str(config_tmpdir),

--- a/invisible_cities/conftest.py
+++ b/invisible_cities/conftest.py
@@ -2,6 +2,10 @@ import pytest
 import os
 
 @pytest.fixture(scope = 'session')
+def ICDIR():
+    return os.environ['ICDIR']
+
+@pytest.fixture(scope = 'session')
 def irene_diomira_chain_tmpdir(tmpdir_factory):
     return tmpdir_factory.mktemp('irene_diomira_tests')
 
@@ -14,7 +18,7 @@ def config_tmpdir(tmpdir_factory):
                           'electrons_511keV_z250_RWF.h5',
                           'electrons_1250keV_z250_RWF.h5',
                           'electrons_2500keV_z250_RWF.h5'])
-def electron_RWF_file(request):
-    return os.path.join(os.environ['ICDIR'],
+def electron_RWF_file(request, ICDIR):
+    return os.path.join(ICDIR,
                         'database/test_data',
                         request.param)


### PR DESCRIPTION
`os.environ['ICDIR']` appeared lots of times in lots of tests. It's a
pain to write. So provide an `ICDIR` fixture to ease the pain.