### PR TITLE
Corrections

### DIFF
--- a/invisible_cities/reco/corrections.py
+++ b/invisible_cities/reco/corrections.py
@@ -22,3 +22,7 @@ class XYCorrection:
 
     def E(self, x, y): return self._Enorm[(x,y)]
     def U(self, x, y): return self._Unorm[(x,y)]
+
+
+def FCorrection(E, z, fn, *args):
+    return E * fn(z, *args)

--- a/invisible_cities/reco/corrections.py
+++ b/invisible_cities/reco/corrections.py
@@ -3,19 +3,22 @@ import numpy as np
 
 class XYCorrection:
 
-    def __init__(self, xs, ys, E, U, strategy):
-        E_max = E.max()
-        dE = E / E_max if strategy else np.ones_like(E)
-        dN = U / E_max
+    def __init__(self, xs, ys, E, U, strategy, ni=None, nj=None):
+        if   strategy == 'max'  : E_ref = E.max()
+        elif strategy == 'index': E_ref = E[ni,nj]
+
+        dE = E / E_ref if strategy else np.ones_like(E)
+        dU = U / E_ref if strategy else np.ones_like(E)
+
         self._Enorm = { (x,y) : dE[i,j]
                         for i, x in enumerate(xs)
                         for j, y in enumerate(ys) }
 
-        self._Unorm = ({ (x,y) : dN[i,j]
+        self._Unorm = ({ (x,y) : dU[i,j]
                          for i, x in enumerate(xs)
                          for j, y in enumerate(ys) }
 
-                       if strategy else self._Enorm)
+                       if strategy is not None else self._Enorm)
 
     def E(self, x, y): return self._Enorm[(x,y)]
     def U(self, x, y): return self._Unorm[(x,y)]

--- a/invisible_cities/reco/corrections.py
+++ b/invisible_cities/reco/corrections.py
@@ -6,7 +6,10 @@ def Correction(xs, ys, E, _, strategy):
              for i, x in enumerate(xs)
              for j, y in enumerate(ys) }
 
-    def correct(x, y):
+    def correct_E(x, y):
         return norm[(x,y)]
 
-    return correct
+    def correct_U(x, y):
+        return norm[(x,y)]
+
+    return correct_E, correct_U

--- a/invisible_cities/reco/corrections.py
+++ b/invisible_cities/reco/corrections.py
@@ -1,15 +1,16 @@
 import numpy as np
 
-def Correction(xs, ys, E, _, strategy):
-    N = E / E.max() if strategy else np.ones_like(E)
-    norm = { (x,y) : N[i,j]
-             for i, x in enumerate(xs)
-             for j, y in enumerate(ys) }
 
-    def correct_E(x, y):
-        return norm[(x,y)]
+class Correction:
 
-    def correct_U(x, y):
-        return norm[(x,y)]
+    def __init__(self, xs, ys, E, _, strategy):
+        N = E / E.max() if strategy else np.ones_like(E)
+        self._norm = { (x,y) : N[i,j]
+                       for i, x in enumerate(xs)
+                       for j, y in enumerate(ys) }
 
-    return correct_E, correct_U
+    def E(self, x, y):
+        return self._norm[(x,y)]
+
+    def U(self, x, y):
+        return self._norm[(x,y)]

--- a/invisible_cities/reco/corrections.py
+++ b/invisible_cities/reco/corrections.py
@@ -1,0 +1,10 @@
+def Correction(xs, ys, E, _, __):
+    N = E / E.max()
+    norm = { (x,y) : N[i,j]
+             for i, x in enumerate(xs)
+             for j, y in enumerate(ys) }
+
+    def correct(x, y):
+        return norm[(x,y)]
+
+    return correct

--- a/invisible_cities/reco/corrections.py
+++ b/invisible_cities/reco/corrections.py
@@ -1,5 +1,7 @@
-def Correction(xs, ys, E, _, __):
-    N = E / E.max()
+import numpy as np
+
+def Correction(xs, ys, E, _, strategy):
+    N = E / E.max() if strategy else np.ones_like(E)
     norm = { (x,y) : N[i,j]
              for i, x in enumerate(xs)
              for j, y in enumerate(ys) }

--- a/invisible_cities/reco/corrections.py
+++ b/invisible_cities/reco/corrections.py
@@ -1,16 +1,21 @@
 import numpy as np
 
 
-class Correction:
+class XYCorrection:
 
-    def __init__(self, xs, ys, E, _, strategy):
-        N = E / E.max() if strategy else np.ones_like(E)
-        self._norm = { (x,y) : N[i,j]
-                       for i, x in enumerate(xs)
-                       for j, y in enumerate(ys) }
+    def __init__(self, xs, ys, E, U, strategy):
+        E_max = E.max()
+        dE = E / E_max if strategy else np.ones_like(E)
+        dN = U / E_max
+        self._Enorm = { (x,y) : dE[i,j]
+                        for i, x in enumerate(xs)
+                        for j, y in enumerate(ys) }
 
-    def E(self, x, y):
-        return self._norm[(x,y)]
+        self._Unorm = ({ (x,y) : dN[i,j]
+                         for i, x in enumerate(xs)
+                         for j, y in enumerate(ys) }
 
-    def U(self, x, y):
-        return self._norm[(x,y)]
+                       if strategy else self._Enorm)
+
+    def E(self, x, y): return self._Enorm[(x,y)]
+    def U(self, x, y): return self._Unorm[(x,y)]

--- a/invisible_cities/reco/corrections.py
+++ b/invisible_cities/reco/corrections.py
@@ -1,27 +1,15 @@
 import numpy as np
-
+from scipy.interpolate import interp2d
 
 class XYCorrection:
 
     def __init__(self, xs, ys, E, U, strategy, ni=None, nj=None):
-        if   strategy == 'max'  : E_ref = E.max()
-        elif strategy == 'index': E_ref = E[ni,nj]
+        Et, Ut = E.T, U.T
+        if   strategy == 'max'  : E_ref = Et.max()
+        elif strategy == 'index': E_ref = Et[nj,ni]
 
-        dE = E / E_ref if strategy else np.ones_like(E)
-        dU = U / E_ref if strategy else np.ones_like(E)
-
-        self._Enorm = { (x,y) : dE[i,j]
-                        for i, x in enumerate(xs)
-                        for j, y in enumerate(ys) }
-
-        self._Unorm = ({ (x,y) : dU[i,j]
-                         for i, x in enumerate(xs)
-                         for j, y in enumerate(ys) }
-
-                       if strategy is not None else self._Enorm)
-
-    def E(self, x, y): return self._Enorm[(x,y)]
-    def U(self, x, y): return self._Unorm[(x,y)]
+        self.E = interp2d(xs, ys, (Et / E_ref) if strategy else np.ones_like(Et))
+        self.U = interp2d(xs, ys, (Ut / E_ref) if strategy else np.ones_like(Et))
 
 
 def FCorrection(E, z, fn, *args):

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -9,34 +9,53 @@ from pytest import fixture
 from . corrections import Correction
 
 EnergyMap = namedtuple('EnergyMap',
-                       'E_max, E_00, x_0, y_0, x, y, E')
+                       'E, U, E_max, U_max, E_00, U_01, x_0, y_0, y_1, x, y')
 
 @fixture(scope='session')
 def toy_energy_map():
     E_max = 120
+    U_max =   6
     E_00  =  30
+    U_01  =   5
     x_0   =  10.1
     y_0   =  20.3
+    y_1   =  10.2
     x = np.array([x_0, 20.7])
-    y = np.array([y_0, 10.2, 10.3])
+    y = np.array([y_0, y_1, 10.3])
     E = np.array([[E_00,  40,  60],
                   [  80,  90, E_max]])
-    return EnergyMap(E_max, E_00, x_0, y_0, x, y, E)
+    U = np.array([[   3 ,U_01,  12],
+                  [   4,   9, U_max]])
 
+    return EnergyMap(E      = E,
+                     U      = U,
+                     E_max  = E_max,
+                     U_max  = U_max,
+                     E_00   = E_00,
+                     U_01   = U_01,
+                     x_0    = x_0,
+                     y_0    = y_0,
+                     y_1    = y_1,
+                     x      = x,
+                     y      = y)
 
 
 def test_energy_correction_max(toy_energy_map):
     m = toy_energy_map
-    U = np.ones_like(m.E)
-    correct = Correction(m.x, m.y, m.E, U, 'max')
-    correction = m.E_00 / m.E_max
-    assert_allclose(correct(m.x_0, m.y_0), correction)
+    correct_energy, _ = Correction(m.x, m.y, m.E, m.U, 'max')
+    CORRECTION = m.E_00 / m.E_max
+    assert_allclose(correct_energy(m.x_0, m.y_0), CORRECTION)
 
 
 def test_energy_correction_None(toy_energy_map):
     m = toy_energy_map
-    U = np.ones_like(m.E)
-    correct = Correction(m.x, m.y, m.E, U, None)
-    correction = m.E_00 / m.E_max
+    correct_energy, _ = Correction(m.x, m.y, m.E, m.U, None)
     NO_CORRECTION = 1
-    assert_allclose(correct(m.x_0, m.y_0), NO_CORRECTION)
+    assert_allclose(correct_energy(m.x_0, m.y_0), NO_CORRECTION)
+
+
+def test_energy_uncertainty_correction_None(toy_energy_map):
+    m = toy_energy_map
+    _, correct_uncertainty = Correction(m.x, m.y, m.E, m.U, None)
+    NO_CORRECTION = 1
+    assert_allclose(correct_uncertainty(m.x_0, m.y_1), NO_CORRECTION)

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -13,6 +13,7 @@ from hypothesis.strategies  import composite
 from hypothesis.extra.numpy import arrays
 
 from . corrections import XYCorrection
+from . corrections import  FCorrection
 
 EField = namedtuple('EField', 'i,j, x,y, E, U, ni,nj')
 
@@ -88,3 +89,11 @@ def test_energy_uncertainty_correction_None(data):
     correct = XYCorrection(x, y, E, U, None)
     NO_CORRECTION = 1
     assert_allclose(correct.U(x[i], y[j]), NO_CORRECTION)
+
+
+@given(z  = floats(min_value=500, max_value= 2000),
+       mu = floats(min_value=100, max_value=10000),
+       E  = floats(min_value= 40, max_value= 2500))
+def test_z_correction(z, mu, E):
+    corrected_E = FCorrection(E, z, lambda z,mu:np.exp(-z/mu), mu)
+    assert corrected_E == E * np.exp(-z/mu)

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -1,10 +1,18 @@
+from collections import namedtuple
+
 import numpy as np
 
 from numpy.testing import assert_allclose
 
+from pytest import fixture
+
 from . corrections import Correction
 
-def test_correction():
+EnergyMap = namedtuple('EnergyMap',
+                       'E_max, E_00, x_0, y_0, x, y, E')
+
+@fixture(scope='session')
+def toy_energy_map():
     E_max = 120
     E_00  =  30
     x_0   =  10.1
@@ -13,10 +21,22 @@ def test_correction():
     y = np.array([y_0, 10.2, 10.3])
     E = np.array([[E_00,  40,  60],
                   [  80,  90, E_max]])
+    return EnergyMap(E_max, E_00, x_0, y_0, x, y, E)
 
-    U = np.ones_like(E)
 
-    correct = Correction(x, y, E, U, 'max')
 
-    correction = E_00 / E_max
-    assert_allclose(correct(x_0, y_0), correction)
+def test_energy_correction_max(toy_energy_map):
+    m = toy_energy_map
+    U = np.ones_like(m.E)
+    correct = Correction(m.x, m.y, m.E, U, 'max')
+    correction = m.E_00 / m.E_max
+    assert_allclose(correct(m.x_0, m.y_0), correction)
+
+
+def test_energy_correction_None(toy_energy_map):
+    m = toy_energy_map
+    U = np.ones_like(m.E)
+    correct = Correction(m.x, m.y, m.E, U, None)
+    correction = m.E_00 / m.E_max
+    NO_CORRECTION = 1
+    assert_allclose(correct(m.x_0, m.y_0), NO_CORRECTION)

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+from numpy.testing import assert_allclose
+
+from . corrections import Correction
+
+def test_correction():
+    E_max = 120
+    E_00  =  30
+    x_0   =  10.1
+    y_0   =  20.3
+    x = np.array([x_0, 20.7])
+    y = np.array([y_0, 10.2, 10.3])
+    E = np.array([[E_00,  40,  60],
+                  [  80,  90, E_max]])
+
+    U = np.ones_like(E)
+
+    correct = Correction(x, y, E, U, 'max')
+
+    correction = E_00 / E_max
+    assert_allclose(correct(x_0, y_0), correction)

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -97,3 +97,25 @@ def test_energy_uncertainty_correction_None(data):
 def test_z_correction(z, mu, E):
     corrected_E = FCorrection(E, z, lambda z,mu:np.exp(-z/mu), mu)
     assert corrected_E == E * np.exp(-z/mu)
+
+
+def test_interpolation():
+    x = np.array([0.1, 0.2])
+    y = np.array([0.1, 0.2])
+    E = np.array([[12,   8],
+                  [ 6,   4]])
+    correct = XYCorrection(x, y, E, E, 'max')
+    av = np.average
+    # On the points in E
+    assert_allclose(correct.E(0.1 , 0.1 ),       12     / 12)
+    assert_allclose(correct.E(0.2 , 0.1 ),        6     / 12)
+    assert_allclose(correct.E(0.1 , 0.2 ),        8     / 12)
+    assert_allclose(correct.E(0.2 , 0.2 ),        4     / 12)
+    # Interpolation between the points in E
+    assert_allclose(correct.E(0.15, 0.1 ),  av([12, 6]) / 12)
+    assert_allclose(correct.E(0.1 , 0.15),  av([12, 8]) / 12)
+    assert_allclose(correct.E(0.15, 0.2 ),  av([ 8, 4]) / 12)
+    assert_allclose(correct.E(0.2 , 0.15),  av([ 6, 4]) / 12)
+
+    assert_allclose(correct.E(0.15, 0.15),  av([12,  8,
+                                                 6, 4]) / 12)

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -42,20 +42,20 @@ def toy_energy_map():
 
 def test_energy_correction_max(toy_energy_map):
     m = toy_energy_map
-    correct_energy, _ = Correction(m.x, m.y, m.E, m.U, 'max')
+    correct = Correction(m.x, m.y, m.E, m.U, 'max')
     CORRECTION = m.E_00 / m.E_max
-    assert_allclose(correct_energy(m.x_0, m.y_0), CORRECTION)
+    assert_allclose(correct.E(m.x_0, m.y_0), CORRECTION)
 
 
 def test_energy_correction_None(toy_energy_map):
     m = toy_energy_map
-    correct_energy, _ = Correction(m.x, m.y, m.E, m.U, None)
+    correct = Correction(m.x, m.y, m.E, m.U, None)
     NO_CORRECTION = 1
-    assert_allclose(correct_energy(m.x_0, m.y_0), NO_CORRECTION)
+    assert_allclose(correct.E(m.x_0, m.y_0), NO_CORRECTION)
 
 
 def test_energy_uncertainty_correction_None(toy_energy_map):
     m = toy_energy_map
-    _, correct_uncertainty = Correction(m.x, m.y, m.E, m.U, None)
+    correct = Correction(m.x, m.y, m.E, m.U, None)
     NO_CORRECTION = 1
-    assert_allclose(correct_uncertainty(m.x_0, m.y_1), NO_CORRECTION)
+    assert_allclose(correct.U(m.x_0, m.y_1), NO_CORRECTION)


### PR DESCRIPTION
We propose a simple alternative to the Correction class suggested in #212.

The advantages of this proposal are:

+ Simple and legible implementaiton.
+ Simple and legible tests.
+ Generalizes the `centre` strategy to `index`.
+ Considers only x-y corrections, which are the ones really relevant for matrix corrections.
+ It defines a simple wrapper `FCorrection` with a tests which documents its application for the z-corrections associated with exponential attachment.

@gonzaponte should review this.
