### PR TITLE
Test speed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ install:
   - source manage.sh install ${IC_PYTHON_VERSION}
 
 script:
-  - HYPOTHESIS_PROFILE=hard bash manage.sh run_tests_par
+  - HYPOTHESIS_PROFILE=hard bash manage.sh run_tests_par 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ install:
   - source manage.sh install ${IC_PYTHON_VERSION}
 
 script:
-  - bash manage.sh run_tests_par
+  - HYPOTHESIS_PROFILE=hard bash manage.sh run_tests_par

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,11 @@
+import os
+
+from hypothesis import settings
+from hypothesis import Verbosity
+
+# In addition to the 'default' profile, we provide
+settings.register_profile("hard" , settings(max_examples=1000))
+settings.register_profile("dev"  , settings(max_examples=  10))
+settings.register_profile("debug", settings(max_examples=  10,
+                                               verbosity=Verbosity.verbose))
+settings.load_profile(os.getenv(u'HYPOTHESIS_PROFILE', 'dev'))

--- a/invisible_cities/cities/diomira_test.py
+++ b/invisible_cities/cities/diomira_test.py
@@ -177,6 +177,7 @@ def test_command_line_diomira(conf_file_name, config_tmpdir):
     nrequired, nactual = DIOMIRA(['DIOMIRA',
                                   '-c', conf_file_name,
                                   '-i', PATH_IN,
+                                  '-n', '2',
                                   '-o', PATH_OUT,
                                   '-f', str(start_evt),
                                   '-r', str(run_number)])

--- a/invisible_cities/cities/dorothea_test.py
+++ b/invisible_cities/cities/dorothea_test.py
@@ -22,7 +22,6 @@ def conf_file_name_mc(config_tmpdir):
     return conf_file_name
 
 
-@mark.slow
 def test_command_line_dorothea_KrMC(conf_file_name_mc, config_tmpdir, KrMC_pmaps):
     # NB: avoid taking defaults for PATH_IN and PATH_OUT
     # since they are in general test-specific

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -81,7 +81,7 @@ def test_command_line_irene_electrons_40keV(conf_file_name_mc, config_tmpdir, IC
                                    '-c', conf_file_name_mc,
                                    '-i', PATH_IN,
                                    '-o', PATH_OUT,
-                                   '-n', '3',
+                                   '-n', '2',
                                    '-r', '0'])
     if nrequired > 0:
         assert nrequired == nactual
@@ -172,7 +172,7 @@ def test_irene_output_file_structure(conf_file_name_data, config_tmpdir, ICDIR):
                                    '-c', conf_file_name_data,
                                    '-i', PATH_IN,
                                    '-o', PATH_OUT,
-                                   '-n', '3',
+                                   '-n', '2',
                                    '-r', '2983'])
 
     with tb.open_file(PATH_OUT) as h5out:

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -124,6 +124,7 @@ def test_command_line_irene_run_2983(conf_file_name_data, config_tmpdir, ICDIR):
     if nrequired > 0:
         assert nrequired == nactual
 
+@mark.slow # not slow itself, but depends on a slow test
 @mark.serial
 def test_command_line_irene_runinfo_run_2983(config_tmpdir, ICDIR):
     """Read back the file written by previous test. Check runinfo."""
@@ -159,6 +160,7 @@ def test_command_line_irene_runinfo_run_2983(config_tmpdir, ICDIR):
         assert rin == rout
 
 
+@mark.slow
 def test_irene_output_file_structure(conf_file_name_data, config_tmpdir, ICDIR):
     PATH_IN = os.path.join(ICDIR,
                            'database/test_data/',
@@ -202,7 +204,6 @@ def test_empty_events_issue_81(conf_file_name_mc, config_tmpdir, ICDIR):
     assert empty   == 1
 
 
-@mark.slow
 def test_irene_electrons_40keV_pmt_active_is_correctly_set(job_info_missing_pmts, config_tmpdir, ICDIR):
     """Run Irene. Write an output file."""
 

--- a/invisible_cities/cities/isidora_test.py
+++ b/invisible_cities/cities/isidora_test.py
@@ -46,6 +46,7 @@ def test_command_line_isidora(conf_file_name, config_tmpdir):
                                   '-c', conf_file_name,
                                   '-i', PATH_IN,
                                   '-o', PATH_OUT,
+                                  '-n', '2',
                                   '-r', '0'])
     if nrequired > 0:
         assert nrequired == nactual

--- a/invisible_cities/cities/paolina_test.py
+++ b/invisible_cities/cities/paolina_test.py
@@ -8,7 +8,6 @@ from pytest import mark
 parametrize = mark.parametrize
 
 from hypothesis            import given
-from hypothesis            import settings
 from hypothesis.strategies import lists
 from hypothesis.strategies import floats
 from hypothesis.strategies import builds
@@ -43,7 +42,6 @@ box_sizes = builds(np.array, lists(box_dimension,
 
 
 @given(bunch_of_hits)
-@settings(max_examples=40)
 def test_bounding_box(hits):
     if not len(hits): # TODO: deal with empty sequences
         return
@@ -68,7 +66,6 @@ def test_bounding_box(hits):
 
 
 @given(bunch_of_hits, box_sizes)
-@settings(max_examples=20)
 def test_voxelize_hits_does_not_lose_energy(hits, voxel_dimensions):
     voxels = voxelize_hits(hits, voxel_dimensions)
 
@@ -82,7 +79,6 @@ def test_voxelize_hits_does_not_lose_energy(hits, voxel_dimensions):
 
 
 @given(bunch_of_hits, box_sizes)
-@settings(max_examples=20)
 def test_voxelize_hits_keeps_bounding_box(hits, voxel_dimensions):
     voxels = voxelize_hits(hits, voxel_dimensions)
 
@@ -95,7 +91,6 @@ def test_voxelize_hits_keeps_bounding_box(hits, voxel_dimensions):
     assert (vlo <= hlo).all()
     assert (vhi >= hhi).all()
 
-@settings(max_examples=20)
 @given(bunch_of_hits, box_sizes)
 def test_make_voxel_graph_keeps_all_voxels(hits, voxel_dimensions):
     voxels = voxelize_hits    (hits  , voxel_dimensions)

--- a/invisible_cities/cities/paolina_test.py
+++ b/invisible_cities/cities/paolina_test.py
@@ -8,6 +8,7 @@ from pytest import mark
 parametrize = mark.parametrize
 
 from hypothesis            import given
+from hypothesis            import settings
 from hypothesis.strategies import lists
 from hypothesis.strategies import floats
 from hypothesis.strategies import builds
@@ -41,8 +42,8 @@ box_sizes = builds(np.array, lists(box_dimension,
                                    max_size = 3))
 
 
-@mark.slow
 @given(bunch_of_hits)
+@settings(max_examples=40)
 def test_bounding_box(hits):
     if not len(hits): # TODO: deal with empty sequences
         return
@@ -66,8 +67,8 @@ def test_bounding_box(hits):
         assert_almost_equal(maxs[d], hi[d])
 
 
-@mark.slow
 @given(bunch_of_hits, box_sizes)
+@settings(max_examples=20)
 def test_voxelize_hits_does_not_lose_energy(hits, voxel_dimensions):
     voxels = voxelize_hits(hits, voxel_dimensions)
 
@@ -80,8 +81,8 @@ def test_voxelize_hits_does_not_lose_energy(hits, voxel_dimensions):
     assert_almost_equal(sum_energy(hits), sum_energy(voxels))
 
 
-@mark.slow
 @given(bunch_of_hits, box_sizes)
+@settings(max_examples=20)
 def test_voxelize_hits_keeps_bounding_box(hits, voxel_dimensions):
     voxels = voxelize_hits(hits, voxel_dimensions)
 
@@ -94,7 +95,7 @@ def test_voxelize_hits_keeps_bounding_box(hits, voxel_dimensions):
     assert (vlo <= hlo).all()
     assert (vhi >= hhi).all()
 
-@mark.given
+@settings(max_examples=20)
 @given(bunch_of_hits, box_sizes)
 def test_make_voxel_graph_keeps_all_voxels(hits, voxel_dimensions):
     voxels = voxelize_hits    (hits  , voxel_dimensions)

--- a/invisible_cities/conftest.py
+++ b/invisible_cities/conftest.py
@@ -1,5 +1,6 @@
-import pytest
 import os
+import pytest
+
 
 @pytest.fixture(scope = 'session')
 def ICDIR():
@@ -114,5 +115,3 @@ def Kr_dst_data(ICDIR):
     df = DataFrame(data, columns = cols)
 
     return (ICDIR + "/database/test_data/Kr_dst.h5", "DST", "data"), df
-
-

--- a/invisible_cities/core/core_functions_test.py
+++ b/invisible_cities/core/core_functions_test.py
@@ -7,7 +7,6 @@ import numpy  as np
 import numpy.testing as npt
 
 from hypothesis            import given
-from hypothesis            import settings
 from hypothesis.strategies import integers
 from hypothesis.strategies import floats
 from hypothesis.strategies import sampled_from
@@ -50,7 +49,6 @@ def test_in_range_infinite(data):
 
 @given(random_length_float_arrays(mask = lambda x: ((x<-10) or
                                                (x>+10) )))
-@settings(max_examples=20)
 def test_in_range_with_hole(data):
     assert not core.in_range(data, -10, 10).any()
 
@@ -61,7 +59,6 @@ def test_in_range_positives():
 
 
 @given(random_length_float_arrays(max_length = 1000))
-@settings(max_examples=20)
 def test_in_range_right_shape(data):
     assert core.in_range(data, -1., 1.).shape == data.shape
 

--- a/invisible_cities/core/core_functions_test.py
+++ b/invisible_cities/core/core_functions_test.py
@@ -7,6 +7,7 @@ import numpy  as np
 import numpy.testing as npt
 
 from hypothesis            import given
+from hypothesis            import settings
 from hypothesis.strategies import integers
 from hypothesis.strategies import floats
 from hypothesis.strategies import sampled_from
@@ -48,7 +49,8 @@ def test_in_range_infinite(data):
 
 
 @given(random_length_float_arrays(mask = lambda x: ((x<-10) or
-                                                    (x>+10) )))
+                                               (x>+10) )))
+@settings(max_examples=20)
 def test_in_range_with_hole(data):
     assert not core.in_range(data, -10, 10).any()
 
@@ -59,6 +61,7 @@ def test_in_range_positives():
 
 
 @given(random_length_float_arrays(max_length = 1000))
+@settings(max_examples=20)
 def test_in_range_right_shape(data):
     assert core.in_range(data, -1., 1.).shape == data.shape
 

--- a/invisible_cities/core/core_functions_test.py
+++ b/invisible_cities/core/core_functions_test.py
@@ -20,7 +20,7 @@ from .           import core_functions as core
 def test_timefunc(capfd):
     # We run a function with a defined time duration (sleep) and we check
     # the decorator prints a correct measurement.
-    time = 1
+    time = 0.12
     result = core.timefunc(sleep)(time)
     out, err = capfd.readouterr()
     time_measured = re.search('\d+\.\d+', out).group(0)

--- a/invisible_cities/core/fit_functions_test.py
+++ b/invisible_cities/core/fit_functions_test.py
@@ -162,7 +162,6 @@ def test_fit_with_errors(reduced):
     assert_allclose(f.values, pars)
 
 
-@mark.slow
 @mark.parametrize(["func"],
                   ((fit.profileX,),
                    (fit.profileY,)))

--- a/invisible_cities/core/fit_functions_test.py
+++ b/invisible_cities/core/fit_functions_test.py
@@ -9,7 +9,6 @@ from numpy.testing import assert_array_equal
 from numpy.testing import assert_allclose
 
 from hypothesis            import given
-from hypothesis            import settings
 from hypothesis.strategies import integers
 from hypothesis.strategies import floats
 
@@ -30,7 +29,6 @@ def test_get_errors():
 
 @given(float_arrays(min_value=-10,
                     max_value=10))
-@settings(max_examples=20)
 def test_gauss_symmetry(data):
     assert_allclose(fit.gauss( data, 1., 0., 1.),
                     fit.gauss(-data, 1., 0., 1.))

--- a/invisible_cities/core/fit_functions_test.py
+++ b/invisible_cities/core/fit_functions_test.py
@@ -9,6 +9,7 @@ from numpy.testing import assert_array_equal
 from numpy.testing import assert_allclose
 
 from hypothesis            import given
+from hypothesis            import settings
 from hypothesis.strategies import integers
 from hypothesis.strategies import floats
 
@@ -29,8 +30,9 @@ def test_get_errors():
 
 @given(float_arrays(min_value=-10,
                     max_value=10))
+@settings(max_examples=20)
 def test_gauss_symmetry(data):
-    assert_allclose(fit.gauss(data, 1., 0., 1.),
+    assert_allclose(fit.gauss( data, 1., 0., 1.),
                     fit.gauss(-data, 1., 0., 1.))
 
 

--- a/invisible_cities/reco/test_xy_algorithms.py
+++ b/invisible_cities/reco/test_xy_algorithms.py
@@ -6,7 +6,6 @@ from pytest import raises
 parametrize = mark.parametrize
 
 from hypothesis             import given
-from hypothesis             import settings
 from hypothesis.strategies  import floats
 from hypothesis.strategies  import integers
 from hypothesis.strategies  import composite
@@ -33,7 +32,6 @@ def positions_and_qs(draw, min_value=0, max_value=100):
 
 
 @given(positions_and_qs(1))
-@settings(max_examples=20)
 def test_barycenter(p_q):
     pos, qs = p_q
     B  = barycenter(pos, qs)

--- a/invisible_cities/reco/test_xy_algorithms.py
+++ b/invisible_cities/reco/test_xy_algorithms.py
@@ -6,6 +6,7 @@ from pytest import raises
 parametrize = mark.parametrize
 
 from hypothesis             import given
+from hypothesis             import settings
 from hypothesis.strategies  import floats
 from hypothesis.strategies  import integers
 from hypothesis.strategies  import composite
@@ -30,7 +31,9 @@ def positions_and_qs(draw, min_value=0, max_value=100):
     qs   = draw(arrays(float, (size,  ), floats(0.1,1)))
     return pos, qs
 
+
 @given(positions_and_qs(1))
+@settings(max_examples=20)
 def test_barycenter(p_q):
     pos, qs = p_q
     B  = barycenter(pos, qs)


### PR DESCRIPTION
#227 suggests switching between hypothesis generation and numpy random number generation. The downsides of this are that it would require

+ Writing two generators for every test to which this applies

+ Having to invent a switching mechanism

This PR uses hypothesis profiles to change the number cases that are generated. The default profile that comes with hypothesis uses 200 cases. Here we add a `dev` profile which uses 10 cases (for speedy turnaround during development) and a `hard` profile which use 1000 cases and is used on Travis.

The profile can be chosen on the command line in two ways:

+ `pytest --hypothesis-profile <profile name>`
+ `HYPOTHESIS_PROFILE=<profile name> <general command>`

With our current test suite, we observe the following times

+ `dev`: 25s
+ `default`: 40s
+ `hard`: 90s 


Close #227.
