### PR TITLE
Remove obsolete coveralls badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,10 +63,7 @@ recent version:
    
 
 :Travis CI: |travis|
-:Coveralls: |coveralls|
 
 .. |travis| image:: https://img.shields.io/travis/nextic/IC.png
         :target: https://travis-ci.org/nextic/IC
 
-.. |coveralls| image:: https://coveralls.io/repos/nextic/IC/badge.png
-        :target: https://coveralls.io/r/nextic/IC


### PR DESCRIPTION
We do not use coveralls any more, but the badge is still there on our
main readme page, constantly reporting 'unknown'.

Let's get rid of it!