### PR TITLE
Take negative run numbers for MC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ branches:
 
 install:
   - source manage.sh install ${IC_PYTHON_VERSION}
+  - bash manage.sh download_test_db_dev
 
 script:
   - HYPOTHESIS_PROFILE=hard bash manage.sh run_tests_par 4

--- a/invisible_cities/database/load_db.py
+++ b/invisible_cities/database/load_db.py
@@ -24,17 +24,17 @@ def get_min_run_values(db, run_number, sensors):
     if sensors == 'sipm': bound = '>' #sipms id's are > 100
 
     sql = '''select Max(MinRun) from ChannelGain
-where SensorID {} 100 and MinRun < {}'''.format(bound, run_number)
+where SensorID {} 100 and MinRun < {}'''.format(bound, abs(run_number))
     cursor = db.execute(sql)
     minrun_gain = cursor.fetchone()[0]
 
     sql = '''select Max(MinRun) from ChannelPosition
-where SensorID {} 100 and MinRun < {}'''.format(bound, run_number)
+where SensorID {} 100 and MinRun < {}'''.format(bound, abs(run_number))
     cursor = db.execute(sql)
     minrun_position = cursor.fetchone()[0]
 
     sql = '''select Max(MinRun) from ChannelMapping
-where SensorID {} 100 and MinRun < {}'''.format(bound, run_number)
+where SensorID {} 100 and MinRun < {}'''.format(bound, abs(run_number))
     cursor = db.execute(sql)
     minrun_map = cursor.fetchone()[0]
 
@@ -65,7 +65,7 @@ as gain ON pos.SensorID = gain.SensorID LEFT JOIN
 as blr ON map.ElecID = blr.ElecID
 where pos.SensorID < 100 and pos.MinRun={0} and map.MinRun={2} and pos.Label LIKE 'PMT%'
 order by Active desc, pos.SensorID'''\
-    .format(minrun_position, minrun_gain, minrun_map, run_number)
+    .format(minrun_position, minrun_gain, minrun_map, abs(run_number))
     data = pd.read_sql_query(sql, conn)
     data.fillna(0, inplace=True)
     conn.close()
@@ -90,7 +90,7 @@ ON pos.SensorID = map.SensorID LEFT JOIN
 ON pos.SensorID = msk.SensorID
 where pos.SensorID > 100 and pos.MinRun={0} and gain.MinRun={1}
 and map.MinRun={2} order by pos.SensorID'''\
-    .format(minrun_position, minrun_gain, minrun_map, run_number)
+    .format(minrun_position, minrun_gain, minrun_map, abs(run_number))
     data = pd.read_sql_query(sql, conn)
     conn.close()
     return data
@@ -104,27 +104,25 @@ def DetectorGeo():
     return data
 
 def SiPMNoise(run_number=1e5):
-    if run_number == 0:
-        run_number = runNumberForMC
     dbfile = os.environ['ICTDIR'] + DATABASE_LOCATION
     conn = sqlite3.connect(dbfile)
     cursor = conn.cursor()
 
     sqlbaseline = '''select Energy from SipmBaseline
 where MinRun <= {0} and (MaxRun >= {0} or MaxRun is NULL)
-order by SensorID;'''.format(run_number)
+order by SensorID;'''.format(abs(run_number))
     cursor.execute(sqlbaseline)
     baselines = np.array(tmap(itemgetter(0), cursor.fetchall()))
 
     sqlnoisebins = '''select Energy from SipmNoiseBins
 where MinRun <= {0} and (MaxRun >= {0} or MaxRun is NULL)
-order by Bin;'''.format(run_number)
+order by Bin;'''.format(abs(run_number))
     cursor.execute(sqlnoisebins)
     noise_bins = np.array(tmap(itemgetter(0), cursor.fetchall()))
 
     sqlnoise = '''select * from SipmNoise
 where MinRun <= {0} and (MaxRun >= {0} or MaxRun is NULL)
-order by SensorID;'''.format(run_number)
+order by SensorID;'''.format(abs(run_number))
     cursor.execute(sqlnoise)
     data = tmap(itemgetter(slice(3,None)), cursor.fetchall())
     noise = np.array(data).reshape(1792, 300)

--- a/invisible_cities/database/load_db_test.py
+++ b/invisible_cities/database/load_db_test.py
@@ -45,3 +45,8 @@ def test_DetectorGeometry():
     assert geo['ZMIN'][0] ==    0
     assert geo['ZMAX'][0] ==  532
     assert geo['RMAX'][0] ==  198
+
+
+def test_mc_runs_equal_data_runs():
+    assert (DB.DataPMT (-3550).values == DB.DataPMT (3550).values).all()
+    assert (DB.DataSiPM(-3550).values == DB.DataSiPM(3550).values).all()


### PR DESCRIPTION
This PR changes the way we use the DB. Instead of using just run number 0 for MC, now the idea is to put a negative number. The configuration obtained will be the same as the one from the same positive run number. The negative sign will indicate that is an MC file.