### PR TITLE
Irene masked pmts

### DIFF
--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -72,6 +72,7 @@ class City:
         # This is JCK-1: text reveals symmetry!
         self.xs              = DataSiPM.X.values
         self.ys              = DataSiPM.Y.values
+        self.pmt_active      = np.nonzero(DataPMT.Active.values)[0].tolist()
         self.adc_to_pes      = abs(DataPMT.adc_to_pes.values).astype(np.double)
         self.sipm_adc_to_pes = DataSiPM.adc_to_pes.values    .astype(np.double)
         self.coeff_c         = DataPMT.coeff_c.values        .astype(np.double)
@@ -321,6 +322,7 @@ class DeconvolutionCity(City):
         return blr.deconv_pmt(RWF,
                               self.coeff_c,
                               self.coeff_blr,
+                              pmt_active  = self.pmt_active,
                               n_baseline  = self.n_baseline,
                               thr_trigger = self.thr_trigger)
 
@@ -425,8 +427,9 @@ class CalibratedCity(DeconvolutionCity):
         """Return the csum and csum_mau calibrated sums."""
         return cpf.calibrated_pmt_sum(CWF,
                                       self.adc_to_pes,
-                                        n_MAU =   self.n_MAU,
-                                      thr_MAU = self.thr_MAU)
+                                      pmt_active = self.pmt_active,
+                                           n_MAU = self.  n_MAU   ,
+                                         thr_MAU = self.thr_MAU   )
 
     def csum_zs(self, csum, threshold):
         """Zero Suppression over csum"""

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -1,4 +1,4 @@
-a"""
+"""
 code: irene_test.py
 description: test suite for irene
 author: J.J. Gomez-Cadenas
@@ -15,7 +15,6 @@ from collections import namedtuple
 
 from   invisible_cities.cities.irene import Irene, IRENE
 from   invisible_cities.reco.pmaps_functions import read_run_and_event_from_pmaps_file
-
 
 @fixture(scope='module')
 def conf_file_name_mc(config_tmpdir):

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -1,4 +1,4 @@
-"""
+a"""
 code: irene_test.py
 description: test suite for irene
 author: J.J. Gomez-Cadenas
@@ -14,6 +14,8 @@ from pytest import mark, fixture
 from collections import namedtuple
 
 from   invisible_cities.cities.irene import Irene, IRENE
+from   invisible_cities.reco.pmaps_functions import read_run_and_event_from_pmaps_file
+
 
 @fixture(scope='module')
 def conf_file_name_mc(config_tmpdir):

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -176,7 +176,7 @@ def test_empty_events_issue_81(conf_file_name_mc, config_tmpdir, ICDIR):
     assert empty   == 1
 
 
-#@mark.slow
+@mark.slow
 def test_irene_electrons_40keV_pmt_active_is_correctly_set(job_info_missing_pmts, config_tmpdir, ICDIR):
     """Run Irene. Write an output file."""
 
@@ -186,18 +186,3 @@ def test_irene_electrons_40keV_pmt_active_is_correctly_set(job_info_missing_pmts
 
     assert IRENE.pmt_active == job_info_missing_pmts.pmt_active
 
-
-"""
-def test_irene_electrons_40keV_cwf_contain_zeros_for_missing_pmts(job_info_missing_pmts, config_tmpdir, ICDIR):
-
-    info = job_info_missing_pmts
-    IRENE = Irene(run_number =  info.run_number,
-                  files_in   = [info. input_filename],
-                  files_out  = [info.output_filename])
-
-    _, _, empty = IRENE.run(1)
-    if not empty:
-        with tb.open_file(info.outputfilename) as h5in:
-            cwf = h5in.root.
-        assert not np.any(cwf[:, info.pmt_missing, :])
-"""

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -14,12 +14,6 @@ from pytest import mark, fixture
 from collections import namedtuple
 
 from   invisible_cities.cities.irene import Irene, IRENE
-from   invisible_cities.core.system_of_units_c import units
-from   invisible_cities.reco.params import S12Params as S12P
-from   invisible_cities.reco.params import SensorParams
-import invisible_cities.reco.tbl_functions as tbl
-from   invisible_cities.reco.pmaps_functions import (
-    read_pmaps, read_run_and_event_from_pmaps_file)
 
 @fixture(scope='module')
 def conf_file_name_mc(config_tmpdir):

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -11,6 +11,7 @@ import os
 import tables as tb
 import numpy  as np
 from pytest import mark, fixture
+from collections import namedtuple
 
 from   invisible_cities.cities.irene import Irene, IRENE
 from   invisible_cities.core.system_of_units_c import units
@@ -41,6 +42,28 @@ def conf_file_name_data(config_tmpdir):
                             PATH_OUT = str(config_tmpdir),
                             NEVENTS  = 1)
     return conf_file_name
+
+
+@fixture(scope='module')
+def job_info_missing_pmts(config_tmpdir, ICDIR):
+    # Specifies a name for a data configuration file. Also, default number
+    # of events set to 1.
+    job_info = namedtuple("job_info",
+                          "run_number pmt_missing pmt_active input_filename output_filename")
+
+    run_number  = 3366
+    pmt_missing = [11]
+    pmt_active  = list(filter(lambda x: x not in pmt_missing, range(12)))
+
+
+    ifilename   = os.path.join(ICDIR,
+                                'database/test_data/',
+                                'electrons_40keV_z250_RWF.h5.h5')
+
+    ofilename   = os.path.join(str(config_tmpdir),
+                                'electron_40keV_z250_pmaps_missing_PMT.h5')
+
+    return job_info(run_number, pmt_missing, pmt_active, ifilename, ofilename)
 
 
 @mark.slow
@@ -151,3 +174,30 @@ def test_empty_events_issue_81(conf_file_name_mc, config_tmpdir, ICDIR):
                                    '-r', '0'])
     assert nactual == 0
     assert empty   == 1
+
+
+#@mark.slow
+def test_irene_electrons_40keV_pmt_active_is_correctly_set(job_info_missing_pmts, config_tmpdir, ICDIR):
+    """Run Irene. Write an output file."""
+
+    IRENE = Irene(run_number =  job_info_missing_pmts.run_number,
+                  files_in   = [job_info_missing_pmts. input_filename],
+                  file_out   =  job_info_missing_pmts.output_filename)
+
+    assert IRENE.pmt_active == job_info_missing_pmts.pmt_active
+
+
+"""
+def test_irene_electrons_40keV_cwf_contain_zeros_for_missing_pmts(job_info_missing_pmts, config_tmpdir, ICDIR):
+
+    info = job_info_missing_pmts
+    IRENE = Irene(run_number =  info.run_number,
+                  files_in   = [info. input_filename],
+                  files_out  = [info.output_filename])
+
+    _, _, empty = IRENE.run(1)
+    if not empty:
+        with tb.open_file(info.outputfilename) as h5in:
+            cwf = h5in.root.
+        assert not np.any(cwf[:, info.pmt_missing, :])
+"""

--- a/invisible_cities/reco/peak_functions_test.py
+++ b/invisible_cities/reco/peak_functions_test.py
@@ -42,7 +42,8 @@ def csum_zs_blr_cwf(electron_RWF_file):
         adc_to_pes = abs(DataPMT.adc_to_pes.values)
 
         event = 0
-        CWF = blr.deconv_pmt(pmtrwf[event], coeff_c, coeff_blr, pmt_active)
+        CWF  = blr.deconv_pmt(pmtrwf[event], coeff_c, coeff_blr, pmt_active)
+        CWF6 = blr.deconv_pmt(pmtrwf[event], coeff_c, coeff_blr, list(range(6)))
         csum_cwf, _ =      cpf.calibrated_pmt_sum(
                                CWF,
                                adc_to_pes,
@@ -97,12 +98,15 @@ def csum_zs_blr_cwf(electron_RWF_file):
         from collections import namedtuple
 
         return (namedtuple('Csum',
-                        """csum_cwf csum_blr csum_blr_py
+                        """cwf cwf6
+                           csum_cwf csum_blr csum_blr_py
                            csum_cwf_pmt6 csum_blr_pmt6 csum_blr_py_pmt6
                            CAL_PMT, CAL_PMT_MAU,
                            wfzs_ene wfzs_ene_py
                            wfzs_indx wfzs_indx_py""")
-        (csum_cwf          = csum_cwf,
+        (cwf               = CWF,
+         cwf6              = CWF6,
+         csum_cwf          = csum_cwf,
          csum_blr          = csum_blr,
          csum_blr_py       = csum_blr_py,
          csum_cwf_pmt6     = csum_cwf_pmt6,
@@ -340,3 +344,7 @@ def test_csum_zs_s12():
     for i in S12L2.keys():
         e = S12L2[i][1]
         npt.assert_allclose(e, E)
+
+
+def test_cwf_are_empty_for_masked_pmts(csum_zs_blr_cwf):
+    assert np.all(csum_zs_blr_cwf.cwf6[6:] == 0.)


### PR DESCRIPTION
This PR updates the cities machinery to work with the new functionality introduced in the last PR. 

The Deconvolution and Calibrated cities have been extended to work with a reduced set of PMTs. This is done by adding a new configuration parameter PMT_ACTIVE which is a list of the PMTs that are alive in the detector.

Since this new parameter is a list, the `read_config_file` function has been also updated to work with lists.

A new test using Irene with a reduced number of PMTs has been introduced.
