### PR TITLE
Ignore inline comments in config files

### DIFF
--- a/invisible_cities/core/configure.py
+++ b/invisible_cities/core/configure.py
@@ -141,8 +141,11 @@ def read_config_file(cfile):
     """
     n = argparse.Namespace(VERBOSITY=20, RUN_ALL=False, COMPRESSION="ZLIB4")
     for line in open(cfile, "r"):
-        if line == "\n" or line[0] == "#":
+        line = line.split("#", 1)[0]
+
+        if line.isspace() or line == "":
             continue
+
         # python-2 & python-3
         #tokens = [i for i in line.rstrip().split(" ") if i]
         # python-2 only. In python-2 filter returns a list in

--- a/invisible_cities/core/configure_test.py
+++ b/invisible_cities/core/configure_test.py
@@ -9,7 +9,7 @@ import invisible_cities.core.configure as conf
 
 config_file_format = """
 # set_input_files
-PATH_IN {PATH_IN}
+PATH_IN {PATH_IN} # comment to be ignored 1
 FILE_IN {FILE_IN}
 
 # set_pmap_store


### PR DESCRIPTION
Example:
S1_LMIN 0 # This comment will be ignored