### PR TITLE
Switch to relative imports

### DIFF
--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -12,31 +12,29 @@ Authors: J.J. Gomez-Cadenas and J. Generowicz.
 Feburary, 2017.
 """
 
-import abc
 import sys
-import copy
 from textwrap import dedent
 
 import numpy as np
 
-from   invisible_cities.database import load_db
-from   invisible_cities.core.system_of_units_c import units
-import invisible_cities.sierpe.blr as blr
-import invisible_cities.reco.peak_functions_c as cpf
-import invisible_cities.reco.peak_functions as pf
-import invisible_cities.reco.pmaps_functions as pmp
-from   invisible_cities.core.exceptions import NoInputFiles, NoOutputFile
-import invisible_cities.sierpe.fee as FE
-import invisible_cities.reco.tbl_functions as tbf
-import invisible_cities.core.fit_functions as fitf
-import invisible_cities.reco.wfm_functions as wfm
-from   invisible_cities.core.random_sampling \
-         import NoiseSampler as SiPMsNoiseSampler
-from   invisible_cities.core.configure import print_configuration
-from   invisible_cities.reco.dst_io import PointLikeEvent
+from .. core.configure         import print_configuration
+from .. core.exceptions        import NoInputFiles
+from .. core.exceptions        import NoOutputFile
+from .. core.system_of_units_c import units
 
-from   invisible_cities.reco.nh5 import DECONV_PARAM
-import invisible_cities.reco.pmap_io as pio
+from .. database import load_db
+
+from ..reco        import peak_functions_c as cpf
+from ..reco        import peak_functions   as pf
+from ..reco        import pmaps_functions  as pmp
+from ..reco        import pmap_io          as pio
+from ..reco        import tbl_functions    as tbf
+from ..reco        import wfm_functions    as wfm
+from ..reco.dst_io import PointLikeEvent
+from ..reco.nh5    import DECONV_PARAM
+
+from ..sierpe import blr
+from ..sierpe import fee as FE
 
 if sys.version_info >= (3,5):
     # Exec to avoid syntax errors in older Pythons

--- a/invisible_cities/cities/diomira.py
+++ b/invisible_cities/cities/diomira.py
@@ -11,21 +11,23 @@ import sys
 from glob import glob
 from time import time
 
-import numpy as np
 import tables as tb
 
-import invisible_cities.reco.tbl_functions as tbl
-from   invisible_cities.core.configure import configure, print_configuration
-from   invisible_cities.cities.base_cities import SensorResponseCity
-from   invisible_cities.reco.params import SensorParams
-from   invisible_cities.reco.nh5 import FEE, RunInfo, EventInfo, MCTrack
-from   invisible_cities.core.random_sampling \
-         import NoiseSampler as SiPMsNoiseSampler
-import invisible_cities.reco.wfm_functions as wfm
-from   invisible_cities.core.system_of_units_c import units
-from   invisible_cities.core.mctrk_functions import MCTrackWriter
-from   invisible_cities.core.exceptions import ParameterNotSet
+from .. core.configure         import configure
+from .. core.configure         import print_configuration
+from .. core.random_sampling   import NoiseSampler as SiPMsNoiseSampler
+from .. core.system_of_units_c import units
+from .. core.mctrk_functions   import MCTrackWriter
+from .. core.exceptions        import ParameterNotSet
 
+from .. reco        import wfm_functions as wfm
+from .. reco        import tbl_functions as tbl
+from .. reco.params import SensorParams
+from .. reco.nh5    import FEE
+from .. reco.nh5    import RunInfo
+from .. reco.nh5    import EventInfo
+
+from .  base_cities import SensorResponseCity
 
 
 class Diomira(SensorResponseCity):

--- a/invisible_cities/cities/diomira_test.py
+++ b/invisible_cities/cities/diomira_test.py
@@ -8,19 +8,22 @@ package: invisible cities. See release notes and licence
 """
 import os
 import tables as tb
-import numpy as np
+import numpy  as np
 
-from pytest import mark, fixture
+from pytest import mark
+from pytest import fixture
 
-import invisible_cities.reco.tbl_functions as tbl
-import invisible_cities.reco.wfm_functions as wfm
-import invisible_cities.core.system_of_units as units
-from   invisible_cities.sierpe import fee as FEE
-import invisible_cities.sierpe.blr as blr
-from   invisible_cities.database import load_db
-from   invisible_cities.cities.diomira import Diomira, DIOMIRA
-from   invisible_cities.core.random_sampling \
-     import NoiseSampler as SiPMsNoiseSampler
+from .. core import system_of_units as units
+from .. core.random_sampling import NoiseSampler as SiPMsNoiseSampler
+
+from .. reco     import tbl_functions as tbl
+from .. reco     import wfm_functions as wfm
+from .. sierpe   import fee as FEE
+from .. sierpe   import blr
+from .. database import load_db
+
+from .  diomira  import Diomira
+from .  diomira  import DIOMIRA
 
 
 @fixture(scope='module')

--- a/invisible_cities/cities/dorothea.py
+++ b/invisible_cities/cities/dorothea.py
@@ -6,12 +6,17 @@ import textwrap
 import numpy  as np
 import tables as tb
 
-from invisible_cities.core.configure         import configure
-from invisible_cities.core.system_of_units_c import units
-from invisible_cities.reco.dst_io            import Kr_writer
-from invisible_cities.cities.base_cities     import City, S12SelectorCity, merge_two_dicts, dedent
-from invisible_cities.reco.tbl_functions     import get_event_numbers_and_timestamps
-from invisible_cities.reco.pmaps_functions   import load_pmaps
+from .. core.configure         import configure
+from .. core.system_of_units_c import units
+
+from .. reco.dst_io            import Kr_writer
+from .. reco.pmaps_functions   import load_pmaps
+from .. reco.tbl_functions     import get_event_numbers_and_timestamps
+
+from .  base_cities            import City
+from .  base_cities            import S12SelectorCity
+from .  base_cities            import merge_two_dicts
+from .  base_cities            import dedent
 
 
 class Dorothea(City, S12SelectorCity):

--- a/invisible_cities/cities/dorothea_test.py
+++ b/invisible_cities/cities/dorothea_test.py
@@ -1,11 +1,14 @@
 import os
 
-from pytest import mark, fixture
+from pytest import mark
+from pytest import fixture
 from pandas import DataFrame
 
-from invisible_cities.cities.dorothea      import Dorothea, DOROTHEA
-from invisible_cities.reco  .dst_functions import load_dst
-from invisible_cities.core  .test_utils    import assert_dataframes_close
+from . dorothea import Dorothea
+from . dorothea import DOROTHEA
+
+from .. reco.dst_functions import load_dst
+from .. core.test_utils    import assert_dataframes_close
 
 @fixture(scope='module')
 def conf_file_name_mc(config_tmpdir):

--- a/invisible_cities/cities/irene.py
+++ b/invisible_cities/cities/irene.py
@@ -6,15 +6,15 @@ from time import time
 import numpy  as np
 import tables as tb
 
+from .. core.configure         import configure
+from .. core.system_of_units_c import units
+from .. core.mctrk_functions   import MCTrackWriter
 
-from invisible_cities.core.configure import configure, print_configuration
-from invisible_cities.core.system_of_units_c import units
+from .. reco.pmap_io import pmap_writer
+from .. reco.params  import SensorParams
+from .. reco.params  import S12Params as S12P
 
-from invisible_cities.reco.pmap_io import pmap_writer, S12, S2Si
-from invisible_cities.core.system_of_units_c import units
-from invisible_cities.cities.base_cities import PmapCity
-from invisible_cities.reco.params import SensorParams, S12Params as S12P
-from invisible_cities.core.mctrk_functions import MCTrackWriter
+from .  base_cities  import PmapCity
 
 
 class Irene(PmapCity):

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -8,13 +8,17 @@ package: invisible cities. See release notes and licence
 last changed: 01-12-2017
 """
 import os
-import tables as tb
-import numpy  as np
-from pytest import mark, fixture
 from collections import namedtuple
 
-from   invisible_cities.cities.irene import Irene, IRENE
-from   invisible_cities.reco.pmaps_functions import read_run_and_event_from_pmaps_file
+import tables as tb
+import numpy  as np
+
+from pytest import mark
+from pytest import fixture
+
+from .  irene import Irene
+from .  irene import IRENE
+from .. reco.pmaps_functions import read_run_and_event_from_pmaps_file
 
 @fixture(scope='module')
 def conf_file_name_mc(config_tmpdir):

--- a/invisible_cities/cities/isidora.py
+++ b/invisible_cities/cities/isidora.py
@@ -2,15 +2,17 @@ import sys
 
 from glob import glob
 from time import time
-import numpy as np
+
+import numpy  as np
 import tables as tb
 
-from   invisible_cities.reco.nh5 import RunInfo, EventInfo
-import invisible_cities.reco.tbl_functions as tbl
-from   invisible_cities.core.configure import configure
-from   invisible_cities.core.system_of_units_c import units
-from   invisible_cities.cities.base_cities import DeconvolutionCity
-from   invisible_cities.reco.params import SensorParams
+from .. core.configure         import configure
+from .. core.system_of_units_c import units
+
+from .. reco        import tbl_functions as tbl
+from .. reco.params import SensorParams
+
+from .  base_cities import DeconvolutionCity
 
 class Isidora(DeconvolutionCity):
     """

--- a/invisible_cities/cities/isidora_test.py
+++ b/invisible_cities/cities/isidora_test.py
@@ -7,12 +7,15 @@ G. Martinez, J.A. Hernando, J.M Benlloch
 package: invisible cities. See release notes and licence
 last changed: 01-12-2017
 """
-
 import os
-from   pytest import mark, raises, fixture
 
-from   invisible_cities.core.exceptions import NoInputFiles
-from   invisible_cities.cities.isidora import Isidora, ISIDORA
+from   pytest import mark
+from   pytest import raises
+from   pytest import fixture
+
+from .. core.exceptions import NoInputFiles
+from .  isidora import Isidora
+from .  isidora import ISIDORA
 
 
 @fixture(scope='module')

--- a/invisible_cities/cities/maurilia.py
+++ b/invisible_cities/cities/maurilia.py
@@ -11,13 +11,12 @@ import sys
 from glob import glob
 from time import time
 
-import numpy  as np
 import tables as tb
 
-import invisible_cities.reco.tbl_functions as tbl
-from   invisible_cities.core.configure import configure, print_configuration
-from   invisible_cities.reco.nh5 import MCTrack
-from   invisible_cities.cities.base_cities import City
+from .. core.configure import configure
+from .. reco.nh5       import MCTrack
+from .. reco           import tbl_functions as tbl
+from .  base_cities import City
 
 class Maurilia(City):
     """

--- a/invisible_cities/cities/maurilia_test.py
+++ b/invisible_cities/cities/maurilia_test.py
@@ -6,8 +6,9 @@ IC core team: Jacek Generowicz, JJGC,
 G. Martinez, J.A. Hernando, J.M Benlloch
 package: invisible cities. See release notes and licence
 """
-from pytest import mark, fixture
-from   invisible_cities.cities.maurilia import Maurilia, MAURILIA
+from pytest import  fixture
+from . maurilia import Maurilia
+from . maurilia import MAURILIA
 
 
 @fixture(scope='module')

--- a/invisible_cities/conftest.py
+++ b/invisible_cities/conftest.py
@@ -23,10 +23,10 @@ def electron_RWF_file(request, ICDIR):
                         'database/test_data',
                         request.param)
 
-from invisible_cities.reco.pmaps_functions import (df_to_pmaps_dict,
-                                                   df_to_s2si_dict,
-                                                   read_pmaps,
-                                                   load_pmaps)
+from .reco.pmaps_functions import (df_to_pmaps_dict,
+                                   df_to_s2si_dict,
+                                   read_pmaps,
+                                   load_pmaps)
 from pandas import DataFrame, Series
 import numpy as np
 

--- a/invisible_cities/core/configure.py
+++ b/invisible_cities/core/configure.py
@@ -5,7 +5,7 @@ import argparse
 import sys
 import os
 
-from invisible_cities.core.log_config import logger
+from . log_config import logger
 
 
 def print_configuration(options):

--- a/invisible_cities/core/configure_test.py
+++ b/invisible_cities/core/configure_test.py
@@ -3,7 +3,7 @@ from pytest import mark
 from hypothesis import given, example
 from hypothesis.strategies import integers, floats, one_of, none
 
-import invisible_cities.core.configure as conf
+from . import configure as conf
 
 config_file_format = """
 # set_input_files

--- a/invisible_cities/core/core_functions.py
+++ b/invisible_cities/core/core_functions.py
@@ -3,8 +3,6 @@ Core functions
 This module includes utility functions.
 """
 import numpy as np
-import pandas as pd
-import math
 import time
 
 

--- a/invisible_cities/core/core_functions_performance.py
+++ b/invisible_cities/core/core_functions_performance.py
@@ -5,8 +5,9 @@ Performance of some coreFunctions
 
 from time import time
 import numpy as np
-import invisible_cities.reco.wfm_functions as wfm
-import invisible_cities.reco.peak_functions_c as cpf
+
+from .. reco import  wfm_functions   as wfm
+from .. reco import peak_functions_c as cpf
 
 
 t = np.arange(1.,100., 0.1, dtype=np.double)

--- a/invisible_cities/core/core_functions_test.py
+++ b/invisible_cities/core/core_functions_test.py
@@ -1,4 +1,5 @@
-import sys, os
+import re
+from time      import sleep
 from functools import partial
 
 import pandas as pd
@@ -9,10 +10,8 @@ from hypothesis import given
 from hypothesis.strategies import integers, floats, sampled_from, composite
 sane_floats = partial(floats, allow_nan=False, allow_infinity=False)
 
-from invisible_cities.core.test_utils import random_length_float_arrays
-from . import core_functions as core
-import re
-from time import sleep
+from .test_utils import random_length_float_arrays
+from .           import core_functions as core
 
 def test_timefunc(capfd):
     # We run a function with a defined time duration (sleep) and we check

--- a/invisible_cities/core/fit_functions.py
+++ b/invisible_cities/core/fit_functions.py
@@ -8,8 +8,8 @@ import numpy as np
 import scipy.optimize
 import scipy.stats
 
-from invisible_cities.core.core_functions import in_range
-from invisible_cities.reco.params         import FitFunction
+from .  core_functions import in_range
+from .. reco.params    import FitFunction
 
 def get_errors(cov):
     """

--- a/invisible_cities/core/fit_functions_test.py
+++ b/invisible_cities/core/fit_functions_test.py
@@ -4,14 +4,20 @@ Tests for fit_functions
 
 import numpy as np
 from pytest import mark
-from numpy.testing import assert_array_equal, assert_allclose
-from hypothesis import given
-from hypothesis.strategies import integers, floats
 
-from   invisible_cities.core.test_utils    import float_arrays, FLOAT_ARRAY, \
-                                                  random_length_float_arrays
-import invisible_cities.core.core_functions as core
-import invisible_cities.core.fit_functions  as fit
+from numpy.testing import assert_array_equal
+from numpy.testing import assert_allclose
+
+from hypothesis            import given
+from hypothesis.strategies import integers
+from hypothesis.strategies import floats
+
+from .test_utils import float_arrays
+from .test_utils import FLOAT_ARRAY
+from .test_utils import random_length_float_arrays
+
+from . import core_functions as core
+from . import  fit_functions as fit
 
 
 def test_get_errors():

--- a/invisible_cities/core/mctrk_functions.py
+++ b/invisible_cities/core/mctrk_functions.py
@@ -2,8 +2,8 @@
 Monte Carlo tracks functions
 """
 import matplotlib.pyplot as plt
-from   invisible_cities.reco.nh5 import MCTrack
-import invisible_cities.reco.tbl_functions as tbl
+from ..reco.nh5 import MCTrack
+from ..reco     import tbl_functions as tbl
 
 class MCTrackWriter:
     """Write MCTracks to file."""

--- a/invisible_cities/core/mpl_functions.py
+++ b/invisible_cities/core/mpl_functions.py
@@ -1,6 +1,5 @@
 """A utility module for plots with matplotlib"""
 
-import math
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.patches import Circle
@@ -8,10 +7,7 @@ from matplotlib.collections import PatchCollection
 # from mpl_toolkits.mplot3d import Axes3D
 # from IPython.display import HTML
 
-import invisible_cities.core.core_functions as cf
-import invisible_cities.core.system_of_units as units
-import invisible_cities.reco.tbl_functions as tbl
-
+from .      import system_of_units as units
 
 # matplotlib.style.use("ggplot")
 #matplotlib.rc('animation', html='html5')

--- a/invisible_cities/core/random_sampling.py
+++ b/invisible_cities/core/random_sampling.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-import invisible_cities.database.load_db as DB
+from .. database import load_db as DB
 
 
 class NoiseSampler:

--- a/invisible_cities/core/sensor_functions.py
+++ b/invisible_cities/core/sensor_functions.py
@@ -5,9 +5,8 @@ import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.animation
 
-from   invisible_cities.database import load_db
-import invisible_cities.core.system_of_units as units
-from   invisible_cities.core.mpl_functions import circles
+from .. database     import load_db
+from . mpl_functions import circles
 
 
 def weighted_sum(CWF, w_vector):

--- a/invisible_cities/database/load_db_test.py
+++ b/invisible_cities/database/load_db_test.py
@@ -1,10 +1,4 @@
-import tables
-from invisible_cities.database import download
-import invisible_cities.database.load_db as DB
-import os
-
-
-from pytest import fixture, mark
+from . import load_db as DB
 
 
 def test_pmts_pd():

--- a/invisible_cities/reco/dst_functions_test.py
+++ b/invisible_cities/reco/dst_functions_test.py
@@ -1,6 +1,9 @@
 import pandas as pd
-from invisible_cities.core.test_utils    import assert_dataframes_equal
-from invisible_cities.reco.dst_functions import load_dst, load_dsts
+
+from .. core.test_utils    import assert_dataframes_equal
+
+from .  dst_functions      import load_dst
+from .  dst_functions      import load_dsts
 
 
 def test_load_dst(Kr_dst_data):

--- a/invisible_cities/reco/dst_io.py
+++ b/invisible_cities/reco/dst_io.py
@@ -1,8 +1,8 @@
 import abc
 import tables as tb
 
-import invisible_cities.reco.nh5 as table_formats
-import invisible_cities.reco.tbl_functions as tbf
+from . import nh5           as table_formats
+from . import tbl_functions as tbf
 
 
 class DST_writer:

--- a/invisible_cities/reco/dst_io_test.py
+++ b/invisible_cities/reco/dst_io_test.py
@@ -1,10 +1,10 @@
 import os
 
-from invisible_cities.core.test_utils    import assert_dataframes_equal
-from invisible_cities.reco.dst_io        import Kr_writer, PointLikeEvent
-from invisible_cities.reco.dst_functions import load_dst
-
 from pytest import mark
+
+from .. core.test_utils    import assert_dataframes_equal
+from .. reco.dst_io        import Kr_writer, PointLikeEvent
+from .. reco.dst_functions import load_dst
 
 
 @mark.parametrize(  'filename,          with_',

--- a/invisible_cities/reco/peak_functions.py
+++ b/invisible_cities/reco/peak_functions.py
@@ -1,22 +1,18 @@
 """Functions to find peaks, S12 selection etc.
 JJGC and GML December 2016
 """
-import math
-import numpy as np
-import pandas as pd
-from time import time
-import tables as tb
+
+
+import numpy  as np
 
 from scipy import signal
 
-import invisible_cities.core.system_of_units as units
-import invisible_cities.sierpe.blr as blr
-import invisible_cities.reco.peak_functions_c as cpf
-from   invisible_cities.database import load_db
-from   invisible_cities.reco.params import (S12Params,
-                                            ThresholdParams,
-                                            CalibratedSum,
-                                            PMaps)
+from .. core   import system_of_units as units
+from .. sierpe import blr
+
+from .         import peak_functions_c as cpf
+from .  params import CalibratedSum
+from .  params import PMaps
 
 def calibrated_pmt_sum(CWF, adc_to_pes, pmt_active = [], n_MAU=200, thr_MAU=5):
     """Compute the ZS calibrated sum of the PMTs

--- a/invisible_cities/reco/peak_functions_c.pyx
+++ b/invisible_cities/reco/peak_functions_c.pyx
@@ -6,7 +6,7 @@ cimport numpy as np
 import  numpy as np
 from scipy import signal
 
-import invisible_cities.reco.pmap_io as pio
+from . import pmap_io as pio
 
 cpdef calibrated_pmt_sum(double [:, :]  CWF,
                          double [:]     adc_to_pes,

--- a/invisible_cities/reco/peak_functions_test.py
+++ b/invisible_cities/reco/peak_functions_test.py
@@ -1,23 +1,26 @@
-from pytest import mark, fixture
-import sys, os
-from os import path
-
-import pandas as pd
-import numpy as np
-import numpy.testing as npt
-import tables as tb
-
-from   invisible_cities.database import load_db
-import invisible_cities.sierpe.blr as blr
-import invisible_cities.reco.tbl_functions as tbl
-import invisible_cities.reco.peak_functions_c as cpf
-import invisible_cities.reco.peak_functions as pf
-import invisible_cities.core.sensor_functions as sf
-import invisible_cities.core.core_functions as cf
-from   invisible_cities.reco.params import S12Params, ThresholdParams,\
-        DeconvParams, CalibVectors
-from   invisible_cities.core.system_of_units_c import units
 from collections import namedtuple
+
+import tables        as tb
+import numpy         as np
+import numpy.testing as npt
+
+from pytest import fixture
+
+from .. core                   import core_functions   as cf
+from .. core.system_of_units_c import units
+
+from .. database               import load_db
+
+from .. sierpe                 import blr
+
+from .                         import peak_functions   as pf
+from .                         import peak_functions_c as cpf
+from .                         import tbl_functions    as tbl
+from . params                  import S12Params
+from . params                  import ThresholdParams
+from . params                  import DeconvParams
+from . params                  import CalibVectors
+
 
 # TODO: rethink this test (list(6) could stop working anytime if DataPMT is changed)
 @fixture(scope='module')
@@ -92,8 +95,6 @@ def csum_zs_blr_cwf(electron_RWF_file):
 
         wfzs_ene,    wfzs_indx    = cpf.wfzs(csum_blr,    threshold=0.5)
         wfzs_ene_py, wfzs_indx_py =  pf.wfzs(csum_blr_py, threshold=0.5)
-
-        from collections import namedtuple
 
         return (namedtuple('Csum',
                         """cwf cwf6

--- a/invisible_cities/reco/pmap_io.py
+++ b/invisible_cities/reco/pmap_io.py
@@ -1,7 +1,7 @@
 import tables as tb
 
-import invisible_cities.reco.nh5 as table_formats
-import invisible_cities.reco.tbl_functions as tbl
+from . import nh5           as table_formats
+from . import tbl_functions as tbl
 
 
 class pmap_writer:

--- a/invisible_cities/reco/pmap_io_test.py
+++ b/invisible_cities/reco/pmap_io_test.py
@@ -2,28 +2,33 @@
 code: pmap_io_test.py
 """
 import os
-import tables as tb
-import numpy  as np
 import time
 
-from invisible_cities.database import load_db
-import invisible_cities.reco.tbl_functions as tbl
-import invisible_cities.sierpe.blr as blr
-import invisible_cities.reco.peak_functions_c as cpf
-import invisible_cities.reco.peak_functions as pf
-import invisible_cities.reco.pmaps_functions as pmf
+import tables as tb
+import numpy  as np
 
-from invisible_cities.reco.pmap_io           import pmap_writer, S12, S2Si
-from invisible_cities.core.system_of_units_c import units
-from invisible_cities.reco.pmaps_functions   import read_pmaps, read_run_and_event_from_pmaps_file
+from pytest import mark
 
-from invisible_cities.reco.pmaps_functions_c import (
-    df_to_pmaps_dict, df_to_s2si_dict)
+from .. core.system_of_units_c import units
+from .. database               import load_db
+from .. sierpe                 import blr
 
-from invisible_cities.reco.params import (
-    S12Params as S12P, ThresholdParams, CalibratedSum, PMaps)
+from .                         import tbl_functions    as tbl
+from .                         import peak_functions   as pf
+from .                         import peak_functions_c as cpf
 
-from pytest import mark, fixture
+from . params                  import S12Params        as S12P
+from . params                  import ThresholdParams
+from . params                  import PMaps
+
+from . pmap_io                 import pmap_writer
+from . pmap_io                 import S12
+from . pmap_io                 import S2Si
+
+from . pmaps_functions         import read_pmaps
+from . pmaps_functions         import read_run_and_event_from_pmaps_file
+from . pmaps_functions_c       import df_to_pmaps_dict
+from . pmaps_functions_c       import df_to_s2si_dict
 
 
 @mark.parametrize(  'filename,            with_',

--- a/invisible_cities/reco/pmaps_functions.py
+++ b/invisible_cities/reco/pmaps_functions.py
@@ -2,15 +2,20 @@
 JJGC December 2016
 
 """
-import numpy as np
+import numpy  as np
 import pandas as pd
 import tables as tb
 import matplotlib.pyplot as plt
-from   invisible_cities.reco.pmaps_functions_c import df_to_pmaps_dict, df_to_s2si_dict
-import invisible_cities.core.core_functions as cf
-from   invisible_cities.database import load_db
-from   invisible_cities.core.mpl_functions import circles, set_plot_labels
-from   invisible_cities.core.system_of_units_c import units
+
+from .. core.mpl_functions     import circles
+from .. core.mpl_functions     import set_plot_labels
+from .. core.system_of_units_c import units
+
+from .. database               import load_db
+
+from .  pmaps_functions_c      import df_to_pmaps_dict
+from .  pmaps_functions_c      import df_to_s2si_dict
+
 
 def load_pmaps(PMP_file_name):
     """Read the PMAP file and return transient PMAP rep."""

--- a/invisible_cities/reco/pmaps_functions_c.pyx
+++ b/invisible_cities/reco/pmaps_functions_c.pyx
@@ -6,8 +6,9 @@ JJGC December, 2016
 cimport numpy as np
 import  numpy as np
 
-from invisible_cities.reco.params import Peak
-from invisible_cities.reco.pmap_io import S12, S2Si
+from . params  import Peak
+from . pmap_io import S12
+from . pmap_io import S2Si
 
 
 cpdef df_to_pmaps_dict(df, max_events=None):

--- a/invisible_cities/reco/pmaps_functions_test.py
+++ b/invisible_cities/reco/pmaps_functions_test.py
@@ -1,12 +1,16 @@
 from operator import itemgetter
-import numpy as np
-from pytest import mark
 
+import numpy as np
+
+
+from pytest import mark
 parametrize = mark.parametrize
 
-import invisible_cities.reco.pmaps_functions as pmapf
-import invisible_cities.core.system_of_units as units
-from invisible_cities.reco.pmaps_functions import df_to_pmaps_dict, df_to_s2si_dict
+from .. core           import system_of_units as units
+
+from .                 import pmaps_functions as pmapf
+from . pmaps_functions import df_to_pmaps_dict
+from . pmaps_functions import df_to_s2si_dict
 
 
 def test_integrate_charge():

--- a/invisible_cities/reco/wfm_functions.py
+++ b/invisible_cities/reco/wfm_functions.py
@@ -4,12 +4,13 @@ authors: J.J. Gomez-Cadenas, G. Martinez
 """
 
 import math
+
 import numpy as np
-import tables as tb
+
 import matplotlib.pyplot as plt
-from invisible_cities.core.core_functions import define_window
-from invisible_cities.database import load_db
-import invisible_cities.sierpe.blr as blr
+
+from .. core.core_functions import define_window
+from .. sierpe              import blr
 
 def to_adc(wfs, adc_to_pes):
     """

--- a/invisible_cities/reco/wfm_functions_test.py
+++ b/invisible_cities/reco/wfm_functions_test.py
@@ -1,17 +1,22 @@
 import os
-from os import path
-from hypothesis import given, assume
-from hypothesis.strategies import lists, integers, floats
-from hypothesis.extra.numpy import arrays
+from   os import path
+
+import numpy  as np
+import tables as tb
+
 from pytest import mark
 
-from . import wfm_functions as wfm
-import invisible_cities.reco.peak_functions_c as cpf
-import invisible_cities.reco.tbl_functions as tbl
-from   invisible_cities.reco.params import DeconvParams, CalibVectors
-from   invisible_cities.database import load_db
-import numpy as np
-import tables as tb
+from hypothesis             import given
+from hypothesis.strategies  import floats
+from hypothesis.extra.numpy import arrays
+
+from .. database import load_db
+
+from .        import peak_functions_c as cpf
+from .        import tbl_functions    as tbl
+from .        import wfm_functions    as wfm
+from . params import CalibVectors
+from . params import DeconvParams
 
 
 def ndarrays_of_shape(shape, lo=-1000.0, hi=1000.0):

--- a/invisible_cities/sierpe/fee.py
+++ b/invisible_cities/sierpe/fee.py
@@ -6,8 +6,9 @@ VH, JJGC, November, 2016
 
 import numpy as np
 from scipy import signal
-import invisible_cities.core.system_of_units as units
-import invisible_cities.database.load_db as DB
+
+from .. core     import system_of_units as units
+from .. database import load_db         as DB
 
 # globals describing FEE
 PMT_GAIN = 1.7e6

--- a/invisible_cities/sierpe/fee_test.py
+++ b/invisible_cities/sierpe/fee_test.py
@@ -1,13 +1,11 @@
-from math import sqrt
+import numpy as np
+
 import pytest
-from pytest import raises, mark
-from hypothesis import given
-from hypothesis.strategies import lists, floats
+
 from flaky import flaky
 
-import invisible_cities.sierpe.fee as FE
-import invisible_cities.core.system_of_units as units
-import numpy as np
+from .. core import system_of_units as units
+from .       import fee             as FE
 
 def signal_i_th():
     """Generates a "theoretical" current signal (signal_i)"""


### PR DESCRIPTION
The absolute imports we were using were very noisy. Replace them with
the much less tedious relative imports.

Whilst we're at it, we take the opportunity to:

+ Remove unused imports

+ Conform to PEP8's one import per line rule