### PR TITLE
Drop support for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ matrix:
   - os: osx
 
 env:
-  - IC_PYTHON_VERSION=3.5
   - IC_PYTHON_VERSION=3.6
 
 os:

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,9 @@ the command
   source manage.sh install_and_check 3.6
 
 Where the 3.6 can be replaced with any sensible Python version you
-like. (On 2017-02-24 we actively support Python 3.6 and 3.5.)
+like. (On 2017-06-27 we dropped support for Python 3.5, so Python 3.6
+will be the only supported version until 3.7 is released and the third
+party modules we use are uploaded to conda and pip.)
    
 If you have already done the above procedure once, then you should
 already have an `IC3.6` conda environment available, as long as

--- a/bash_manage.sh
+++ b/bash_manage.sh
@@ -26,7 +26,7 @@ manage.sh()
     if [[ ${prev2} == "manage.sh" ]] ; then
             case "${prev}" in
                         install_and_check|install|work_in_python_version|make_environment)
-                        local versions="3.5 3.6"
+                        local versions="3.6"
                     COMPREPLY=( $(compgen -W "${versions}" -- ${cur}) )
                     return 0
                     ;;
@@ -70,7 +70,7 @@ source_manage.sh()
     if [[ ${prev2} == "manage.sh" ]] ; then
             case "${prev}" in
                         install_and_check|install|work_in_python_version|make_environment)
-                        local versions="3.5 3.6"
+                        local versions="3.6"
                     COMPREPLY=( $(compgen -W "${versions}" -- ${cur}) )
                     return 0
                     ;;

--- a/doc/notebooks.rst
+++ b/doc/notebooks.rst
@@ -31,7 +31,7 @@ Workflow
 --------
 
 1. First thing you will need to do is to configure your environment,  this can
-   be done as usual: ``source manage.sh  work_in_python_version 3.5``.
+   be done as usual: ``source manage.sh  work_in_python_version 3.6``.
 
 2. Define your ``$IC_DATA`` if you don't have it yet.
 

--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -44,15 +44,9 @@ from ..reco.xy_algorithms import barycenter
 from ..sierpe             import blr
 from ..sierpe             import fee as FE
 
-if sys.version_info >= (3,5):
-    # Exec to avoid syntax errors in older Pythons
-    exec("""def merge_two_dicts(a,b):
-               return {**a, **b}""")
-else:
-    def merge_two_dicts(a,b):
-        c = a.copy()
-        c.update(b)
-        return c
+
+def merge_two_dicts(a,b):
+    return {**a, **b}
 
 
 class City:
@@ -126,7 +120,7 @@ class City:
                  Output File = {}
                           """.format(self.__class__.__name__,
                                      nmax, self.input_files, self.output_file))
-                                     
+
     @staticmethod
     def get_rwf_vectors(h5in):
         "Return RWF vectors and sensor data."

--- a/invisible_cities/cities/command_line_execution_test.py
+++ b/invisible_cities/cities/command_line_execution_test.py
@@ -16,7 +16,7 @@ def test_command_line_run(city, tmpdir_factory):
     config_file_name = join(ICTDIR, 'invisible_cities/config', city+'.conf')
     # Ensure that output does not pollute: send it to a temporary dir
     temp_dir = tmpdir_factory.mktemp('output_files')
-    out_file_name = join(str(temp_dir), city+'.out')
+    out_file_name = join(temp_dir, city+'.out')
     # The actual command that we want to test
     command = ('city {city} -c {config_file_name} -o {out_file_name}'
                .format(**locals()))

--- a/invisible_cities/cities/diomira_test.py
+++ b/invisible_cities/cities/diomira_test.py
@@ -97,8 +97,7 @@ def test_diomira_sipm(irene_diomira_chain_tmpdir, ICDIR):
     sipm_noise_cut = 20 # in pes. Should kill essentially all background
 
     max_sipm_with_signal = 10
-    infile = os.path.join(ICDIR,
-                          'database/test_data/electrons_40keV_z250_MCRD.h5')
+    infile = os.path.join(ICDIR, 'database/test_data/electrons_40keV_z250_MCRD.h5')
     with tb.open_file(infile, 'r') as e40rd:
 
         NEVENTS_DST, NSIPM, SIPMWL = e40rd.root.sipmrd.shape
@@ -156,12 +155,9 @@ def test_diomira_identify_bug(ICDIR):
 
 @mark.slow
 def test_diomira_copy_mc_and_offset(config_tmpdir):
-    PATH_IN = os.path.join(os.environ['ICDIR'],
-              'database/test_data/',
-              'electrons_40keV_z250_MCRD.h5')
-    PATH_OUT = os.path.join(str(config_tmpdir),
-              'electrons_40keV_z250_RWF.h5')
-    start_evt  = Diomira.event_number_from_input_file_name(str(PATH_IN))
+    PATH_IN = os.path.join(os.environ['ICDIR'], 'database/test_data/', 'electrons_40keV_z250_MCRD.h5')
+    PATH_OUT = os.path.join(config_tmpdir,                             'electrons_40keV_z250_RWF.h5')
+    start_evt  = Diomira.event_number_from_input_file_name(PATH_IN)
     run_number = 0
 
     diomira = Diomira(run_number = run_number,

--- a/invisible_cities/cities/dorothea_test.py
+++ b/invisible_cities/cities/dorothea_test.py
@@ -14,7 +14,7 @@ def test_dorothea_KrMC(config_tmpdir, KrMC_pmaps):
     # NB: avoid taking defaults for run number (test-specific)
 
     PATH_IN =  KrMC_pmaps[0]
-    PATH_OUT = os.path.join(str(config_tmpdir), 'KrDST.h5')
+    PATH_OUT = os.path.join(config_tmpdir, 'KrDST.h5')
 
     dorothea = Dorothea(run_number = 0,
                         files_in   = [PATH_IN],

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -52,12 +52,8 @@ def job_info_missing_pmts(config_tmpdir, ICDIR):
     pmt_active  = list(filter(lambda x: x not in pmt_missing, range(12)))
 
 
-    ifilename   = os.path.join(ICDIR,
-                                'database/test_data/',
-                                'electrons_40keV_z250_RWF.h5.h5')
-
-    ofilename   = os.path.join(str(config_tmpdir),
-                                'electron_40keV_z250_pmaps_missing_PMT.h5')
+    ifilename   = os.path.join(ICDIR, 'database/test_data/', 'electrons_40keV_z250_RWF.h5.h5')
+    ofilename   = os.path.join(config_tmpdir,                'electrons_40keV_z250_pmaps_missing_PMT.h5')
 
     return job_info(run_number, pmt_missing, pmt_active, ifilename, ofilename)
 
@@ -68,11 +64,8 @@ def test_irene_electrons_40keV(config_tmpdir, ICDIR, s12params):
     # since they are in general test-specific
     # NB: avoid taking defaults for run number (test-specific)
 
-    PATH_IN = os.path.join(ICDIR,
-                           'database/test_data/',
-                           'electrons_40keV_z250_RWF.h5')
-    PATH_OUT = os.path.join(str(config_tmpdir),
-                            'electrons_40keV_z250_CWF.h5')
+    PATH_IN = os.path.join(ICDIR, 'database/test_data/', 'electrons_40keV_z250_RWF.h5')
+    PATH_OUT = os.path.join(config_tmpdir,               'electrons_40keV_z250_CWF.h5')
 
     s1par, s2par = s12params
 
@@ -116,8 +109,7 @@ def test_irene_run_2983(config_tmpdir, ICDIR, s12params):
     PATH_IN = os.path.join(ICDIR,
                            'database/test_data/',
                            'run_2983.h5')
-    PATH_OUT = os.path.join(str(config_tmpdir),
-                            'run_2983_pmaps.h5')
+    PATH_OUT = os.path.join(config_tmpdir, 'run_2983_pmaps.h5')
 
     s1par, s2par = s12params
 
@@ -144,11 +136,8 @@ def test_irene_runinfo_run_2983(config_tmpdir, ICDIR):
     # test, eg. h5in .root.Run.events[0:2] if one has run 2 events.
 
     #import pdb; pdb.set_trace()
-    PATH_IN = os.path.join(ICDIR,
-                           'database/test_data/',
-                           'run_2983.h5')
-    PATH_OUT = os.path.join(str(config_tmpdir),
-                            'run_2983_pmaps.h5')
+    PATH_IN = os.path.join(ICDIR, 'database/test_data/', 'run_2983.h5')
+    PATH_OUT = os.path.join(config_tmpdir,               'run_2983_pmaps.h5')
 
     with tb.open_file(PATH_IN, mode='r') as h5in:
         evt_in  = h5in.root.Run.events[0:2]
@@ -172,7 +161,7 @@ def test_irene_runinfo_run_2983(config_tmpdir, ICDIR):
 @mark.serial
 @mark.slow
 def test_irene_output_file_structure(config_tmpdir, ICDIR):
-    PATH_OUT = os.path.join(str(config_tmpdir), 'run_2983_pmaps.h5')
+    PATH_OUT = os.path.join(config_tmpdir, 'run_2983_pmaps.h5')
 
     with tb.open_file(PATH_OUT) as h5out:
         assert "PMAPS"        in h5out.root
@@ -187,11 +176,8 @@ def test_irene_output_file_structure(config_tmpdir, ICDIR):
 
 def test_empty_events_issue_81(config_tmpdir, ICDIR, s12params):
     # NB: explicit PATH_OUT
-    PATH_IN = os.path.join(ICDIR,
-                           'database/test_data/',
-                           'irene_bug_Kr_ACTIVE_7bar_RWF.h5')
-    PATH_OUT = os.path.join(str(config_tmpdir),
-                            'irene_bug_Kr_ACTIVE_7bar_CWF.h5')
+    PATH_IN = os.path.join(ICDIR, 'database/test_data/', 'irene_bug_Kr_ACTIVE_7bar_RWF.h5')
+    PATH_OUT = os.path.join(config_tmpdir,               'irene_bug_Kr_ACTIVE_7bar_CWF.h5')
 
     s1par, s2par = s12params
 

--- a/invisible_cities/cities/zaira_test.py
+++ b/invisible_cities/cities/zaira_test.py
@@ -10,9 +10,8 @@ def test_zaira_KrMC(config_tmpdir, ICDIR):
     # since they are in general test-specific
     # NB: avoid taking defaults for run number (test-specific)
 
-    PATH_IN =  os.path.join(ICDIR,
-                            'database/test_data', 'KrDST_MC.h5')
-    PATH_OUT = os.path.join(str(config_tmpdir), 'KrCorr.h5')
+    PATH_IN =  os.path.join(ICDIR, 'database/test_data', 'KrDST_MC.h5')
+    PATH_OUT = os.path.join(config_tmpdir,                 'KrCorr.h5')
 
     zaira = Zaira(run_number = 0,
                   files_in   = [PATH_IN],

--- a/invisible_cities/core/configure_test.py
+++ b/invisible_cities/core/configure_test.py
@@ -148,7 +148,7 @@ def test_configure(config_tmpdir, spec):
     """Test configure function. Read from conf file.
     """
 
-    conf_file_name = str(config_tmpdir.join('test.conf'))
+    conf_file_name = config_tmpdir.join('test.conf')
     with open(conf_file_name, 'w') as conf_file:
         conf_file.write(config_file_contents)
 

--- a/invisible_cities/io/dst_io_test.py
+++ b/invisible_cities/io/dst_io_test.py
@@ -13,7 +13,7 @@ from . dst_io             import hits_writer
 
 
 def test_hits_writer(config_tmpdir, hits_toy_data):
-    output_file = os.path.join(str(config_tmpdir), "test_hits.h5")
+    output_file = os.path.join(config_tmpdir, "test_hits.h5")
 
     _, (npeak, nsipm, x, y, xrms, yrms, z, q, e) = hits_toy_data
 

--- a/invisible_cities/io/kdst_io_test.py
+++ b/invisible_cities/io/kdst_io_test.py
@@ -13,7 +13,7 @@ from ..reco.event_model   import PersistentKrEvent
 
 
 def test_Kr_writer(config_tmpdir, Kr_dst_data):
-    filename = os.path.join(str(config_tmpdir), 'test_dst.h5')
+    filename = os.path.join(config_tmpdir, 'test_dst.h5')
     _, df    = Kr_dst_data
 
     def dump_df(write, df):
@@ -37,7 +37,7 @@ def test_Kr_writer(config_tmpdir, Kr_dst_data):
 
 
 def test_xy_writer(config_tmpdir, corr_toy_data):
-    output_file = os.path.join(str(config_tmpdir), "test_corr.h5")
+    output_file = os.path.join(config_tmpdir, "test_corr.h5")
 
     _, (x, y, F, U, N) = corr_toy_data
 

--- a/invisible_cities/io/pmap_io_test.py
+++ b/invisible_cities/io/pmap_io_test.py
@@ -37,7 +37,7 @@ def test_pmap_writer(config_tmpdir, s12_dataframe_converted, s2si_dataframe_conv
 
     filename = 'test_pmaps_auto.h5'
 
-    PMP_file_name = os.path.join(str(config_tmpdir), filename)
+    PMP_file_name = os.path.join(config_tmpdir, filename)
 
     # Get test data
     s12,  a =  s12_dataframe_converted
@@ -111,7 +111,7 @@ def test_pmap_electrons_40keV(config_tmpdir):
               'database/test_data/',
               'electrons_40keV_z250_RWF.h5')
 
-    PMAP_file_name = os.path.join(str(config_tmpdir),
+    PMAP_file_name = os.path.join(config_tmpdir,
               'electrons_40keV_z250_PMP.h5')
 
     s1_params = S12P(time   = minmax(min =     90 * units.mus,


### PR DESCRIPTION
We keep getting annoying test failures because `path.join` cannot handle paths (!) in Python 3.5.

The solution is simple (convert the path to a string), but at this stage it's difficult to see what benefit we get in return for making our code uglier in this way.

It's time to move on.


