### PR TITLE
Change N_BASELINE precision in DECONV_PARAM table

### DIFF
--- a/invisible_cities/reco/nh5.py
+++ b/invisible_cities/reco/nh5.py
@@ -84,7 +84,7 @@ class FEE(tb.IsDescription):
 
 
 class DECONV_PARAM(tb.IsDescription):
-    N_BASELINE            = tb.Int16Col(pos=0)
+    N_BASELINE            = tb.Int32Col(pos=0)
     THR_TRIGGER           = tb.Int16Col(pos=1)
     ACUM_DISCHARGE_LENGTH = tb.Int16Col(pos=2)
     ACUM_TAU              = tb.Int16Col(pos=3)


### PR DESCRIPTION
Int16 is not enough for the values we need to write (up to ~50k). This table also needs to be written by irene on its output files. @gonzaponte will do that and update this PR.