### PR TITLE
Daemons

### DIFF
--- a/invisible_cities/cities/command_line_execution_test.py
+++ b/invisible_cities/cities/command_line_execution_test.py
@@ -26,3 +26,20 @@ def test_command_line_run(city, tmpdir_factory):
         # Ensure that stdout and stderr are visible when test fails
         print(e.stdout.decode())
         raise
+
+def test_run_irene_with_deamons(tmpdir_factory):
+    ICTDIR = getenv('ICTDIR')
+    # Use the example config file included in the repository
+    config_file_name = join(ICTDIR, 'invisible_cities/config/irene_daemon_example.conf')
+    # Ensure that output does not pollute: send it to a temporary dir
+    temp_dir = tmpdir_factory.mktemp('output_files')
+    out_file_name = join(temp_dir, 'irene.out')
+    # The actual command that we want to test
+    command = ('city irene {config_file_name} -o {out_file_name}'
+               .format(**locals()))
+    try:
+        check_output(command, shell = True, stderr=STDOUT)
+    except CalledProcessError as e:
+        # Ensure that stdout and stderr are visible when test fails
+        print(e.stdout.decode())
+        raise

--- a/invisible_cities/cities/diomira_test.py
+++ b/invisible_cities/cities/diomira_test.py
@@ -94,7 +94,8 @@ def test_diomira_copy_mc_and_offset(config_tmpdir):
                      nmax       = nrequired))
 
     diomira = Diomira(**conf)
-    cnt     = diomira.run()
+    diomira.run()
+    cnt     = diomira.end()
     nactual = cnt.counter_value('n_events_tot')
     if nrequired > 0:
         assert nrequired == nactual

--- a/invisible_cities/cities/dorothea_test.py
+++ b/invisible_cities/cities/dorothea_test.py
@@ -49,7 +49,8 @@ def test_dorothea_KrMC(config_tmpdir, KrMC_pmaps):
 
     dorothea = Dorothea(**conf)
 
-    cnt  = dorothea.run()
+    dorothea.run()
+    cnt  = dorothea.end()
     nevt_in = cnt.counter_value('n_events_tot')
     nevt_out = cnt.counter_value('nevt_out')
     if nrequired > 0:

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -96,7 +96,8 @@ def test_irene_electrons_40keV(config_tmpdir, ICDIR, s12params):
                      **unpack_s12params(s12params)))
 
     irene = Irene(**conf)
-    cnt = irene.run()
+    irene.run()
+    cnt = irene.end()
 
     nactual = cnt.counter_value('n_events_tot')
     if nrequired > 0:
@@ -142,7 +143,8 @@ def test_irene_run_2983(config_tmpdir, ICDIR, s12params):
                      **unpack_s12params(s12params)))
 
     irene = Irene(**conf)
-    cnt = irene.run()
+    irene.run()
+    cnt = irene.end()
     if nrequired > 0:
         assert nrequired == cnt.counter_value('n_events_tot')
 
@@ -212,7 +214,8 @@ def test_empty_events_issue_81(config_tmpdir, ICDIR, s12params):
                      **unpack_s12params(s12params)))
 
     irene = Irene(**conf)
-    cnt = irene.run()
+    irene.run()
+    cnt = irene.end()
 
     assert cnt.counter_value('n_events_tot')   == 0
     assert cnt.counter_value('n_empty_events') == 1

--- a/invisible_cities/cities/isidora_test.py
+++ b/invisible_cities/cities/isidora_test.py
@@ -40,7 +40,8 @@ def test_isidora_electrons_40keV(config_tmpdir, ICDIR):
                      nmax       = nrequired))
 
     isidora = Isidora(**conf)
-    cnt = isidora.run()
+    isidora.run()
+    cnt = isidora.end()
 
     nactual = cnt.counter_value('n_events_tot')
     if nrequired > 0:

--- a/invisible_cities/config/irene.conf
+++ b/invisible_cities/config/irene.conf
@@ -6,3 +6,5 @@ include('$ICDIR/config/pmap_city.conf')
 
 # print empty events
 print_empty_events = 1
+# daemons
+# daemons = ['lyra','asriel'] 

--- a/invisible_cities/config/irene_daemon_example.conf
+++ b/invisible_cities/config/irene_daemon_example.conf
@@ -1,0 +1,10 @@
+# irene.conf
+
+# Irene is a concrete PMAPS city
+
+include('$ICDIR/config/pmap_city.conf')
+
+# print empty events
+print_empty_events = 1
+# daemons
+daemons = ['lyra','asriel']

--- a/invisible_cities/daemons/asriel.py
+++ b/invisible_cities/daemons/asriel.py
@@ -1,0 +1,12 @@
+from . daemon import Daemon
+
+class Asriel(Daemon):
+
+    def __init__(self):
+        print('I am Asriel')
+
+    def run(self):
+        print('Asriel runs')
+
+    def end(self):
+        print('Asriel ends')

--- a/invisible_cities/daemons/daemon.py
+++ b/invisible_cities/daemons/daemon.py
@@ -1,0 +1,9 @@
+class Daemon:
+
+    """Defines an interface for daemons"""
+
+    def run(self):
+        pass
+
+    def end(self):
+        pass

--- a/invisible_cities/daemons/idaemon.py
+++ b/invisible_cities/daemons/idaemon.py
@@ -1,0 +1,15 @@
+from importlib import import_module
+import traceback
+
+
+def invoke_daemon(daemon_name):
+    """Takes a daemon name and returns an instance of the daemon"""
+    try:
+        module_name = 'invisible_cities.daemons.' + daemon_name
+        daemon_class  = getattr(import_module(module_name),
+                                          daemon_name.capitalize())
+    except ModuleNotFoundError:
+        traceback.print_exc()
+    else:
+
+        return daemon_class()

--- a/invisible_cities/daemons/lyra.py
+++ b/invisible_cities/daemons/lyra.py
@@ -1,0 +1,12 @@
+from . daemon import Daemon
+
+class Lyra(Daemon):
+
+    def __init__(self):
+        print('I am Lyra')
+
+    def run(self):
+        print('Lyra runs')
+
+    def end(self):
+        print('Lyra ends')


### PR DESCRIPTION
Add daemons to IC

Daemons (see Northern Lights) are people's (external) souls in Lyra's
world. In IC, daemons are slave (or companions) objects that can be
invoked from cities.

Consider for example the problem to add monitoring histograms to a
given city. One solution is to write all the monitoring code in the
city itself. Master forbids! The city becomes
immediately cumbersome, and the code booking and filling histograms
proliferates quickly. Plus, monitoring is typically not stable, since
the critical histograms tend to vary with time.

The alternative is that the city calls a monitoring script (ms). At init
level, the city will call the init level of the ms (say to book
histograms). Then, at run level the city calls the run method of the
ms (fill histograms) and finally, at at the end level the city calls
the end method of the ms (save histograms to disk).

The scheme is quite general, and applies to any type of script that a
given city wants to invoke to delegate any task. Thus, a daemon is
defined as an object with an __init__() method, a run method and an
end method.

Daemons live in the new daemons directory (package) in IC. In this
PR we add to IC the functionality to handle daemons.

1. The config files for cities can now define the presence of daemons by adding a variable called (surprise!) daemons which is set to a list of names (see irene_example_daemon_config.conf)

2. The method drive in base city parses the names and calls function invoke_daemons() to return instances of the corresponding classes, which must be defined in the daemon directory (see examples lyra.py and asriel.py). 

3. Also in drive, the instances of the daemons are set as attributes of the cities, which can now call them. 

4. A new method, in base_cities, called end() calls the end() method of the daemons. The run method of the daemons are called by the concrete cities. 

