### PR TITLE
Diomira fix

### DIFF
--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -466,14 +466,14 @@ class PmapCity(CalibratedCity):
                                    stride              = conf.s1_stride,
                                    length = minmax(min = conf.s1_lmin,
                                                    max = conf.s1_lmax),
-                                   rebin               = False)
+                                   rebin               = conf.s1_rebin)
 
         self.s2_params = S12Params(time = minmax(min   = conf.s2_tmin,
                                                  max   = conf.s2_tmax),
                                    stride              = conf.s2_stride,
                                    length = minmax(min = conf.s2_lmin,
                                                    max = conf.s2_lmax),
-                                   rebin               = True)
+                                   rebin               = conf.s2_rebin)
 
         self.thr_sipm_s2 = conf.thr_sipm_s2
 

--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -796,8 +796,8 @@ class MonteCarloCity(TriggerEmulationCity):
         return sf.simulate_sipm_response(event, sipmrd, sipms_noise_sampler,
                                          sipm_adc_to_pes)
 
-    @staticmethod
-    def simulate_pmt_response(event, pmtrd, sipm_adc_to_pes):
+
+    def simulate_pmt_response(self, event, pmtrd, pmt_adc_to_pes):
         """ Full simulation of the energy plane response
         Input:
          1) extensible array pmtrd
@@ -808,8 +808,9 @@ class MonteCarloCity(TriggerEmulationCity):
         front end electronics (LPF, HPF filters)
         array of BLR waveforms (only decimation)
         """
-        return sf.simulate_pmt_response(event, pmtrd, sipm_adc_to_pes)
-
+        return sf.simulate_pmt_response(event, pmtrd,
+                                        pmt_adc_to_pes,
+                                        self.run_number)
 
     @property
     def FE_t_sample(self):

--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -177,6 +177,7 @@ class City:
             for deamon in self.daemons:
                 deamon.end()
 
+        print(self.cnt)
         return self.cnt
 
     def display_IO_info(self):

--- a/invisible_cities/cities/diomira.py
+++ b/invisible_cities/cities/diomira.py
@@ -94,7 +94,7 @@ class Diomira(MonteCarloCity):
 
             # Simulate detector response
             dataPMT, blrPMT = self.simulate_pmt_response(evt, pmtrd,
-                                                         self.sipm_adc_to_pes)
+                                                         self.adc_to_pes)
             dataSiPM_noisy = self.simulate_sipm_response(evt, sipmrd,
                                                          self.noise_sampler,
                                                          self.sipm_adc_to_pes)

--- a/invisible_cities/cities/diomira.py
+++ b/invisible_cities/cities/diomira.py
@@ -105,7 +105,6 @@ class Diomira(MonteCarloCity):
             # simulate trigger
             peak_data = self.emulate_trigger(RWF)
             # filter events as a function of trigger
-
             if not self.trigger_filter(peak_data):
                 continue
             self.cnt.increment_counter('nevt_out')

--- a/invisible_cities/config/diomira.conf
+++ b/invisible_cities/config/diomira.conf
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 # diomira.conf
 
 # Diomira is a concrete sensor_params city
@@ -10,3 +12,41 @@ nmax =  2
 # override the default input/output files:
 files_in = '$ICDIR/database/test_data/electrons_40keV_z250_MCRD.h5'
 file_out = '/tmp/electrons_40keV_z250_test_RWF.h5'
+
+# override trigger emulation parameters.
+# The values following correspond to typical Kr trigger.
+
+trigger_type = 'S2'
+
+# channels used for trigger
+tr_channels = [0,1]   # this changes depending of configuration
+
+# and correspond to two central PMTs, which are eleciD = [0,1]
+# for run = 0 but elecID = [18, 19] for run = 4446 (a Kr run taken in June)
+
+# At least MIN_NUMB_CHANNELS must have a signal
+min_number_channels = 2
+
+# Min/max height of signal in ADC counts per PMT
+
+min_height =   10 * adc     # baseline deviation in elog
+max_height = 500  * adc    # max amplitude (waveform in bins of 25 ns)
+
+# Min/max width in ns
+min_width =  2000 * ns   # Min time Trh in elog
+max_width = 40000 * ns   # Max time Thr in elog
+
+# Min/max charge in ADC counts per PMT
+min_charge =  5000 * adc  # Qmin in elog
+max_charge = 50000 * adc  # Qmax in elog
+
+# Ad-hoc ratio describing difference in scale between data and MC
+data_mc_ratio = 0.6   # MC has a factor 2.5 less light than data
+
+# Set parameters to search for S2
+s2_tmin   =    101 * mus # assumes S1 at 100 mus, change if S1 not at 100 mus
+s2_tmax   =    799 * mus # end of the window
+s2_stride =     40       #  40 x 25 = 1   mus
+s2_lmin   =    100       # 100 x 25 = 2.5 mus
+s2_lmax   = 100000       # maximum value of S2 width
+s2_rebin  = False        # DO NOT! rebin the PMT waveform

--- a/invisible_cities/config/diomira.conf
+++ b/invisible_cities/config/diomira.conf
@@ -41,7 +41,7 @@ min_charge =  5000 * adc  # Qmin in elog
 max_charge = 50000 * adc  # Qmax in elog
 
 # Ad-hoc ratio describing difference in scale between data and MC
-data_mc_ratio = 0.6   # MC has a factor 2.5 less light than data
+data_mc_ratio = 0.8   # MC has a factor 2.5 less light than data
 
 # Set parameters to search for S2
 s2_tmin   =    101 * mus # assumes S1 at 100 mus, change if S1 not at 100 mus

--- a/invisible_cities/config/pmap_city.conf
+++ b/invisible_cities/config/pmap_city.conf
@@ -1,3 +1,4 @@
+#!/usr/bin/python
 # pmap_city_conf
 
 # A PMAP city computes PMAPS starting from a CalibratedCity
@@ -10,8 +11,9 @@ include('$ICDIR/config/calibrated_city.conf')
 s1_tmin   =  99 * mus # position of S1 in MC files at 100 mus
 s1_tmax   = 101 * mus # change tmin and tmax if S1 not at 100 mus
 s1_stride =   4       # minimum number of 25 ns bins in S1 searches
-s1_lmin   =   8 #        8 x 25 = 200 ns
-s1_lmax   =  20 #       20 x 25 = 500 ns
+s1_lmin   =   8       # 8 x 25 = 200 ns
+s1_lmax   =  20       # 20 x 25 = 500 ns
+s1_rebin  =  False    # Do not rebin S1 by default
 
 # Set parameters to search for S2
 s2_tmin   =    101 * mus # assumes S1 at 100 mus, change if S1 not at 100 mus
@@ -19,6 +21,7 @@ s2_tmax   =   1199 * mus # end of the window
 s2_stride =     40       #  40 x 25 = 1   mus
 s2_lmin   =    100       # 100 x 25 = 2.5 mus
 s2_lmax   = 100000       # maximum value of S2 width
+s2_rebin  =  True        # Rebin by default
 
 # Set S2Si parameters
-thr_sipm_s2 = 20 * pes  # Threshold for the full sipm waveform
+thr_sipm_s2 = 10 * pes  # Threshold for the full sipm waveform

--- a/invisible_cities/config/trigger_emulation_city.conf
+++ b/invisible_cities/config/trigger_emulation_city.conf
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 # trigger_emulation_city.conf
 
 # emulates the online trigger. Cecilia operates
@@ -16,24 +18,18 @@ tr_channels = [0,1]
 min_number_channels = 2
 
 # Min/max height of signal in ADC counts per PMT
-min_height =   15 * adc
-max_height = 20000 * adc
+
+min_height =   10 * adc     # baseline deviation in elog
+max_height = 2000 * adc    # max amplitude
 
 # Min/max width in ns
 min_width =  2000 * ns
-max_width = 50000 * ns
+max_width = 500000 * ns
 
 # Min/max charge in ADC counts per PMT
-min_charge =  3000 * adc
-max_charge = 50000 * adc
+min_charge =  1000 * adc
+max_charge = 500000 * adc
 
 
 # Ad-hoc ratio describing difference in scale between data and MC
 data_mc_ratio = 0.8
-
-# Set parameters to search for S2
-s2_tmin   =    101 * mus # assumes S1 at 100 mus, change if S1 not at 100 mus
-s2_tmax   =    799 * mus # end of the window
-s2_stride =     40       #  40 x 25 = 1   mus
-s2_lmin   =    100       # 100 x 25 = 2.5 mus
-s2_lmax   = 100000       # maximum value of S2 width

--- a/invisible_cities/icaro/pmaps_mpl.py
+++ b/invisible_cities/icaro/pmaps_mpl.py
@@ -39,19 +39,19 @@ def plot_s12(s12, figsize=(6,6)):
             plt.plot(wfm.t/units.mus, wfm.E)
 
 
-def plot_s2si_map(s2si, cmap='Blues'):
+def plot_s2si_map(s2si, run_number=0, cmap='Blues'):
         """Plot a map of the energies of S2Si objects."""
 
-        DataSensor = load_db.DataSiPM(0)
+        DataSensor = load_db.DataSiPM(run_number)
         radius = 2
         xs = DataSensor.X.values
         ys = DataSensor.Y.values
         r = np.ones(len(xs)) * radius
-        #col = np.zeros(len(xs))
+        col = np.zeros(len(xs))
+        for peak_no in range(s2si.number_of_peaks):
+               for sipm_no in s2si.sipms_in_peak(peak_no):
+                    col[sipm_no] += s2si.sipm_total_energy(peak_no, sipm_no)
 
-        col = np.array([s2si.sipm_total_energy(peak_no, sipm_no)
-               for peak_no in range(s2si.number_of_peaks)
-               for sipm_no in s2si.sipms_in_peak(peak_no)])
         plt.figure(figsize=(8, 8))
         plt.subplot(aspect="equal")
         circles(xs, ys, r, c=col, alpha=0.5, ec="none", cmap=cmap)

--- a/invisible_cities/reco/sensor_functions.py
+++ b/invisible_cities/reco/sensor_functions.py
@@ -11,7 +11,7 @@ def convert_channel_id_to_IC_id(data_frame, channel_ids):
     return pd.Index(data_frame.ChannelID).get_indexer(channel_ids)
 
 
-def simulate_pmt_response(event, pmtrd, adc_to_pes):
+def simulate_pmt_response(event, pmtrd, adc_to_pes, run_number = 0):
     """ Full simulation of the energy plane response
     Input:
      1) extensible array pmtrd
@@ -24,7 +24,8 @@ def simulate_pmt_response(event, pmtrd, adc_to_pes):
     # Single Photoelectron class
     spe = FE.SPE()
     # FEE, with noise PMT
-    fee  = FE.FEE(noise_FEEPMB_rms=FE.NOISE_I, noise_DAQ_rms=FE.NOISE_DAQ)
+    fee  = FE.FEE(run_number,
+                  noise_FEEPMB_rms=FE.NOISE_I, noise_DAQ_rms=FE.NOISE_DAQ)
     NPMT = pmtrd.shape[1]
     RWF  = []
     BLRX = []

--- a/invisible_cities/sierpe/fee.py
+++ b/invisible_cities/sierpe/fee.py
@@ -142,7 +142,7 @@ def spe_pulse_from_vector(spe, cnt):
 class FEE:
     """Complete model of Front-end electronics."""
 
-    def __init__(self, gain=FEE_GAIN,
+    def __init__(self, run_number = 0, gain=FEE_GAIN,
                  c2=C2, c1=C1, r1=R1, zin=Zin, fsample=f_sample,
                  flpf1=f_LPF1, flpf2=f_LPF2,
                  noise_FEEPMB_rms=NOISE_I, noise_DAQ_rms=NOISE_DAQ, lsb=LSB):
@@ -172,7 +172,6 @@ class FEE:
         self.freq_zero = 1 / (self.R1 * self.C1)
         self.coeff_c = self.freq_zero / (self.f_sample * np.pi)
 
-        run_number = 0 # until we decide something else, MC is run 0
         DataPMT = DB.DataPMT(run_number)
 
         self.coeff_blr_pmt = DataPMT.coeff_blr.values


### PR DESCRIPTION
This small PR fixes a minor (major) issue.

DIOMIRA simulates both the response of the sensors and the trigger. When emulating the response of the trigger, one is simulating the search on the FPGA on peaks in individual PMTs. This search is performed with the same algos used to search s1 and s2 in the calibrated sum, but the individual PMTs are neither calibrated, nor rebinned. 

Consequently, the search for s1 and s2 must allow the possibility that the waveform is not rebined (previously we never rebinned s1 but always rebinned s2). This is done in this PR, together with defining proper parameters for DIOMIRA.  