### PR TITLE
Fix diomira noisy sipms

### DIFF
--- a/invisible_cities/cities/diomira.py
+++ b/invisible_cities/cities/diomira.py
@@ -56,7 +56,7 @@ class Diomira(SensorResponseCity):
         print(sp)
 
         # Create instance of the noise sampler
-        self.noise_sampler = SiPMsNoiseSampler(sp.SIPMWL, True)
+        self.noise_sampler = SiPMsNoiseSampler(self.run_number, sp.SIPMWL, True)
         # thresholds in adc counts
         self.sipms_thresholds = (self.sipm_noise_cut
                               *  self.sipm_adc_to_pes)

--- a/invisible_cities/cities/diomira_test.py
+++ b/invisible_cities/cities/diomira_test.py
@@ -13,7 +13,6 @@ import numpy  as np
 from pytest import mark
 
 from .. core                 import system_of_units as units
-from .. core.random_sampling import NoiseSampler as SiPMsNoiseSampler
 from .. core.configure       import configure
 
 from .. reco     import tbl_functions as tbl

--- a/invisible_cities/core/random_sampling.py
+++ b/invisible_cities/core/random_sampling.py
@@ -6,7 +6,7 @@ from .. database import load_db as DB
 
 
 class NoiseSampler:
-    def __init__(self, sample_size=1, smear=True):
+    def __init__(self, run_number, sample_size=1, smear=True):
         """Sample a histogram as if it was a PDF.
 
         Parameters
@@ -35,9 +35,11 @@ class NoiseSampler:
         self.nsamples = sample_size
         self.probs, self.xbins, self.baselines = DB.SiPMNoise()
 
-        self.probs = np.apply_along_axis(norm, 1, self.probs)
+        active         = DB.DataSiPM(run_number).Active.values[:, np.newaxis]
+        # probs * active means that masked sensors are set to 0
+        self.probs     = np.apply_along_axis(norm, 1, self.probs * active)
         self.baselines = self.baselines.reshape(self.baselines.shape[0], 1)
-        self.dx = np.diff(self.xbins)[0] * 0.5
+        self.dx        = np.diff(self.xbins)[0] * 0.5
 
         # Sampling functions
         def _sample_sensor(probs):

--- a/invisible_cities/core/random_sampling_test.py
+++ b/invisible_cities/core/random_sampling_test.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+from . random_sampling  import NoiseSampler
+from ..database.load_db import DataSiPM
+
+def test_noise_sampler_masked_sensors():
+    run_number = 0
+
+    sampler = NoiseSampler(run_number, 1000, False)
+    sample  = sampler.Sample()
+
+    datasipm = DataSiPM(run_number)
+    masked_sensors = datasipm[datasipm.Active==0].index.values
+    assert not np.any(sample[masked_sensors])

--- a/invisible_cities/reco/sensor_functions_test.py
+++ b/invisible_cities/reco/sensor_functions_test.py
@@ -76,7 +76,7 @@ def test_sipm_noise_sampler(electron_MCRD_file):
         assert np.mean(sipm_adc_to_pes[sipm_adc_to_pes>0]) < cal_max
 
         sipms_thresholds = sipm_noise_cut *  sipm_adc_to_pes
-        noise_sampler = SiPMsNoiseSampler(SIPMWL, True)
+        noise_sampler = SiPMsNoiseSampler(run_number, SIPMWL, True)
 
         # signal in sipm with noise
         sipmrwf = e40rd.root.sipmrd[event] + noise_sampler.Sample()


### PR DESCRIPTION
Some sensors with weird noise pdfs were causing bad responses in the tracking plane. This PR fixes it by skipping masked sensors when simulating the SiPM noise. On top of that, a test has been added to ensure this behavior is under control.