### PR TITLE
Run the tests in parallel on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ install:
   - source manage.sh install ${IC_PYTHON_VERSION}
 
 script:
-  - bash manage.sh run_tests
+  - bash manage.sh run_tests_par


### PR DESCRIPTION
The parallel tests keep getting broken, because nobody runs them,
because they are still not worth while: serial execution is still
faster. But we seem to be getting close to the break-even point.

The serial tests should pass if the parallel ones do; the reverse is
not necessarily true. So let's get Travis to help us not break the
parallel tests.