### PR TITLE
Stop supporting Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ matrix:
   - os: osx
 
 env:
-  - IC_PYTHON_VERSION=2.7
   - IC_PYTHON_VERSION=3.5
   - IC_PYTHON_VERSION=3.6
 

--- a/bash_manage.sh
+++ b/bash_manage.sh
@@ -26,7 +26,7 @@ manage.sh()
     if [[ ${prev2} == "manage.sh" ]] ; then
             case "${prev}" in
                         install_and_check|install|work_in_python_version|make_environment)
-                        local versions="2.7 3.5 3.6"
+                        local versions="3.5 3.6"
                     COMPREPLY=( $(compgen -W "${versions}" -- ${cur}) )
                     return 0
                     ;;
@@ -70,7 +70,7 @@ source_manage.sh()
     if [[ ${prev2} == "manage.sh" ]] ; then
             case "${prev}" in
                         install_and_check|install|work_in_python_version|make_environment)
-                        local versions="2.7 3.5 3.6"
+                        local versions="3.5 3.6"
                     COMPREPLY=( $(compgen -W "${versions}" -- ${cur}) )
                     return 0
                     ;;

--- a/invisible_cities/cities/diomira.py
+++ b/invisible_cities/cities/diomira.py
@@ -7,8 +7,6 @@ IC core team: Jacek Generowicz, JJGC, G. Martinez, J.A. Hernando, J.M Benlloch
 package: invisible cities. See release notes and licence
 last changed: 09-11-2017
 """
-from __future__ import print_function
-
 import sys
 from glob import glob
 from time import time

--- a/invisible_cities/cities/dorothea.py
+++ b/invisible_cities/cities/dorothea.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import sys
 import glob
 import time

--- a/invisible_cities/cities/irene.py
+++ b/invisible_cities/cities/irene.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import sys
 
 from glob import glob

--- a/invisible_cities/cities/isidora.py
+++ b/invisible_cities/cities/isidora.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import sys
 
 from glob import glob

--- a/invisible_cities/cities/maurilia.py
+++ b/invisible_cities/cities/maurilia.py
@@ -6,7 +6,6 @@ author: Josh Renner
 IC core team: Jacek Generowicz, JJGC, G. Martinez, J.A. Hernando, J.M Benlloch
 package: invisible cities. See release notes and licence
 """
-from __future__ import print_function
 
 import sys
 from glob import glob

--- a/invisible_cities/cities/maurilia_test.py
+++ b/invisible_cities/cities/maurilia_test.py
@@ -6,9 +6,6 @@ IC core team: Jacek Generowicz, JJGC,
 G. Martinez, J.A. Hernando, J.M Benlloch
 package: invisible cities. See release notes and licence
 """
-from __future__ import print_function
-from __future__ import absolute_import
-
 from pytest import mark, fixture
 from   invisible_cities.cities.maurilia import Maurilia, MAURILIA
 

--- a/invisible_cities/core/configure_test.py
+++ b/invisible_cities/core/configure_test.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from os import getenv, path
 from pytest import mark
 from hypothesis import given, example

--- a/invisible_cities/core/core_functions_test.py
+++ b/invisible_cities/core/core_functions_test.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
-
 import sys, os
 from functools import partial
 

--- a/invisible_cities/core/fit_functions.py
+++ b/invisible_cities/core/fit_functions.py
@@ -4,8 +4,6 @@ A set of functions for data fitting.
 GML November 2016
 """
 
-from __future__ import absolute_import, division
-
 import numpy as np
 import scipy.optimize
 import scipy.stats

--- a/invisible_cities/core/mpl_functions.py
+++ b/invisible_cities/core/mpl_functions.py
@@ -1,5 +1,4 @@
 """A utility module for plots with matplotlib"""
-from __future__ import print_function, division, absolute_import
 
 import math
 import numpy as np

--- a/invisible_cities/core/random_sampling.py
+++ b/invisible_cities/core/random_sampling.py
@@ -1,7 +1,5 @@
 """Defines a class for random sampling."""
 
-from __future__ import print_function, division, absolute_import
-
 import numpy as np
 
 import invisible_cities.database.load_db as DB

--- a/invisible_cities/core/sensor_functions.py
+++ b/invisible_cities/core/sensor_functions.py
@@ -1,8 +1,6 @@
 """Functions manipulating sensors (PMTs and SiPMs)
 JJGC January 2017
 """
-from __future__ import print_function, division, absolute_import
-
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.animation

--- a/invisible_cities/database/load_db.py
+++ b/invisible_cities/database/load_db.py
@@ -4,10 +4,6 @@ import pandas as pd
 import os
 from operator import itemgetter
 
-import sys
-if sys.version_info < (3,):
-    from future_builtins import map
-
 
 DATABASE_LOCATION = '/invisible_cities/database/localdb.sqlite3'
 

--- a/invisible_cities/reco/df_pmaps.py
+++ b/invisible_cities/reco/df_pmaps.py
@@ -5,8 +5,6 @@ Not used in main stream analysis. Not tested.
 Kept in repository for future use.
 
 """
-from __future__ import print_function, division, absolute_import
-
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt

--- a/invisible_cities/reco/peak_functions.py
+++ b/invisible_cities/reco/peak_functions.py
@@ -1,8 +1,6 @@
 """Functions to find peaks, S12 selection etc.
 JJGC and GML December 2016
 """
-from __future__ import print_function, division, absolute_import
-
 import math
 import numpy as np
 import pandas as pd

--- a/invisible_cities/reco/peak_functions_c.pyx
+++ b/invisible_cities/reco/peak_functions_c.pyx
@@ -2,8 +2,6 @@
 Cython version of some peak functions
 JJGC December, 2016
 """
-from __future__ import division
-
 cimport numpy as np
 import  numpy as np
 from scipy import signal

--- a/invisible_cities/reco/peak_functions_test.py
+++ b/invisible_cities/reco/peak_functions_test.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from pytest import mark, fixture
 import sys, os
 from os import path

--- a/invisible_cities/reco/pmaps_functions.py
+++ b/invisible_cities/reco/pmaps_functions.py
@@ -2,8 +2,6 @@
 JJGC December 2016
 
 """
-from __future__ import print_function, division, absolute_import
-
 import numpy as np
 import pandas as pd
 import tables as tb

--- a/invisible_cities/reco/pmaps_functions_test.py
+++ b/invisible_cities/reco/pmaps_functions_test.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from operator import itemgetter
 import numpy as np
 from pytest import mark

--- a/invisible_cities/reco/tbl_functions.py
+++ b/invisible_cities/reco/tbl_functions.py
@@ -10,8 +10,6 @@ functions in sensorFunctions for now, give functions here more coherente names
 now returns also calibration constants for RWF and BLR (MC version)
 """
 
-from __future__ import print_function, division, absolute_import
-
 import numpy as np
 import tables as tb
 import pandas as pd

--- a/invisible_cities/reco/wfm_functions_test.py
+++ b/invisible_cities/reco/wfm_functions_test.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import os
 from os import path
 from hypothesis import given, assume

--- a/invisible_cities/sierpe/blr.pyx
+++ b/invisible_cities/sierpe/blr.pyx
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import  numpy as np
 cimport numpy as np
 from scipy import signal as SGN

--- a/invisible_cities/sierpe/cblr.pyx
+++ b/invisible_cities/sierpe/cblr.pyx
@@ -1,4 +1,3 @@
-from __future__ import division
 import  numpy as np
 cimport numpy as np
 from scipy import signal as SGN

--- a/invisible_cities/sierpe/fee.py
+++ b/invisible_cities/sierpe/fee.py
@@ -4,8 +4,6 @@ PMT plane FEE.
 VH, JJGC, November, 2016
 """
 
-from __future__ import print_function, division
-
 import numpy as np
 from scipy import signal
 import invisible_cities.core.system_of_units as units

--- a/invisible_cities/sierpe/fee_test.py
+++ b/invisible_cities/sierpe/fee_test.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from math import sqrt
 import pytest
 from pytest import raises, mark


### PR DESCRIPTION
To my knowledge, none of our users have had any issues with Python 3, or any need to use Python 2.

I see no benefits to keeping Python 2 support, while it does have some downsides, most notably that it is discouraging us from taking advantage of any Python 3 features which are incompatible with Python 2.

The commits in this PR remove Python 2 from the Travis build matrix, and from the command line completion options.

When (rather than if) we accept this PR, developers should feel free to use Python 3 features in new code.