### PR TITLE
Peak functions

### DIFF
--- a/invisible_cities/core/mpl_functions.py
+++ b/invisible_cities/core/mpl_functions.py
@@ -66,7 +66,8 @@ def plot_signal_vs_time_mus(signal,
                             t_min      =    0,
                             t_max      = 1200,
                             signal_min =    0,
-                            signal_max =  200):
+                            signal_max =  200,
+                            label=''):
     """Plot signal versus time in mus (tmin, tmax in mus). """
     tstep = 25 # in ns
     PMTWL = signal.shape[0]
@@ -76,10 +77,14 @@ def plot_signal_vs_time_mus(signal,
     ax1.set_ylim([signal_min, signal_max])
     set_plot_labels(xlabel = "t (mus)",
                     ylabel = "signal (pes/adc)")
-    plt.plot(signal_t, signal)
+    plt.plot(signal_t, signal, label=label)
+    legend = plt.legend(loc='upper right')
+    for label in legend.get_texts():
+        label.set_fontsize('small')
 
 
 def plot_pmt_signals_vs_time_mus(pmt_signals,
+                                 pmt_active,
                                  t_min      =    0,
                                  t_max      = 1200,
                                  signal_min =    0,
@@ -89,15 +94,35 @@ def plot_pmt_signals_vs_time_mus(pmt_signals,
     tstep = 25
     PMTWL = pmt_signals[0].shape[0]
     signal_t = np.arange(0., PMTWL * tstep, tstep)/units.mus
-    plt.figure(figsize=(12, 12))
-    for i in range(len(pmt_signals)):
-        ax1 = plt.subplot(3, 4, i+1)
+    plt.figure(figsize=(10, 10))
+    j=0
+    for i in pmt_active:
+        ax1 = plt.subplot(4, 3, j+1)
         ax1.set_xlim([t_min, t_max])
         ax1.set_ylim([signal_min, signal_max])
         set_plot_labels(xlabel = "t (mus)",
                         ylabel = "signal (pes/adc)")
 
         plt.plot(signal_t, pmt_signals[i])
+        j+=1
+
+
+def plot_calibrated_sum_in_mus(CSUM,
+                               tmin=0, tmax=1200,
+                               signal_min=-5, signal_max=200,
+                               csum=True, csum_mau=False):
+    """Plots calibrated sums in mus (notice units)"""
+
+    if csum:
+        plot_signal_vs_time_mus(CSUM.csum,
+                                t_min=tmin, t_max=tmax,
+                                signal_min=signal_min, signal_max=signal_max,
+                                label='CSUM')
+    if csum_mau:
+        plot_signal_vs_time_mus(CSUM.csum_mau,
+                                t_min=tmin, t_max=tmax,
+                                signal_min=signal_min, signal_max=signal_max,
+                                label='CSUM_MAU')
 
 
 def set_plot_labels(xlabel="", ylabel="", grid=True):

--- a/invisible_cities/reco/params.py
+++ b/invisible_cities/reco/params.py
@@ -8,13 +8,17 @@ def _add_namedtuple_in_this_module(name, attribute_names):
     setattr(this_module, name, new_nametuple)
 
 for name, attrs in (
-        ('S12Params'      , 'tmin tmax stride lmin lmax rebin'),
+        ('RawVectors'     , 'event pmtrwf sipmrwf pmt_active sipm_active'),
         ('SensorParams'   , 'NPMT PMTWL NSIPM SIPMWL'),
+        ('CalibParams'    , 'coeff_c, coeff_blr, adc_to_pes_pmt adc_to_pes_sipm'),
+        ('S12Params'      , 'tmin tmax stride lmin lmax rebin'),
+        ('PmapParams'      ,'s1_params s2_params s1p_params s1_PMT_params s1p_PMT_params'),
         ('ThresholdParams', 'thr_s1 thr_s2 thr_MAU thr_sipm thr_SIPM'),
         ('CalibratedSum'  , 'csum csum_mau'),
+        ('CalibratedPMT'  , 'CPMT CPMT_mau'),
+        ('S1PMaps'        , 'S1 S1_PMT S1p S1p_PMT'),
         ('PMaps'          , 'S1 S2 S2Si'),
         ('Peak'           , 't E')):
     _add_namedtuple_in_this_module(name, attrs)
 
 # Leave nothing but the namedtuple types in the namespace of this module
-del name, namedtuple, sys, this_module, _add_namedtuple_in_this_module

--- a/invisible_cities/reco/peak_functions_c.pxd
+++ b/invisible_cities/reco/peak_functions_c.pxd
@@ -13,13 +13,32 @@ after correcting the baseline with a MAU to suppress low frequency noise.
 input:
 CWF:    Corrected waveform (passed by BLR)
 adc_to_pes: a vector with calibration constants
+pmt_active: a list of active PMTs
 n_MAU:  length of the MAU window
 thr_MAU: treshold above MAU to select sample
 """
 cpdef calibrated_pmt_sum(double [:, :] CWF,
                          double [:] adc_to_pes,
-                         int n_MAU=*,
-                         double thr_MAU=*)
+                         list       pmt_active = *,
+                         int        n_MAU      = *,
+                         double thr_MAU        = *)
+
+
+"""
+Return a vector of calibrated PMTs
+after correcting the baseline with a MAU to suppress low frequency noise.
+input:
+CWF:    Corrected waveform (passed by BLR)
+adc_to_pes: a vector with calibration constants
+pmt_active: a list of active PMTs
+n_MAU:  length of the MAU window
+thr_MAU: treshold above MAU to select sample
+"""
+cpdef calibrated_pmt_mau(double [:, :]  CWF,
+                         double [:] adc_to_pes,
+                         list       pmt_active = *,
+                         int        n_MAU      = *,
+                         double     thr_MAU    = *)
 
 
 """

--- a/invisible_cities/reco/pmaps_functions.py
+++ b/invisible_cities/reco/pmaps_functions.py
@@ -80,56 +80,42 @@ def scan_s2si_map(S2Si):
 class S12F:
     """
     Defines the global features of an S12 peak, namely:
-    1) peak width
+    1) peak start (tmin), end (tmax) and width
     2) peak maximum (both energy and time)
     3) energy total
     4) ratio peak/total energy
     """
 
-    def __init__(self, length):
-        self.w    = np.zeros(length, dtype=np.double)
-        self.tmax = np.zeros(length, dtype=np.double)
-        self.emax = np.zeros(length, dtype=np.double)
-        self.etot = np.zeros(length, dtype=np.double)
-        self.er   = np.zeros(length, dtype=np.double)
+    def __init__(self):
+        self.peak = []
+        self.w    = []
+        self.tmin = []
+        self.tmax = []
+        self.tpeak = []
+        self.emax = []
+        self.etot = []
+        self.er   = []
 
+    def add_features(self, S12, peak_number=0):
+        t = S12[peak_number][0]
+        E = S12[peak_number][1]
 
-def s12_features(S12L, peak=0, max_events=100):
-    """
-    input: S1L
-    returns a S1F object for specific peak
-    """
-    nk = np.array(list(S12L.keys()))
+        tmin = t[0]
+        tmax = t[-1]
+        i_t = loc_elem_1d(E, emax)
+        tpeak = t[i_t]
 
-    # max event: but notice that some events may be missing
-    evt_max = np.max(nk)
+        emax = np.max(E)
+        etot = np.sum(E)
+        er = 9e+9
+        if etot > 0:
+            er = emax/etot
 
-    n = min(evt_max+1, max_events)
-    print('required {} events; found in dict {} events'
-          .format(max_events, evt_max+1))
-    s1f = S12F(n)
-
-    for i in nk:
-        if i >= n:
-            break
-
-        S1 = S12L[i]
-        try:
-            T = S1[peak][0]
-            E = S1[peak][1]
-        except KeyError:
-            print('peak number {} does not exit in S12L'.format(peak))
-            return 0
-
-        s1f.w[i] = T[-1] - T[0]
-        s1f.emax[i] = np.max(E)
-        i_t = cf.loc_elem_1d(E, s1f.emax[i])
-        s1f.tmax[i] = T[i_t]
-        s1f.etot[i] = np.sum(E)
-
-        if s1f.etot[i] > 0:
-            s1f.er[i] = s1f.emax[i] / s1f.etot[i]
-        else:
-            s1f.er[i] = 0
-
-    return s1f
+        self.w.append(tmax - tmin)
+        self.tmin.append(tmin)
+        self.tmax.append(tmax)
+        self.tpeak.append(tpeak)
+        self.emax.append(emax)
+        self.etot.append(etot)
+        self.etot.append(er)
+        self.peak.append(peak_number)

--- a/invisible_cities/sierpe/blr.pxd
+++ b/invisible_cities/sierpe/blr.pxd
@@ -29,12 +29,15 @@ import numpy as np
 cimport numpy as np
 
 cpdef deconvolve_signal(double [:] signal_daq,
-                        int n_baseline=*,
-                        double coef_clean=*,
-                        double coef_blr=*,
-                        double thr_trigger=*,
-                        int acum_discharge_length=*)
+                        int        n_baseline     = *,
+                        double     coef_clean     = *,
+                        double     coef_blr       = *,
+                        double     thr_trigger    = *,
+                        int acum_discharge_length = *)
 
 cpdef deconv_pmt(np.ndarray[np.int16_t, ndim=2] pmtrwf,
-                 double [:] coeff_c, double [:] coeff_blr,
-                 int n_baseline=*, double thr_trigger=*)
+                 double [:]                     coeff_c,
+                 double [:]                     coeff_blr,
+                 list                           pmt_active  = *,
+                 int                            n_baseline  = *,
+                 double                         thr_trigger = *)

--- a/invisible_cities/sierpe/blr.pyx
+++ b/invisible_cities/sierpe/blr.pyx
@@ -91,10 +91,21 @@ cpdef deconvolve_signal(double [:] signal_daq,
 cpdef deconv_pmt(np.ndarray[np.int16_t, ndim=2] pmtrwf,
                  double [:] coeff_c,
                  double [:] coeff_blr,
-                 int    n_baseline  = 28000,
-                 double thr_trigger =     5):
+                 list       pmt_active   =    [],
+                 int        n_baseline   = 28000,
+                 double     thr_trigger  =     5):
     """
-    Deconvolution of all the PMTs in the event cython function
+    Deconvolve all the PMTs in the event.
+    :param pmtrwf: array of PMTs holding the raw waveform
+    :param coeff_c:     cleaning coefficient
+    :param coeff_blr:   deconvolution coefficient
+    :param pmt_active:  list of active PMTs (by id number). An empt list
+                        implies that all PMTs are active
+    :param n_baseline:  number of samples taken to compute baseline
+    :param thr_trigger: threshold to start the BLR process
+    
+    :returns: an array with deconvoluted PMTs. If PMT is not active
+              the array is filled with zeros.
     """
 
     cdef int NPMT = pmtrwf.shape[0]
@@ -103,8 +114,12 @@ cpdef deconv_pmt(np.ndarray[np.int16_t, ndim=2] pmtrwf,
     cdef double [:]    signal_r = np.zeros(NWF, dtype=np.double)
     CWF = []
 
+    cdef list PMT = list(range(NPMT))
+    if len(pmt_active) > 0:
+        PMT = pmt_active
+
     cdef int pmt
-    for pmt in range(NPMT):
+    for pmt in PMT:
         signal_r = deconvolve_signal(signal_i[pmt],
                                      n_baseline  = n_baseline,
                                      coef_clean  = coeff_c[pmt],


### PR DESCRIPTION
This PR addresses modifications in various functions needed to deal with the fact that one can have a number of dead PMTs (in real data). This is handled by defining a list of active PMTs which is passed around the functions that operate with PMTs. If the list is empty, the default is all PMTs active (this guarantees backward compatibility, e.g, preserves the signatures of functions). Some tests have been added to check the new functionality. 