### PR TITLE
Fix DB code to include external PMT

### DIFF
--- a/invisible_cities/database/load_db.py
+++ b/invisible_cities/database/load_db.py
@@ -67,7 +67,7 @@ as msk ON pos.SensorID = msk.SensorID LEFT JOIN
 as gain ON pos.SensorID = gain.SensorID LEFT JOIN
 (select * from PmtBlr where MinRun < {3} and (MaxRun >= {3} or MaxRun is NULL))
 as blr ON map.ElecID = blr.ElecID
-where pos.SensorID < 100 and pos.MinRun={0} and map.MinRun={2}
+where pos.SensorID < 100 and pos.MinRun={0} and map.MinRun={2} and pos.Label LIKE 'PMT%'
 order by Active desc, pos.SensorID'''\
     .format(minrun_position, minrun_gain, minrun_map, run_number)
     data = pd.read_sql_query(sql, conn)

--- a/invisible_cities/database/load_db_test.py
+++ b/invisible_cities/database/load_db_test.py
@@ -13,8 +13,18 @@ def test_pmts_pd():
     columns =['SensorID', 'ChannelID', 'PmtID', 'Active', 'X', 'Y',
               'coeff_blr', 'coeff_c', 'adc_to_pes', 'noise_rms', 'Sigma']
     assert columns == list(pmts)
+    assert pmts['PmtID'].str.startswith('PMT').all()
     assert pmts.shape[0] == 12
 
+def test_pmts_MC_pd():
+    """Check that we retrieve the correct number of PMTs."""
+    mc_run = 0
+    pmts = DB.DataPMT(mc_run)
+    columns =['SensorID', 'ChannelID', 'PmtID', 'Active', 'X', 'Y',
+              'coeff_blr', 'coeff_c', 'adc_to_pes', 'noise_rms', 'Sigma']
+    assert columns == list(pmts)
+    assert pmts['PmtID'].str.startswith('PMT').all()
+    assert pmts.shape[0] == 12
 
 def test_sipm_pd():
     """Check that we retrieve the correct number of SiPMs."""


### PR DESCRIPTION
For the processing of some sodium runs we need to include the external PMT used in the detector to trigger in coincidence. This PMTs has a different label (PmtID), which is NaI. This PR updates load_db.DataPMT to include only PMTs with names like PMT* (from PMT1 to PMTC). 

The test has been updated to check that the returned dataframe includes only those kind of sensors.

Regarding the tests there is one small issue, DataPMT() has an optional argument, the run number. For MC we call DataPMT(0), if we run DataPMT() we will get the latest calibration available. Apart from that, tests test_pmts_pd and test_pmts_MC_pd are the same. Probably this could be parametrize, but I don't know how to parametrize it giving one argument in one case and no argument in the other.

When everything is ok, this should also be squashed before rebasing master.