### PR TITLE
Add function load_pmaps() to return transient rep of PMAPS

### DIFF
--- a/invisible_cities/reco/pmaps_functions.py
+++ b/invisible_cities/reco/pmaps_functions.py
@@ -13,7 +13,15 @@ import invisible_cities.core.core_functions as cf
 from   invisible_cities.database import load_db
 from   invisible_cities.core.mpl_functions import circles
 
+def load_pmaps(PMP_file_name):
+    """Read the PMAP file and return transient PMAP rep."""
 
+    s1t, s2t, s2sit = read_pmaps(PMP_file_name)
+    S1              = df_to_pmaps_dict(s1t)
+    S2              = df_to_pmaps_dict(s2t)
+    S2Si            = df_to_s2si_dict(s2sit)
+    return S1, S2, S2Si
+    
 def read_pmaps(PMP_file_name):
     """Return the PMAPS as PD DataFrames."""
     with tb.open_file(PMP_file_name, 'r') as h5f:

--- a/invisible_cities/reco/pmaps_functions_test.py
+++ b/invisible_cities/reco/pmaps_functions_test.py
@@ -19,7 +19,33 @@ def KrMC_pmaps():
     S2_evts   = list(range(31, 41))
     S2Si_evts = list(range(31, 41))
     s1s, s2s, s2sis = pmapf.read_pmaps(test_file)
-    return (s1s, s2s, s2sis), (S1_evts, S2_evts, S2Si_evts)
+    s1, s2, s2si    = pmapf.load_pmaps(test_file)
+    return (s1s, s2s, s2sis), (S1_evts, S2_evts, S2Si_evts),\
+           (s1, s2, s2si)
+
+
+def test_load_pmaps(KrMC_pmaps):
+
+    (s1t, s2t, s2sit), (_, _, _), (s1, s2, s2si) = KrMC_pmaps
+    S1              = df_to_pmaps_dict(s1t)
+    S2              = df_to_pmaps_dict(s2t)
+    S2Si            = df_to_s2si_dict(s2sit)
+
+    for event, s1d in S1.items():
+        for i, (t, E) in s1d.items():
+            assert np.allclose(t, s1[event][i][0], rtol=1e-4)
+            assert np.allclose(E, s1[event][i][1], rtol=1e-4)
+
+    for event, s2d in S2.items():
+        for i, (t, E) in s2d.items():
+            assert np.allclose(t, s2[event][i][0], rtol=1e-4)
+            assert np.allclose(E, s2[event][i][1], rtol=1e-4)
+
+    for event, s2sid in S2Si.items():
+        for i, sipm in s2sid.items():
+            for nsipm, E in sipm.items():
+                assert np.allclose(E, s2si[event][i][nsipm], rtol=1e-4)
+
 
 
 ###############################################################
@@ -27,7 +53,7 @@ def KrMC_pmaps():
 ###############################################################
 def test_df_to_pmaps_dict_limit_events(KrMC_pmaps):
     max_events = 30
-    (s1s, s2s, s2sis), (S1_evts, _, _) = KrMC_pmaps
+    (s1s, s2s, s2sis), (S1_evts, _, _), _ = KrMC_pmaps
     s1dict = df_to_pmaps_dict(s1s, max_events)
     s2dict = df_to_pmaps_dict(s2s, max_events)
     assert sorted(s1dict.keys()) == S1_evts[:7]
@@ -36,7 +62,7 @@ def test_df_to_pmaps_dict_limit_events(KrMC_pmaps):
 
 def test_df_to_pmaps_dict_take_all_events_if_limit_too_high(KrMC_pmaps):
     max_events_is_more_than_available = 10000
-    (s1s, s2s, s2sis), (S1_evts, S2_evts, _) = KrMC_pmaps
+    (s1s, s2s, s2sis), (S1_evts, S2_evts, _), _  = KrMC_pmaps
     s1dict = df_to_pmaps_dict(s1s, max_events_is_more_than_available)
     s2dict = df_to_pmaps_dict(s2s, max_events_is_more_than_available)
     assert sorted(s1dict.keys()) == S1_evts
@@ -45,7 +71,7 @@ def test_df_to_pmaps_dict_take_all_events_if_limit_too_high(KrMC_pmaps):
 
 def test_df_to_pmaps_dict_default_number_of_events(KrMC_pmaps):
     # Read all events
-    (s1s, s2s, s2sis), (S1_evts, S2_evts, _) = KrMC_pmaps
+    (s1s, s2s, s2sis), (S1_evts, S2_evts, _), _  = KrMC_pmaps
     s1dict = df_to_pmaps_dict(s1s)
     s2dict = df_to_pmaps_dict(s2s)
     assert sorted(s1dict.keys()) == S1_evts
@@ -55,7 +81,7 @@ def test_df_to_pmaps_dict_default_number_of_events(KrMC_pmaps):
 def test_df_to_pmaps_dict_negative_limit_takes_all_events(KrMC_pmaps):
     # Read all events
     negative_max_events = -23
-    (s1s, s2s, s2sis), (S1_evts, S2_evts, _) = KrMC_pmaps
+    (s1s, s2s, s2sis), (S1_evts, S2_evts, _), _  = KrMC_pmaps
     s1dict = df_to_pmaps_dict(s1s, negative_max_events)
     s2dict = df_to_pmaps_dict(s2s, negative_max_events)
     assert sorted(list(s1dict.keys())) == S1_evts
@@ -63,7 +89,7 @@ def test_df_to_pmaps_dict_negative_limit_takes_all_events(KrMC_pmaps):
 
 
 def test_df_to_pmaps_dict_arrays_lengths_are_equal(KrMC_pmaps):
-    (_, s2s, _), (_, S2_evts, _) = KrMC_pmaps
+    (_, s2s, _), (_, S2_evts, _), _  = KrMC_pmaps
 
     s2dict = df_to_pmaps_dict(s2s)
     for evt in s2dict.values():
@@ -123,21 +149,21 @@ def test_df_to_pmaps_dict_events_data_correct(s12_dataframe_converted):
 ###############################################################
 def test_df_to_s2si_dict_limit_events(KrMC_pmaps):
     max_events = 30
-    (_, _, s2sis), (_, _, S2Si_evts) = KrMC_pmaps
+    (_, _, s2sis), (_, _, S2Si_evts), _  = KrMC_pmaps
     S2Sidict = df_to_s2si_dict(s2sis, max_events)
     assert sorted(S2Sidict.keys()) == []
 
 
 def test_df_to_s2si_dict_take_all_events_if_limit_too_high(KrMC_pmaps):
     max_events_is_more_than_available = 10000
-    (_, _, s2sis), (_, _, S2Si_evts) = KrMC_pmaps
+    (_, _, s2sis), (_, _, S2Si_evts), _  = KrMC_pmaps
     S2Sidict = df_to_s2si_dict(s2sis, max_events_is_more_than_available)
     assert sorted(S2Sidict.keys()) == S2Si_evts
 
 
 def test_df_to_s2si_dict_default_number_of_events(KrMC_pmaps):
     # Read all events
-    (_, _, s2sis), (_, _, S2Si_evts) = KrMC_pmaps
+    (_, _, s2sis), (_, _, S2Si_evts), _  = KrMC_pmaps
     S2Sidict = df_to_s2si_dict(s2sis)
     assert sorted(S2Sidict.keys()) == S2Si_evts
 
@@ -145,13 +171,13 @@ def test_df_to_s2si_dict_default_number_of_events(KrMC_pmaps):
 def test_df_to_s2si_dict_negative_limit_takes_all_events(KrMC_pmaps):
     # Read all events
     negative_max_events = -23
-    (_, _, s2sis), (_, _, S2Si_evts) = KrMC_pmaps
+    (_, _, s2sis), (_, _, S2Si_evts), _  = KrMC_pmaps
     S2Sidict = df_to_s2si_dict(s2sis, negative_max_events)
     assert sorted(S2Sidict.keys()) == S2Si_evts
 
 
 def test_df_to_s2si_dict_number_of_slices_is_correct(KrMC_pmaps):
-    (_, s2s, s2sis), (_, S2_evts, _) = KrMC_pmaps
+    (_, s2s, s2sis), (_, S2_evts, _), _  = KrMC_pmaps
     S2_energy   = df_to_pmaps_dict(  s2s)
     S2_tracking = df_to_s2si_dict (s2sis)
 


### PR DESCRIPTION
Function read_pmaps() returns data frames (e.g, a "memcopy" in the
form of a dataframe of the table used for persistent rep of PMAPS. The
user needs to call extra functions to obtain the transient rep. This
addition allows the use to obtain the transient rep (e.g, dicts) with
a single call, simplfying the interface and hiding the low level
stuff.

A test has been added to ensure correct behaviour.