### PR TITLE
Get first event number from input filename

### DIFF
--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -185,13 +185,7 @@ class City:
 
     @staticmethod
     def event_number_from_input_file_name(filename):
-        file_base_name = filename.split('/')[-1]
-        base_hash = hash(file_base_name)
-        # Something, somewhere, is preventing us from using the full
-        # 64 bit space, and limiting us to 32 bits. TODO find and
-        # eliminate it.
-        limited_hash = base_hash % int(1e9)
-        return limited_hash
+        return tbf.event_number_from_input_file_name(filename)
 
     def _get_rwf(self, h5in):
         "Return raw waveforms for SIPM and PMT data"

--- a/invisible_cities/cities/diomira_test.py
+++ b/invisible_cities/cities/diomira_test.py
@@ -191,3 +191,14 @@ def test_diomira_copy_mc_and_offset(config_tmpdir):
             assert mctracks_out[0] == start_evt
             for e in zip(mctracks_in[1:], mctracks_out[1:]):
                 np.testing.assert_array_equal(e[0],e[1])
+
+@mark.parametrize('filename, first_evt',
+             (('dst_NEXT_v0_08_09_Co56_INTERNALPORTANODE_74_0_7bar_MCRD_10000.root.h5',
+               740000),
+              ('NEXT_v0_08_09_Co56_2_0_7bar_MCRD_1000.root.h5',
+               2000),
+              ('electrons_40keV_z250_MCRD.h5',
+               0)))
+def test_event_number_from_input_file_name(filename, first_evt):
+    assert Diomira.event_number_from_input_file_name(filename) == first_evt
+


### PR DESCRIPTION
We use the structure of the filename to compute first event number. Filename needs to have a particular structure including software version, file number and number of events. For more details look at the regular expression.

Sample filename: dst_NEXT_v0_08_09_Co56_INTERNALPORTANODE_74_0_7bar_MCRD_10000.root.h5

If the filename does not match the pattern (for files not in the official production), gives 0 as first event number.

@jjgomezcadenas what do you think?