### PR TITLE
Add hypothesis profile: noshrink

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,8 +4,10 @@ from hypothesis import settings
 from hypothesis import Verbosity
 
 # In addition to the 'default' profile, we provide
-settings.register_profile("hard" , settings(max_examples=1000))
-settings.register_profile("dev"  , settings(max_examples=  10))
-settings.register_profile("debug", settings(max_examples=  10,
-                                               verbosity=Verbosity.verbose))
+settings.register_profile("hard"     , settings(max_examples = 1000))
+settings.register_profile("dev"      , settings(max_examples =   10))
+settings.register_profile("noshrink" , settings(max_examples =   10,
+                                                max_shrinks  =    0))
+settings.register_profile("debug"    , settings(max_examples =   10,
+                                                verbosity=Verbosity.verbose))
 settings.load_profile(os.getenv(u'HYPOTHESIS_PROFILE', 'dev'))


### PR DESCRIPTION
When hypothesis needs to generate complex examples, the generation may
take some considerable time. If the test fails, the shrinking process
generates many more examples of similar complexity in the attempt to
find the simplest case. In IC we have observed wait times of over a
minute!

If, at the end of this process, we get some useful information, then
the wait is worthwhile. If the information we get at the end of the
shrink is that we made a typo in the source code, then the wait was a
complete waste of time.

The `noshrink` profile switches off the shrinking process completely,
by setting `max_shrinks` to zero.

To use it:

    pytest --hypothesis-profile noshrink