### PR TITLE
Penthesilea

### DIFF
--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -31,6 +31,7 @@ from ..io.dst_io          import KrEvent
 from ..reco               import peak_functions_c as cpf
 from ..reco               import peak_functions   as pf
 from ..reco               import pmaps_functions  as pmp
+from ..reco               import dst_functions    as dstf
 from ..reco               import tbl_functions    as tbf
 from ..reco               import wfm_functions    as wfm
 from ..reco.params        import SensorParams
@@ -533,7 +534,7 @@ class HitCollectionCity(City):
                  lifetime         = None,
                  reco_algorithm   = barycenter):
 
-        super().__init__(self,
+        City.__init__(self,
                          run_number  = run_number,
                          files_in    = files_in,
                          file_out    = file_out,

--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -529,9 +529,6 @@ class HitCollectionCity(City):
                  nprint      = 10000,
                  # Parameters added at this level
                  rebin            = 1,
-                  z_corr_filename = None,
-                 xy_corr_filename = None,
-                 lifetime         = None,
                  reco_algorithm   = barycenter):
 
         City.__init__(self,
@@ -542,11 +539,6 @@ class HitCollectionCity(City):
                          nprint      = nprint)
 
         self.rebin          = rebin
-        self. z_corr        = (LifetimeCorrection(lifetime)
-                               if lifetime else
-                               dstf.load_z_corrections(z_corr_filename))
-
-        self.xy_corr        = dstf.load_xy_corrections(xy_corr_filename)
         self.reco_algorithm = reco_algorithm
 
     def rebin_s2(self, S2, Si):
@@ -567,11 +559,6 @@ class HitCollectionCity(City):
         qs = np.array([c.Q for c in clusters])
         return e * qs / np.sum(qs)
 
-    def correct_energy(self, e, x, y, z):
-        ecorr = e * self.z_corr([z])[0][0]
-        if not np.isnan([x, y]).any():
-            ecorr *= self.xy_corr([x], [y])[0][0]
-        return ecorr
 
     def compute_xy_position(self, si, slice_no):
         si      = pmp.select_si_slice(si, slice_no)

--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -481,58 +481,6 @@ class PmapCity(CalibratedCity):
             raise IOError('must set S1/S2 parameters before running')
 
 
-    def select_event(self, evt_number, evt_time, S1, S2, Si):
-        evt       = KrEvent()
-        evt.event = evt_number
-        evt.time  = evt_time * 1e-3 # s
-
-        from .. filters.s1s2_filter import s1s2_filter
-        if not s1s2_filter(S1, S2, Si):
-            return
-
-        evt.nS1 = len(S1)
-        for peak_no, (t, e) in sorted(S1.items()):
-            evt.S1w.append(pmp.width(t))
-            evt.S1h.append(np.max(e))
-            evt.S1e.append(np.sum(e))
-            evt.S1t.append(t[np.argmax(e)])
-
-        evt.nS2 = len(S2)
-        for peak_no, (t, e) in sorted(S2.items()):
-            s2time  = t[np.argmax(e)]
-
-            evt.S2w.append(pmp.width(t, to_mus=True))
-            evt.S2h.append(np.max(e))
-            evt.S2e.append(np.sum(e))
-            evt.S2t.append(s2time)
-
-            IDs, Qs = pmp.integrate_charge(Si[peak_no])
-            xsipms  = self.xs[IDs]
-            ysipms  = self.ys[IDs]
-            x       = np.average(xsipms, weights=Qs)
-            y       = np.average(ysipms, weights=Qs)
-            q       = np.sum    (Qs)
-
-            evt.Nsipm.append(len(IDs))
-            evt.S2q  .append(q)
-
-            evt.X    .append(x)
-            evt.Y    .append(y)
-
-            evt.Xrms .append((np.sum(Qs * (xsipms-x)**2) / (q - 1))**0.5)
-            evt.Yrms .append((np.sum(Qs * (ysipms-y)**2) / (q - 1))**0.5)
-
-            evt.R    .append((x**2 + y**2)**0.5)
-            evt.Phi  .append(np.arctan2(y, x))
-
-            dt  = s2time - evt.S1t[0] if len(evt.S1t) > 0 else -1e3
-            dt *= units.ns / units.mus
-            evt.DT   .append(dt)
-            evt.Z    .append(dt * units.mus * self.drift_v)
-
-        return evt
-
-
 class MapCity(City):
     def __init__(self,
                  lifetime           ,

--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -573,21 +573,33 @@ class MapCity(City):
 
 class HitCollectionCity(City):
     def __init__(self,
+                 run_number  = 0,
+                 files_in    = None,
+                 file_out    = None,
+                 compression = 'ZLIB4',
+                 nprint      = 10000,
+                 # Parameters added at this level
                  rebin            = 1,
                   z_corr_filename = None,
                  xy_corr_filename = None,
                  lifetime         = None,
                  reco_algorithm   = barycenter):
 
+        super().__init__(self,
+                         run_number  = run_number,
+                         files_in    = files_in,
+                         file_out    = file_out,
+                         compression = compression,
+                         nprint      = nprint)
+
         self.rebin          = rebin
-        self. z_corr        = LifetimeCorrection(lifetime)\
-                              if lifetime else\
-                              dstf.load_z_corrections(z_corr_filename)
+        self. z_corr        = (LifetimeCorrection(lifetime)
+                               if lifetime else
+                               dstf.load_z_corrections(z_corr_filename))
 
         self.xy_corr        = dstf.load_xy_corrections(xy_corr_filename)
         self.reco_algorithm = reco_algorithm
 
-    # TODO: remove from here
     def rebin_s2(self, S2, Si):
         if self.rebin <= 1:
             return S2, Si

--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -559,12 +559,11 @@ class HitCollectionCity(City):
         qs = np.array([c.Q for c in clusters])
         return e * qs / np.sum(qs)
 
-
     def compute_xy_position(self, si, slice_no):
-        si      = pmp.select_si_slice(si, slice_no)
-        IDs, Qs = map(list, zip(*si.items()))
-        xs, ys  = self.xs[IDs], self.ys[IDs]
-        return self.reco_algorithm(np.stack((xs, ys)), Qs)
+        si_slice = pmp.select_si_slice(si, slice_no)
+        IDs, Qs  = pmp.integrate_sipm_charges_in_peak(si)
+        xs, ys   = self.xs[IDs], self.ys[IDs]
+        return self.reco_algorithm(np.stack((xs, ys)).T, Qs)
 
     def select_event(self, evt_number, evt_time, S1, S2, Si):
         hitc = HitCollection()

--- a/invisible_cities/cities/command_line_execution_test.py
+++ b/invisible_cities/cities/command_line_execution_test.py
@@ -9,7 +9,7 @@ from pytest import mark
 
 @mark.slow
 @mark.parametrize('city',
-                  'diomira isidora irene dorothea zaira cecilia'.split())
+                  'diomira isidora irene dorothea zaira cecilia penthesilea'.split())
 def test_command_line_run(city, tmpdir_factory):
     ICTDIR = getenv('ICTDIR')
     # Use the example config file included in the repository

--- a/invisible_cities/cities/dorothea.py
+++ b/invisible_cities/cities/dorothea.py
@@ -10,7 +10,7 @@ from .. core.configure         import configure
 from .. core.system_of_units_c import units
 
 from .. io.dst_io              import kr_writer
-from .. io.dst_io              import KrEvent
+from .. io.dst_io              import PersistentKrEvent
 
 from .. reco                   import tbl_functions as tbl
 from .. reco                   import pmaps_functions  as pmp
@@ -145,7 +145,7 @@ class Dorothea(City):
         return nevt_in, nevt_out, max_events_reached
 
     def _create_kr_event(self, evt_number, evt_time, S1, S2, Si):
-        evt       = KrEvent()
+        evt       = PersistentKrEvent()
         evt.event = evt_number
         evt.time  = evt_time * 1e-3 # s
 

--- a/invisible_cities/cities/dorothea.py
+++ b/invisible_cities/cities/dorothea.py
@@ -165,7 +165,7 @@ class Dorothea(City):
             evt.S2e.append(np.sum(e))
             evt.S2t.append(s2time)
 
-            IDs, Qs = pmp.integrate_charge(Si[peak_no])
+            IDs, Qs = pmp.integrate_charges(Si[peak_no])
             xsipms  = self.xs[IDs]
             ysipms  = self.ys[IDs]
             x       = np.average(xsipms, weights=Qs)

--- a/invisible_cities/cities/dorothea.py
+++ b/invisible_cities/cities/dorothea.py
@@ -12,8 +12,8 @@ from .. core.system_of_units_c import units
 from .. io.dst_io              import kr_writer
 from .. io.dst_io              import PersistentKrEvent
 
-from .. reco                   import tbl_functions as tbl
-from .. reco                   import pmaps_functions  as pmp
+from .. reco                   import tbl_functions   as tbl
+from .. reco                   import pmaps_functions as pmp
 from .. reco.pmaps_functions   import load_pmaps
 from .. reco.tbl_functions     import get_event_numbers_and_timestamps_from_file_name
 

--- a/invisible_cities/cities/dorothea.py
+++ b/invisible_cities/cities/dorothea.py
@@ -165,7 +165,7 @@ class Dorothea(City):
             evt.S2e.append(np.sum(e))
             evt.S2t.append(s2time)
 
-            IDs, Qs = pmp.integrate_charges(Si[peak_no])
+            IDs, Qs = pmp.integrate_sipm_charges_in_peak(Si[peak_no])
             xsipms  = self.xs[IDs]
             ysipms  = self.ys[IDs]
             x       = np.average(xsipms, weights=Qs)

--- a/invisible_cities/cities/penthesilea.py
+++ b/invisible_cities/cities/penthesilea.py
@@ -9,7 +9,7 @@ import tables as tb
 
 from ..core.configure         import configure
 from ..core.system_of_units_c import units
-from ..reco.dst_io            import HitCollection_writer
+from ..io.dst_io              import hits_writer
 from ..cities.base_cities     import City
 from ..cities.base_cities     import S12SelectorCity
 from ..cities.base_cities     import HitCollectionCity

--- a/invisible_cities/cities/penthesilea.py
+++ b/invisible_cities/cities/penthesilea.py
@@ -59,14 +59,14 @@ class Penthesilea(HitCollectionCity):
                  lifetime         = None,
                  reco_algorithm   = barycenter):
 
-        super().__init__(self,
+        HitCollectionCity.__init__(self,
                          run_number       = run_number,
                          files_in         = files_in,
                          file_out         = file_out,
                          compression      = compression,
                          nprint           = nprint,
                          rebin            = rebin,
-                         z_corr_filename =  z_corr_filename,
+                         z_corr_filename  = z_corr_filename,
                          xy_corr_filename = xy_corr_filename,
                          lifetime         = lifetime,
                          reco_algorithm   = reco_algorithm)

--- a/invisible_cities/cities/penthesilea.py
+++ b/invisible_cities/cities/penthesilea.py
@@ -234,13 +234,8 @@ def PENTHESILEA(argv = sys.argv):
     t0 = time.time()
     nevts = CFP.NEVENTS if not CFP.RUN_ALL else -1
 
-    nevt_in, nevt_out, ratio = penthesilea.run(nmax = nevts)
+    nevt_in, nevt_out = penthesilea.run(nmax = nevts)
     t1 = time.time()
     dt = t1 - t0
 
     print("run {} evts in {} s, time/event = {}".format(nevt_in, dt, dt/nevt_in))
-
-    return nevts, nevt_in, nevt_out
-
-if __name__ == "__main__":
-    PENTHESILEA(sys.argv)

--- a/invisible_cities/cities/penthesilea.py
+++ b/invisible_cities/cities/penthesilea.py
@@ -1,0 +1,199 @@
+import sys
+import glob
+import time
+import textwrap
+
+import numpy  as np
+import tables as tb
+
+
+from ..core.configure         import configure
+from ..core.system_of_units_c import units
+from ..reco.dst_io            import HitCollection_writer
+from ..cities.base_cities     import City
+from ..cities.base_cities     import S12SelectorCity
+from ..cities.base_cities     import HitCollectionCity
+from ..reco.tbl_functions     import get_event_numbers_and_timestamps
+from ..reco.pmaps_functions   import load_pmaps
+from ..reco.xy_algorithms     import barycenter
+from ..reco.xy_algorithms     import find_algorithm
+
+
+class Penthesilea(HitCollectionCity):
+    def __init__(self,
+                 run_number       = 0,
+                 files_in         = None,
+                 file_out         = None,
+                 compression      = "ZLIB4",
+                 nprint           = 10000,
+
+                 drift_v          = 1 * units.mm/units.mus,
+
+                 S1_Emin          = 0,
+                 S1_Emax          = np.inf,
+                 S1_Lmin          = 0,
+                 S1_Lmax          = np.inf,
+                 S1_Hmin          = 0,
+                 S1_Hmax          = np.inf,
+                 S1_Ethr          = 0,
+
+                 S2_Nmin          = 1,
+                 S2_Nmax          = 1000,
+                 S2_Emin          = 0,
+                 S2_Emax          = np.inf,
+                 S2_Lmin          = 0,
+                 S2_Lmax          = np.inf,
+                 S2_Hmin          = 0,
+                 S2_Hmax          = np.inf,
+                 S2_NSIPMmin      = 1,
+                 S2_NSIPMmax      = np.inf,
+                 S2_Ethr          = 0,
+
+                 rebin            = 1,
+                  z_corr_filename = None,
+                 xy_corr_filename = None,
+                 lifetime         = None,
+                 reco_algorithm   = barycenter):
+
+        City             .__init__(self,
+                                   run_number       = run_number,
+                                   files_in         = files_in,
+                                   file_out         = file_out,
+                                   compression      = compression,
+                                   nprint           = nprint)
+
+        S12SelectorCity  .__init__(self,
+                                   drift_v          = drift_v,
+
+                                   S1_Emin          = S1_Emin,
+                                   S1_Emax          = S1_Emax,
+                                   S1_Lmin          = S1_Lmin,
+                                   S1_Lmax          = S1_Lmax,
+                                   S1_Hmin          = S1_Hmin,
+                                   S1_Hmax          = S1_Hmax,
+                                   S1_Ethr          = S1_Ethr,
+
+                                   S2_Nmin          = S2_Nmin,
+                                   S2_Nmax          = S2_Nmax,
+                                   S2_Emin          = S2_Emin,
+                                   S2_Emax          = S2_Emax,
+                                   S2_Lmin          = S2_Lmin,
+                                   S2_Lmax          = S2_Lmax,
+                                   S2_Hmin          = S2_Hmin,
+                                   S2_Hmax          = S2_Hmax,
+                                   S2_NSIPMmin      = S2_NSIPMmin,
+                                   S2_NSIPMmax      = S2_NSIPMmax,
+                                   S2_Ethr          = S2_Ethr)
+
+
+        HitCollectionCity.__init__(self,
+                                   rebin            = rebin,
+                                    z_corr_filename =  z_corr_filename,
+                                   xy_corr_filename = xy_corr_filename,
+                                   lifetime         = lifetime,
+                                   reco_algorithm   = reco_algorithm)
+
+    def run(self, max_evt = -1):
+        nevt_in = nevt_out = 0
+
+        with HitCollection_writer(self.output_file, "DST", "w",
+                                  self.compression, "Tracks") as write:
+
+            exit_file_loop = False
+            for filename in self.input_files:
+                print("Reading {}".format(filename), end="... ")
+
+                try:
+                    S1s, S2s, S2Sis = load_pmaps(filename)
+                except (ValueError, tb.exceptions.NoSuchNodeError):
+                    print("Empty file. Skipping.")
+                    continue
+
+                event_numbers, timestamps = get_event_numbers_and_timestamps(filename)
+                for evt_number, evt_time in zip(event_numbers, timestamps):
+                    nevt_in +=1
+
+                    S1 = S1s  .get(evt_number, {})
+                    S2 = S2s  .get(evt_number, {})
+                    Si = S2Sis.get(evt_number, {})
+
+                    evt = self.select_event(evt_number, evt_time, S1, S2, Si)
+
+                    if evt:
+                        nevt_out += 1
+                        write(evt)
+
+                    if not nevt_in % self.nprint:
+                        print("{} evts analyzed".format(nevt_in))
+
+                    if -1 < max_evt < nevt_in:
+                        exit_file_loop = True
+                        break
+
+                print("OK")
+                if exit_file_loop:
+                    break
+
+
+        print(textwrap.dedent("""
+                              Number of events in : {}
+                              Number of events out: {}
+                              Ratio               : {}
+                              """.format(nevt_in, nevt_out, nevt_out/nevt_in)))
+        return nevt_in, nevt_out, nevt_in/nevt_out
+
+
+def PENTHESILEA(argv = sys.argv):
+    """Penthesilea DRIVER"""
+
+    # get parameters dictionary
+    CFP = configure(argv)
+
+    #class instance
+    penthesilea = Penthesilea(run_number       = CFP.RUN_NUMBER,
+                              files_in         = sorted(glob.glob(CFP.FILE_IN)),
+                              file_out         = CFP.FILE_OUT,
+                              compression      = CFP.COMPRESSION,
+                              nprint           = CFP.NPRINT,
+
+                              drift_v          = CFP.DRIFT_V * units.mm/units.mus,
+
+                              S1_Emin          = CFP.S1_EMIN * units.pes,
+                              S1_Emax          = CFP.S1_EMAX * units.pes,
+                              S1_Lmin          = CFP.S1_LMIN,
+                              S1_Lmax          = CFP.S1_LMAX,
+                              S1_Hmin          = CFP.S1_HMIN * units.pes,
+                              S1_Hmax          = CFP.S1_HMAX * units.pes,
+                              S1_Ethr          = CFP.S1_ETHR * units.pes,
+
+                              S2_Nmin          = CFP.S2_NMIN,
+                              S2_Nmax          = CFP.S2_NMAX,
+                              S2_Emin          = CFP.S2_EMIN * units.pes,
+                              S2_Emax          = CFP.S2_EMAX * units.pes,
+                              S2_Lmin          = CFP.S2_LMIN,
+                              S2_Lmax          = CFP.S2_LMAX,
+                              S2_Hmin          = CFP.S2_HMIN * units.pes,
+                              S2_Hmax          = CFP.S2_HMAX * units.pes,
+                              S2_NSIPMmin      = CFP.S2_NSIPMMIN,
+                              S2_NSIPMmax      = CFP.S2_NSIPMMAX,
+                              S2_Ethr          = CFP.S2_ETHR * units.pes,
+
+                              rebin            = CFP.REBIN if "REBIN" in CFP else 1,
+                               z_corr_filename = CFP. Z_CORR_FILENAME if "Z_CORR_FILENAME" in CFP else None,
+                              xy_corr_filename = CFP.XY_CORR_FILENAME,
+                              lifetime         = CFP.LIFETIME if "LIFETIME" in CFP else None,
+                              reco_algorithm   = find_algorithm(CFP.RECO_ALGORITHM))
+
+    t0 = time.time()
+    nevts = CFP.NEVENTS if not CFP.RUN_ALL else -1
+
+    nevt_in, nevt_out, ratio = penthesilea.run(max_evt = nevts)
+    t1 = time.time()
+    dt = t1 - t0
+
+    print("run {} evts in {} s, time/event = {}".format(nevt_in, dt, dt/nevt_in))
+
+    return nevts, nevt_in, nevt_out
+
+if __name__ == "__main__":
+    PENTHESILEA(sys.argv)

--- a/invisible_cities/cities/penthesilea.py
+++ b/invisible_cities/cities/penthesilea.py
@@ -6,21 +6,19 @@ import textwrap
 import numpy  as np
 import tables as tb
 
-
 from ..core.configure         import configure
 from ..core.system_of_units_c import units
 from ..io.dst_io              import hits_writer
 from ..cities.base_cities     import City
-from ..cities.base_cities     import S12SelectorCity
 from ..cities.base_cities     import HitCollectionCity
-from ..reco.tbl_functions     import get_event_numbers_and_timestamps
 from ..reco                   import tbl_functions as tbl
+from ..reco.tbl_functions     import get_event_numbers_and_timestamps_from_file_name
+
 from ..reco.pmaps_functions   import load_pmaps
 from ..reco.xy_algorithms     import barycenter
 from ..reco.xy_algorithms     import find_algorithm
-from .. filters.s1s2_filter   import s1s2_filter
-from .. filters.s1s2_filter   import S12Selector
-
+from ..filters.s1s2_filter    import s1s2_filter
+from ..filters.s1s2_filter    import S12Selector
 
 
 class Penthesilea(HitCollectionCity):
@@ -229,8 +227,8 @@ def PENTHESILEA(argv = sys.argv):
                               S2_Ethr          = CFP.S2_ETHR * units.pes,
 
                               rebin            = CFP.REBIN if "REBIN" in CFP else 1,
-                               z_corr_filename = CFP. Z_CORR_FILENAME if "Z_CORR_FILENAME" in CFP else None,
-                              xy_corr_filename = CFP.XY_CORR_FILENAME,
+                               z_corr_filename = CFP. Z_CORR_FILENAME if  "Z_CORR_FILENAME" in CFP else None,
+                              xy_corr_filename = CFP.XY_CORR_FILENAME if "XY_CORR_FILENAME" in CFP else None,
                               lifetime         = CFP.LIFETIME if "LIFETIME" in CFP else None,
                               reco_algorithm   = find_algorithm(CFP.RECO_ALGORITHM))
 

--- a/invisible_cities/cities/penthesilea.py
+++ b/invisible_cities/cities/penthesilea.py
@@ -52,9 +52,6 @@ class Penthesilea(HitCollectionCity):
                  S2_Ethr          = 0,
 
                  rebin            = 1,
-                  z_corr_filename = None,
-                 xy_corr_filename = None,
-                 lifetime         = None,
                  reco_algorithm   = barycenter):
 
         HitCollectionCity.__init__(self,
@@ -64,9 +61,6 @@ class Penthesilea(HitCollectionCity):
                          compression      = compression,
                          nprint           = nprint,
                          rebin            = rebin,
-                         z_corr_filename  = z_corr_filename,
-                         xy_corr_filename = xy_corr_filename,
-                         lifetime         = lifetime,
                          reco_algorithm   = reco_algorithm)
 
         self.drift_v        = drift_v
@@ -182,8 +176,6 @@ class Penthesilea(HitCollectionCity):
                     hit.Z     = z
                     hit.Q     = c.Q
                     hit.E     = e
-                    hit.Ecorr = self.correct_energy(e, c.X, c.Y, z)
-                    hit.Nsipm = c.Nsipm
                     hitc.hits.append(hit)
             npeak += 1
 
@@ -227,9 +219,6 @@ def PENTHESILEA(argv = sys.argv):
                               S2_Ethr          = CFP.S2_ETHR * units.pes,
 
                               rebin            = CFP.REBIN if "REBIN" in CFP else 1,
-                               z_corr_filename = CFP. Z_CORR_FILENAME if  "Z_CORR_FILENAME" in CFP else None,
-                              xy_corr_filename = CFP.XY_CORR_FILENAME if "XY_CORR_FILENAME" in CFP else None,
-                              lifetime         = CFP.LIFETIME if "LIFETIME" in CFP else None,
                               reco_algorithm   = find_algorithm(CFP.RECO_ALGORITHM))
 
     t0 = time.time()

--- a/invisible_cities/cities/penthesilea.py
+++ b/invisible_cities/cities/penthesilea.py
@@ -6,11 +6,12 @@ import textwrap
 import numpy  as np
 import tables as tb
 
-
 from ..core.configure         import configure
 from ..core.system_of_units_c import units
 from ..io.dst_io              import hits_writer
 from ..cities.base_cities     import City
+from ..io.dst_io              import PersistentHitCollection
+from ..io.dst_io              import Hit
 from ..cities.base_cities     import HitCollectionCity
 from ..reco                   import tbl_functions as tbl
 from ..reco.tbl_functions     import get_event_numbers_and_timestamps_from_file_name
@@ -20,8 +21,6 @@ from ..reco.xy_algorithms     import find_algorithm
 from ..filters.s1s2_filter    import s1s2_filter
 from ..filters.s1s2_filter    import S12Selector
 from ..reco.pmaps_functions   import integrate_S2Si_charge
-
-
 
 
 class Penthesilea(HitCollectionCity):
@@ -180,11 +179,10 @@ class Penthesilea(HitCollectionCity):
                 z        = (t_slice - S1t) * units.ns * self.drift_v
                 for c, e in zip(clusters, es):
                     hit       = Hit()
-                    hit.Npeak = npeak
-                    hit.X     = c.X
-                    hit.Y     = c.Y
-                    hit.R     = (c.X**2 + c.Y**2)**0.5
-                    hit.Phi   = np.arctan2(c.Y, c.X)
+                    hit.npeak = npeak
+                    hit.nsipm = c.nsipm
+                    hit.X     = c.pos.X
+                    hit.Y     = c.pos.Y
                     hit.Z     = z
                     hit.Q     = c.Q
                     hit.E     = e

--- a/invisible_cities/config/penthesilea.conf
+++ b/invisible_cities/config/penthesilea.conf
@@ -36,8 +36,6 @@ S2_NSIPMMIN    1 # Min number of SiPMs touched
 S2_NSIPMMAX 1000 # Max number of SiPMs touched
 S2_ETHR        1 # Energy threshold for S2
 
-Z_CORR_FILENAME $ICDIR/database/test_data/Krcorr.h5
-XY_CORR_FILENAME $ICDIR/database/test_data/Krcorr.h5
 RECO_ALGORITHM barycenter
 
 # Job

--- a/invisible_cities/config/penthesilea.conf
+++ b/invisible_cities/config/penthesilea.conf
@@ -1,0 +1,45 @@
+# Input files
+PATH_IN $ICDIR/database/test_data/
+FILE_IN KrMC_pmaps*.h5
+
+# Output file
+PATH_OUT $ICDIR/database/test_data/
+FILE_OUT KrTracks.h5
+COMPRESSION ZLIB4
+
+# Run info
+RUN_NUMBER 0
+
+# Miscellanea
+NPRINT     10000 # print modulo
+
+# Dorothea
+DRIFT_V      1.0 # Expected drift velocity
+
+S1_EMIN        0 # Min S1 energy integral in pes
+S1_EMAX    10000 # Max S1 energy integral in pes
+S1_LMIN        4 # Min number of 25 ns samples
+S1_LMAX       20 # Max number of 25 ns samples
+S1_HMIN        0 # Min S1 height in pes
+S1_HMAX     1000 # Max S1 height in pes
+S1_ETHR      0.5 # Energy threshold for S1
+
+S2_NMIN        1 # Min number of S2 signals
+S2_NMAX        2 # Max number of S2 signals
+S2_EMIN     1000 # Min S2 energy integral in pes
+S2_EMAX  1000000 # Max S2 energy integral in pes
+S2_LMIN        1 # Min number of 1 mus samples
+S2_LMAX     1000 # Max number of 1 mus samples
+S2_HMIN        0 # Min S2 height in pes
+S2_HMAX   100000 # Max S2 height in pes
+S2_NSIPMMIN    1 # Min number of SiPMs touched
+S2_NSIPMMAX 1000 # Max number of SiPMs touched
+S2_ETHR        1 # Energy threshold for S2
+
+Z_CORR_FILENAME $ICDIR/database/test_data/Krcorr.h5
+XY_CORR_FILENAME $ICDIR/database/test_data/Krcorr.h5
+RECO_ALGORITHM barycenter
+
+# Job
+NEVENTS 10000
+RUN_ALL False

--- a/invisible_cities/io/dst_io.py
+++ b/invisible_cities/io/dst_io.py
@@ -122,18 +122,3 @@ class KrEvent(PointLikeEvent):
             row["Yrms" ] = self.Yrms [i]
             row.append()
 
-def write_test_dst(df, filename, group, node):
-    with tb.open_file(filename, "w") as h5in:
-        group = h5in.create_group(h5in.root, group)
-        table = h5in.create_table(group,
-                                  "data",
-                                  table_formats.KrTable,
-                                  "Test data",
-                                  tbl.filters("ZLIB4"))
-
-        tablerow = table.row
-        for index, row in df.iterrows():
-            for name, value in row.items():
-                tablerow[name] = value
-            tablerow.append()
-        table.flush()

--- a/invisible_cities/io/dst_io.py
+++ b/invisible_cities/io/dst_io.py
@@ -17,6 +17,20 @@ def _make_kr_tables(hdf5_file, compression):
         dst_group, 'Events', table_formats.KrTable, 'Events Table', c)
     return events_table
 
+# TODO: Remove duplication: this is just like the above
+def hits_writer(file, *, compression='ZLIB4'):
+    hits_table = _make_hits_tables(file, compression)
+    def write_hits(hits_event):
+        hits_event.store(hits_table)
+    return write_hits
+
+def _make_hits_tables(hdf5_file, compression):
+    c = tbl.filters(compression)
+    dst_group = hdf5_file.create_group(hdf5_file.root, 'DST')
+    events_table = hdf5_file.create_table(
+        dst_group, 'Events', table_formats.HitsTable, 'Events Table', c)
+    return events_table
+
 
 def xy_writer(file, *, compression='ZLIB4'):
     xy_table = _make_xy_tables(file, compression)

--- a/invisible_cities/io/dst_io.py
+++ b/invisible_cities/io/dst_io.py
@@ -66,6 +66,8 @@ def _make_table(hdf5_file, group, name, format, compression, description):
     return table
 
 
+# TODO: these have no busieness being here! Move them somewhere more
+# sensible.
 class Event:
     def __init__(self):
         self.evt  = None
@@ -147,43 +149,39 @@ class PersistentKrEvent(KrEvent):
 
 class Hit:
     def __init__(self):
-        self.Npeak = -1
+        self.npeak = -1
         self.X     = -1e12
         self.Y     = -1e12
-        self.R     = -1e12
-        self.Phi   = -1e12
         self.Z     = -1
         self.E     = -1
         self.Q     = -1
-        self.Nsipm = -1
+        self.nsipm = -1
+
+    @property
+    def R(self): return np.sqrt(self.X ** 2 + self.Y ** 2)
+
+    @property
+    def Phi(self): return np.arctan2(self.Y, self.X)
 
 
 class HitCollection(Event):
     def __init__(self):
         super().__init__()
         self.hits = []
-        self.S1w = -1
-        self.S1h = -1
-        self.S1e = -1
-        self.S1t = -1
 
 
 class PersistentHitCollection(HitCollection):
 
-    def store(self, row):
+    def store(self, table):
+        row = table.row
         for hit in self.hits:
             row["event"] = self.evt
             row["time" ] = self.time
-            row["S1w"  ] = self.S1w
-            row["S1h"  ] = self.S1h
-            row["S1e"  ] = self.S1e
-            row["S1t"  ] = self.S1t
-
             row["npeak"] = hit.npeak
+            row["nsipm"] = hit.nsipm
             row["X"    ] = hit.X
             row["Y"    ] = hit.Y
             row["Z"    ] = hit.Z
-            row["R"    ] = hit.R
-            row["Phi"  ] = hit.Phi
-            row["Nsipm"] = hit.Nsipm
+            row["Q"    ] = hit.Q
+            row["E"    ] = hit.E
             row.append()

--- a/invisible_cities/io/dst_io.py
+++ b/invisible_cities/io/dst_io.py
@@ -1,5 +1,3 @@
-import abc
-
 import tables as tb
 
 from .. reco import tbl_functions as tbl
@@ -54,11 +52,21 @@ def _make_table(hdf5_file, group, name, format, compression, description):
     return table
 
 
-class PointLikeEvent:
+class Event:
     def __init__(self):
-        self.evt   = -1
-        self.T     = -1
+        self.evt  = None
+        self.time = None
 
+    def __str__(self):
+        s = "{0}Event\n{0}".format("#"*20 + "\n")
+        for attr in self.__dict__:
+            s += "{}: {}\n".format(attr, getattr(self, attr))
+        return s
+
+
+class KrEvent(Event):
+    def __init__(self):
+        super().__init__()
         self.nS1   = -1
         # Consider replacing with a list of namedtuples or a
         # structured array
@@ -91,7 +99,7 @@ class PointLikeEvent:
         return s
 
 
-class KrEvent(PointLikeEvent):
+class PersistentKrEvent(KrEvent):
     def store(self, table):
         row = table.row
         for i in range(int(self.nS2)):
@@ -122,3 +130,46 @@ class KrEvent(PointLikeEvent):
             row["Yrms" ] = self.Yrms [i]
             row.append()
 
+
+class Hit:
+    def __init__(self):
+        self.Npeak = -1
+        self.X     = -1e12
+        self.Y     = -1e12
+        self.R     = -1e12
+        self.Phi   = -1e12
+        self.Z     = -1
+        self.E     = -1
+        self.Q     = -1
+        self.Nsipm = -1
+
+
+class HitCollection(Event):
+    def __init__(self):
+        super().__init__()
+        self.hits = []
+        self.S1w = -1
+        self.S1h = -1
+        self.S1e = -1
+        self.S1t = -1
+
+
+class PersistentHitCollection(HitCollection):
+
+    def store(self, row):
+        for hit in self.hits:
+            row["event"] = self.evt
+            row["time" ] = self.time
+            row["S1w"  ] = self.S1w
+            row["S1h"  ] = self.S1h
+            row["S1e"  ] = self.S1e
+            row["S1t"  ] = self.S1t
+
+            row["npeak"] = hit.npeak
+            row["X"    ] = hit.X
+            row["Y"    ] = hit.Y
+            row["Z"    ] = hit.Z
+            row["R"    ] = hit.R
+            row["Phi"  ] = hit.Phi
+            row["Nsipm"] = hit.Nsipm
+            row.append()

--- a/invisible_cities/io/dst_io_test.py
+++ b/invisible_cities/io/dst_io_test.py
@@ -7,7 +7,7 @@ from pytest import mark
 from .. core.test_utils    import assert_dataframes_equal
 from .. reco.dst_functions import load_dst
 from .  dst_io             import kr_writer
-from .  dst_io             import KrEvent
+from .  dst_io             import PersistentKrEvent
 
 
 def test_Kr_writer(config_tmpdir, Kr_dst_data):
@@ -16,7 +16,7 @@ def test_Kr_writer(config_tmpdir, Kr_dst_data):
 
     def dump_df(write, df):
         for evt_no in sorted(set(df.event)):
-            evt = KrEvent()
+            evt = PersistentKrEvent()
             for row in df[df.event == evt_no].iterrows():
                 for col in df.columns:
                     value = row[1][col]

--- a/invisible_cities/reco/dst_functions.py
+++ b/invisible_cities/reco/dst_functions.py
@@ -15,6 +15,11 @@ def load_dsts(dst_list, group, node):
     return pd.concat(dsts)
 
 
+def load_z_corrections(filename):
+    dst = load_dst(filename, "Corrections", "Zcorrections")
+    return Correction((dst.z.values,), dst.factor.values, dst.uncertainty.values)
+
+
 def load_xy_corrections(filename, interp_strategy="nearest"):
     dst  = load_dst(filename, "Corrections", "XYcorrections")
     x, y = np.unique(dst.x.values), np.unique(dst.y.values)

--- a/invisible_cities/reco/nh5.py
+++ b/invisible_cities/reco/nh5.py
@@ -156,3 +156,18 @@ class Tfactors(tb.IsDescription):
     t            = tb.Float32Col(pos=0)
     factor       = tb.Float32Col(pos=1)
     uncertainty  = tb.Float32Col(pos=2)
+
+class HitsTable(tb.IsDescription):
+    event = tb.  Int32Col(pos= 0)
+    time  = tb.Float64Col(pos= 1)
+
+    npeak = tb. UInt16Col(pos= 2)
+    X     = tb.Float64Col(pos= 3)
+    Y     = tb.Float64Col(pos= 4)
+    Z     = tb.Float64Col(pos= 5)
+    R     = tb.Float64Col(pos= 6)
+    Phi   = tb.Float64Col(pos= 7)
+    Nsipm = tb. UInt16Col(pos= 8)
+    Q     = tb.Float64Col(pos= 9)
+    E     = tb.Float64Col(pos=10)
+    Ecorr = tb.Float64Col(pos=11)

--- a/invisible_cities/reco/nh5.py
+++ b/invisible_cities/reco/nh5.py
@@ -157,17 +157,14 @@ class Tfactors(tb.IsDescription):
     factor       = tb.Float32Col(pos=1)
     uncertainty  = tb.Float32Col(pos=2)
 
-class HitsTable(tb.IsDescription):
-    event = tb.  Int32Col(pos= 0)
-    time  = tb.Float64Col(pos= 1)
 
-    npeak = tb. UInt16Col(pos= 2)
-    X     = tb.Float64Col(pos= 3)
-    Y     = tb.Float64Col(pos= 4)
-    Z     = tb.Float64Col(pos= 5)
-    R     = tb.Float64Col(pos= 6)
-    Phi   = tb.Float64Col(pos= 7)
-    Nsipm = tb. UInt16Col(pos= 8)
-    Q     = tb.Float64Col(pos= 9)
-    E     = tb.Float64Col(pos=10)
-    Ecorr = tb.Float64Col(pos=11)
+class HitsTable(tb.IsDescription):
+    event = tb.  Int32Col(pos=0)
+    time  = tb.Float64Col(pos=1)
+    npeak = tb. UInt16Col(pos=2)
+    nsipm = tb. UInt16Col(pos=3)
+    X     = tb.Float64Col(pos=4)
+    Y     = tb.Float64Col(pos=5)
+    Z     = tb.Float64Col(pos=6)
+    Q     = tb.Float64Col(pos=7)
+    E     = tb.Float64Col(pos=8)

--- a/invisible_cities/reco/params.py
+++ b/invisible_cities/reco/params.py
@@ -55,6 +55,7 @@ for name, attrs in (
         ('Cluster'        , 'Q pos rms nsipm'),
         ('TriggerParams'  , 'trigger_channels min_number_channels charge height width'),
         ('PeakData'       , 'charge height width'),
+        ('XY'             , 'X Y'),
         ('Measurement'    , 'value uncertainty')):
     _add_namedtuple_in_this_module(name, attrs)
 

--- a/invisible_cities/reco/params.py
+++ b/invisible_cities/reco/params.py
@@ -52,7 +52,7 @@ for name, attrs in (
         ('PMaps'          , 'S1 S2 S2Si'),
         ('Peak'           , 't E'),
         ('FitFunction'    , 'fn values errors chi2 pvalue'),
-        ('Cluster'        , 'Q pos rms Nsipm'),
+        ('Cluster'        , 'Q pos rms nsipm'),
         ('TriggerParams'  , 'trigger_channels min_number_channels charge height width'),
         ('PeakData'       , 'charge height width'),
         ('Measurement'    , 'value uncertainty')):

--- a/invisible_cities/reco/pmaps_functions.py
+++ b/invisible_cities/reco/pmaps_functions.py
@@ -134,3 +134,9 @@ def integrate_charge(d):
     """
     newd = dict((key, np.sum(value)) for key, value in d.items())
     return list(map(np.array, list(zip(*newd.items()))))
+
+def select_si_slice(si, slice_no):
+    # This is a temporary fix! The number of slices in the SiPM arrays
+    # must match that of the PMT PMaps.
+    return {sipm_no: (sipm[slice_no] if len(sipm) > slice_no else 0)
+                      for sipm_no, sipm in si.items()}

--- a/invisible_cities/reco/pmaps_functions.py
+++ b/invisible_cities/reco/pmaps_functions.py
@@ -128,12 +128,15 @@ def width(times, to_mus=False):
     return w * units.ns/units.mus if to_mus else w
 
 
-def integrate_charge(d):
-    """
-    Integrate charge from a SiPM dictionary.
-    """
-    newd = dict((key, np.sum(value)) for key, value in d.items())
-    return list(map(np.array, list(zip(*newd.items()))))
+def integrate_charges_as_dict(d):
+    "Return dict of integrated charges from a SiPM dictionary."
+    return { sipm : sum(qs) for (sipm, qs) in d.items() }
+
+def integrate_charges(d):
+    sipms_and_Q_totals = integrate_charges_as_dict(d)
+    sipms = np.array(tuple(sipms_and_Q_totals.keys()))
+    Qs    = np.array(tuple(sipms_and_Q_totals.values()))
+    return sipms, Qs
 
 def select_si_slice(si, slice_no):
     # This is a temporary fix! The number of slices in the SiPM arrays

--- a/invisible_cities/reco/pmaps_functions.py
+++ b/invisible_cities/reco/pmaps_functions.py
@@ -128,15 +128,43 @@ def width(times, to_mus=False):
     return w * units.ns/units.mus if to_mus else w
 
 
-def integrate_charges_as_dict(d):
-    "Return dict of integrated charges from a SiPM dictionary."
-    return { sipm : sum(qs) for (sipm, qs) in d.items() }
+def integrate_sipm_charges_in_peak_as_dict(Si):
+    """Return dict of integrated charges from a SiPM dictionary.
 
-def integrate_charges(d):
-    sipms_and_Q_totals = integrate_charges_as_dict(d)
+    S2Si = {  peak : Si }
+      Si = { nsipm : [ q1, q2, ...] }
+
+    Returns an integrated Si = { nsipm : sum(q_n) }
+    """
+    return { sipm : sum(qs) for (sipm, qs) in Si.items() }
+
+
+def integrate_sipm_charges_in_peak(Si):
+    """Return arrays of nsipm and integrated charges from SiPM dictionary.
+
+    S2Si = {  peak : Si }
+      Si = { nsipm : [ q1, q2, ...] }
+
+    Returns (np.array[[nsipm_1 ,     nsipm_2, ...]],
+             np.array[[sum(q_1), sum(nsipm_2), ...]])
+    """
+    sipms_and_Q_totals = integrate_sipm_charges_in_peak_as_dict(Si)
     sipms = np.array(tuple(sipms_and_Q_totals.keys()))
     Qs    = np.array(tuple(sipms_and_Q_totals.values()))
     return sipms, Qs
+
+
+def integrate_S2Si_charge(S2Si):
+    """Return S2Si containing integrated charges.
+
+    S2Si = {  peak : Si }
+      Si = { nsipm : [ q1, q2, ...] }
+
+    Returns S2Si where Si = { nsipm : sum([q1, q2, ...])}
+"""
+    return { peak_no : integrate_sipm_charges_in_peak_as_dict(peak)
+             for (peak_no, peak) in S2Si.items() }
+
 
 def select_si_slice(si, slice_no):
     # This is a temporary fix! The number of slices in the SiPM arrays

--- a/invisible_cities/reco/pmaps_functions_test.py
+++ b/invisible_cities/reco/pmaps_functions_test.py
@@ -13,7 +13,7 @@ from . pmaps_functions import df_to_pmaps_dict
 from . pmaps_functions import df_to_s2si_dict
 
 
-def test_integrate_charges_as_dict():
+def test_integrate_sipm_charges_in_peak_as_dict():
     sipm1 = 1000
     sipm2 = 1001
     qs1 = list(range(5))
@@ -22,19 +22,44 @@ def test_integrate_charges_as_dict():
              sipm2:     qs2 }
     Qs    = {sipm1: sum(qs1),
              sipm2: sum(qs2)}
-    assert pmapf.integrate_charges_as_dict(sipms) == Qs
+    assert pmapf.integrate_sipm_charges_in_peak_as_dict(sipms) == Qs
 
-
-def test_integrate_charges():
+def test_integrate_sipm_charges_in_peak():
     sipm1 = 1234
     sipm2 =  987
     qs1 = [8,6,9,3]
     qs2 = [4,1,9,6,7]
     sipms = {sipm1: qs1,
              sipm2: qs2}
-    ids, Qs =  pmapf.integrate_charges(sipms)
+    ids, Qs =  pmapf.integrate_sipm_charges_in_peak(sipms)
     assert np.array_equal(ids, np.array((  sipm1,    sipm2)))
     assert np.array_equal(Qs , np.array((sum(qs1), sum(qs2))))
+
+def test_integrate_S2Si_charge():
+    peak1 = 0
+    sipm1_1, Q1_1 = 1000, list(range(5))
+    sipm1_2, Q1_2 = 1001, list(range(10))
+
+    peak2 = 1
+    sipm2_1, Q2_1 =  999, [6,4,9]
+    sipm2_2, Q2_2 =  456, [8,4,3,7,5]
+    sipm2_3, Q2_3 = 1234, [6,2]
+    sipm2_4, Q2_4 =  666, [0,0] # !!! Zero charge
+
+    S2Si = {peak1 : {sipm1_1 : Q1_1,
+                     sipm1_2 : Q1_2},
+            peak2 : {sipm2_1 : Q2_1,
+                     sipm2_2 : Q2_2,
+                     sipm2_3 : Q2_3,
+                     sipm2_4 : Q2_4}}
+
+    integrated_S2Si = pmapf.integrate_S2Si_charge(S2Si)
+    assert integrated_S2Si == {peak1 : {sipm1_1 : sum(Q1_1),
+                                        sipm1_2 : sum(Q1_2)},
+                               peak2 : {sipm2_1 : sum(Q2_1),
+                                        sipm2_2 : sum(Q2_2),
+                                        sipm2_3 : sum(Q2_3),
+                                        sipm2_4 : sum(Q2_4)}}
 
 
 def test_width():

--- a/invisible_cities/reco/pmaps_functions_test.py
+++ b/invisible_cities/reco/pmaps_functions_test.py
@@ -13,12 +13,28 @@ from . pmaps_functions import df_to_pmaps_dict
 from . pmaps_functions import df_to_s2si_dict
 
 
-def test_integrate_charge():
-    sipms = {1000: range(5),
-             1001: range(10)}
-    charges = np.array([[1000,1001],[10,45]])
-    charges_test = pmapf.integrate_charge(sipms)
-    np.testing.assert_array_equal(charges, charges_test)
+def test_integrate_charges_as_dict():
+    sipm1 = 1000
+    sipm2 = 1001
+    qs1 = list(range(5))
+    qs2 = list(range(10))
+    sipms = {sipm1:     qs1,
+             sipm2:     qs2 }
+    Qs    = {sipm1: sum(qs1),
+             sipm2: sum(qs2)}
+    assert pmapf.integrate_charges_as_dict(sipms) == Qs
+
+
+def test_integrate_charges():
+    sipm1 = 1234
+    sipm2 =  987
+    qs1 = [8,6,9,3]
+    qs2 = [4,1,9,6,7]
+    sipms = {sipm1: qs1,
+             sipm2: qs2}
+    ids, Qs =  pmapf.integrate_charges(sipms)
+    assert np.array_equal(ids, np.array((  sipm1,    sipm2)))
+    assert np.array_equal(Qs , np.array((sum(qs1), sum(qs2))))
 
 
 def test_width():

--- a/invisible_cities/reco/test_xy_algorithms.py
+++ b/invisible_cities/reco/test_xy_algorithms.py
@@ -37,7 +37,7 @@ def test_barycenter(p_q):
     B  = barycenter(pos, qs)[0]
     assert np.allclose(B.pos, np.average(pos, weights=qs, axis=0))
     assert np. isclose(B.Q  , qs.sum())
-    assert B.Nsipm == len(qs)
+    assert B.nsipm == len(qs)
 
 def test_barycenter_raises_sipm_empty_list():
     with raises(SipmEmptyList):
@@ -69,7 +69,7 @@ def test_corona_barycenter_are_same_with_one_cluster(toy_sipm_signal):
     np.array_equal(c_cluster.pos, b_cluster.pos)
     np.array_equal(c_cluster.rms, b_cluster.rms)
     assert c_cluster.Q     == b_cluster.Q
-    assert c_cluster.Nsipm == b_cluster.Nsipm
+    assert c_cluster.nsipm == b_cluster.nsipm
 
 def test_corona_multiple_clusters(toy_sipm_signal):
     pos, qs = toy_sipm_signal
@@ -92,7 +92,7 @@ def test_corona_min_threshold_Qthr():
                       msipm          = 1)
     assert len(clusters) ==   1
     assert clusters[0].Q ==  99
-    assert clusters[0].pos.tolist() == [990, 0]
+    assert clusters[0].pos == (990, 0)
 
 def test_corona_msipm(toy_sipm_signal):
     pos, qs = toy_sipm_signal

--- a/invisible_cities/reco/test_xy_algorithms.py
+++ b/invisible_cities/reco/test_xy_algorithms.py
@@ -34,7 +34,7 @@ def positions_and_qs(draw, min_value=0, max_value=100):
 @given(positions_and_qs(1))
 def test_barycenter(p_q):
     pos, qs = p_q
-    B  = barycenter(pos, qs)
+    B  = barycenter(pos, qs)[0]
     assert np.allclose(B.pos, np.average(pos, weights=qs, axis=0))
     assert np. isclose(B.Q  , qs.sum())
     assert B.Nsipm == len(qs)
@@ -63,7 +63,7 @@ def test_corona_barycenter_are_same_with_one_cluster(toy_sipm_signal):
                         Qlm           =  4.9 * units.pes,
                         Qthr          =  0)
     c_cluster = c_clusters[0]
-    b_cluster = barycenter(pos, qs)
+    b_cluster = barycenter(pos, qs)[0]
 
     assert len(c_cluster)  == len(b_cluster)
     np.array_equal(c_cluster.pos, b_cluster.pos)

--- a/invisible_cities/reco/xy_algorithms.py
+++ b/invisible_cities/reco/xy_algorithms.py
@@ -6,6 +6,13 @@ from .. core.exceptions        import SipmEmptyList
 from .. core.exceptions        import SipmZeroCharge
 from .       params            import Cluster
 
+
+def find_algorithm(algoname):
+    if algoname in sys.modules[__name__].__dict__:
+        return getattr(sys.modules[__name__], algoname)
+    else:
+        raise ValueError("The algorithm <{}> does not exist".format(algoname))
+
 def barycenter(pos, qs):
     if not len(pos): raise SipmEmptyList
     if sum(qs) == 0: raise SipmZeroCharge

--- a/invisible_cities/reco/xy_algorithms.py
+++ b/invisible_cities/reco/xy_algorithms.py
@@ -5,6 +5,7 @@ from .. core.system_of_units_c import units
 from .. core.exceptions        import SipmEmptyList
 from .. core.exceptions        import SipmZeroCharge
 from .       params            import Cluster
+from .       params            import XY
 
 
 def find_algorithm(algoname):
@@ -21,8 +22,6 @@ def barycenter(pos, qs):
     # For uniformity of interface, all xy algorithms should return a
     # list of clusters. barycenter always returns a single clusters,
     # but we still want it in a list.
-    from collections import namedtuple
-    XY = namedtuple('XY', 'X Y')
     return [Cluster(sum(qs), XY(*mu), std, len(qs))]
 
 def discard_sipms(sis, pos, qs):


### PR DESCRIPTION
The functionality of Penthesilea (at this moment) is

+ filter PMAPs
+ compute a hit collection from from remaining PMAPs
+ write to disk

A number of simplifications and some refactoring has been done WRT the
original class proposed by Gonzalo:

+ Penthesilea no longer makes energy corrections, which are deferred
  further down the reconstruction line.

+ Hit classes have been simplified

+ The run method has been made to conform to current standards, in
  particular Dorothea and Penthesilea have essentially identical
  run structure.

Additionally, some pre-existing code has been modified

+ `barycenter` now returns a list containing just one Cluster ()

+ The quick-fix implemented by Gonzalo (`select_si_slice`), which
  addressed the occasional mismatch between S2 and Si slices, is
  currently bypassed. The reason for this is twofold

  - to allow us to progress with implementing Penthesilea without
    dealing with this distraction

  - to allow us to understand the problem being addressed by
    `select_si_slice` further down the line, and decide whether this
    is the right approach: the point is that we *want* the code to
    fail, to highlight the situations in which the issue arises.

+ The `pos` attribute of `Cluster` is now filled with an `XY` object
  instead of a plain 2D numpy array.
