### PR TITLE
Fix error in MCTracks event numbers

### DIFF
--- a/invisible_cities/cities/diomira.py
+++ b/invisible_cities/cities/diomira.py
@@ -123,7 +123,7 @@ class Diomira(SensorResponseCity):
                     for evt in range(NEVT):
                         # copy corresponding MCTracks to output MCTracks table
                         mctracks_writer.copy_mctracks(h5in.root.MC.MCTracks,
-                                          n_events_tot)
+                                          n_events_tot, self.first_evt)
 
                         # simulate PMT and SiPM response
                         # RWF and BLR

--- a/invisible_cities/cities/diomira_test.py
+++ b/invisible_cities/cities/diomira_test.py
@@ -188,7 +188,12 @@ def test_command_line_diomira(conf_file_name, config_tmpdir):
             assert h5out.root.Run.events[0]['evt_number'] == start_evt
 
             # check mctracks
-            mctracks_in  = h5in .root.MC.MCTracks[0]
-            mctracks_out = h5out.root.MC.MCTracks[0]
-            for e in zip(mctracks_in, mctracks_out):
+            # we have to convert manually into a tuple because MCTracks[0]
+            # returns an object of type numpy.void where we cannot index
+            # using ranges like mctracks_in[1:]
+            mctracks_in  = tuple(h5in .root.MC.MCTracks[0])
+            mctracks_out = tuple(h5out.root.MC.MCTracks[0])
+            #evt number is not equal if we redefine first event number
+            assert mctracks_out[0] == start_evt
+            for e in zip(mctracks_in[1:], mctracks_out[1:]):
                 np.testing.assert_array_equal(e[0],e[1])

--- a/invisible_cities/core/mctrk_functions.py
+++ b/invisible_cities/core/mctrk_functions.py
@@ -27,11 +27,12 @@ class MCTrackWriter:
                         title       = "MCTracks",
                         filters     = tbl.filters(self.compression))
 
-    def copy_mctracks(self, mctracks, evt_number):
+    def copy_mctracks(self, mctracks, evt_number, offset=0):
         for r in mctracks.iterrows(start=self.last_row):
             if r['event_indx'] == evt_number:
                 self.last_row += 1
-                self.mc_table.append([r[:]])
+                evt = (r['event_indx']+ offset,)+ r[1:]
+                self.mc_table.append([evt])
             else:
                 break
         self.mc_table.flush()


### PR DESCRIPTION
When we change event numbers in diomira using the parameter `FIRST_EVT`, where are not updating those numbers also in MCTracks table. This PR fixes that mismatch.

The first commit include a test showing the error and the second commit contains the fix. If everyone is happy I'll squash them so we can rebase onto master.