### PR TITLE
functions for finding and using s2s from individual pmts

### DIFF
--- a/invisible_cities/core/exceptions.py
+++ b/invisible_cities/core/exceptions.py
@@ -44,3 +44,6 @@ class NoHits(ICException):
 
 class NoVoxels(ICException):
     pass
+
+class SumNotEqualToSumOfParts(ICException):
+    pass

--- a/invisible_cities/core/exceptions.py
+++ b/invisible_cities/core/exceptions.py
@@ -45,5 +45,5 @@ class NoHits(ICException):
 class NoVoxels(ICException):
     pass
 
-class SumNotEqualToSumOfParts(ICException):
+class InconsistentS2dS2pmtd(ICException):
     pass

--- a/invisible_cities/evm/pmaps.pxd
+++ b/invisible_cities/evm/pmaps.pxd
@@ -47,7 +47,7 @@ cdef class S2Si(S2):
     The s2sid is a dictionary {peak:{nsipm:[E]}}
     """
     cdef public s2sid
-    cdef dict _s2sid
+    cdef  dict _s2sid
     cpdef number_of_sipms_in_peak(self, int peak_number)
     cpdef sipms_in_peak(self, int peak_number)
     cpdef sipm_waveform(self, int peak_number, int sipm_number)
@@ -60,9 +60,11 @@ cdef class S2Si(S2):
 """Given an s2d and an s2sid, return an s2d containing only the peaks shared by s2sid"""
 cpdef check_s2d_and_s2sid_share_peaks(dict s2d, dict s2sid)
 
+
 cdef class S2Pmt(S2):
-  cdef public s2pmtd
-  cdef dict _s2pmtd
-  cpdef pmt_waveform(self, int peak_number, int pmt_number)
-  cpdef pmt_total_energy(self, int peak_number, int pmt_number)
-  cpdef store(self, table, event_number)
+    cdef public s2pmtd
+    cdef  dict _s2pmtd
+    cpdef pmt_waveform(self, int peak_number, int pmt_number)
+    cpdef pmt_total_energy_in_peak(self, int peak_number, int pmt_number)
+    cpdef pmt_total_energy(self, int pmt_number)
+    cpdef store(self, table, event_number)

--- a/invisible_cities/evm/pmaps.pxd
+++ b/invisible_cities/evm/pmaps.pxd
@@ -59,3 +59,10 @@ cdef class S2Si(S2):
 
 """Given an s2d and an s2sid, return an s2d containing only the peaks shared by s2sid"""
 cpdef check_s2d_and_s2sid_share_peaks(dict s2d, dict s2sid)
+
+cdef class S2Pmt(S2):
+  cdef public s2pmtd
+  cdef dict _s2pmtd
+  cpdef pmt_waveform(self, int peak_number, int pmt_number)
+  cpdef pmt_total_energy(self, int peak_number, int pmt_number)
+  cpdef store(self, table, event_number)

--- a/invisible_cities/evm/pmaps.pyx
+++ b/invisible_cities/evm/pmaps.pyx
@@ -316,21 +316,34 @@ cdef class S2Pmt(S2):
           E = self.s2pmtd[peak_number][pmt_number]
           return Peak(self.peak_waveform(peak_number).t, np.asarray(E))
 
-    cpdef pmt_total_energy(self, int peak_number, int pmt_number):
+    cpdef pmt_total_energy_in_peak(self, int peak_number, int pmt_number):
         """
         For peak_number and and pmt_number return the integrated energy in that pmt in that peak
         s2pmtd[peak_number][pmt_number].sum().
         """
         cdef double et
         try:
-            et = np.sum(self.s2sid[peak_number][pmt_number])
+            et = np.sum(self.s2pmtd[peak_number][pmt_number])
             return et
         except KeyError:
             raise PeakNotFound
 
+    cpdef pmt_total_energy(self, int pmt_number):
+        """
+        For peak_number and and pmt_number return the integrated energy in that pmt in that peak
+        s2pmtd[peak_number][pmt_number].sum().
+        """
+        cdef double sum
+        cdef int pn
+        sum = 0
+        for pn in self.s2pmtd:
+            sum += self.pmt_total_energy_in_peak(pn, pmt_number)
+        return sum
+
+
     cpdef store(self, table, event_number):
         row = table.row
-        for peak, s2_pmts in self.s2sid.items():
+        for peak, s2_pmts in self.s2pmtd.items():
             for npmt, s2_pmt in enumerate(s2_pmt):
                 for E in s2_pmt:
                     row["event"]   = event_number

--- a/invisible_cities/evm/pmaps.pyx
+++ b/invisible_cities/evm/pmaps.pyx
@@ -8,6 +8,7 @@ from .. core.exceptions        import PeakNotFound
 from .. core.exceptions        import SipmEmptyList
 from .. core.exceptions        import SipmNotFound
 from .. core.core_functions    import loc_elem_1d
+from .. core.exceptions        import SumNotEqualToSumOfParts
 from .. core.system_of_units_c import units
 
 
@@ -281,3 +282,59 @@ cdef class S2Si(S2):
 
     def __repr__(self):
         return self.__str__()
+
+
+cdef class S2Pmt(S2):
+    """
+    A pmt S2 class for storing individual pmt s2 responses.
+
+    It is analagous to S2Si with the caveat that each peak key in s2pmtd maps to a nparray of
+    pmt energies instead of another dictionary. Here a dictionary mapping pmt_number --> energy is
+    superfluous since the csum of all active pmts are used to calculate the s2 energy.
+    """
+    def __init__(self, s2d, s2pmtd):
+        """where:
+        s2d    = { peak_number: [[t], [E]]}
+        s2pmtd = { peak_number: [[Epmt0], [Epmt1], ... ,[EpmtN]] }
+        """
+
+        cdef int i, pn
+        cdef double E
+        for pn in s2d:
+            for i, E in enumerate(s2d[pn][1]):        # Check that each energy in s2d[peak][E]
+                if E != s2pmtd[pn][:, i].sum():      # equals the sum of the energies in
+                    raise SumNotEqualToSumOfParts    # the pmts at that time bin.
+
+        S2.__init__(self, s2d)
+        self.s2pmtd = s2pmtd
+
+    cpdef pmt_waveform(self, int peak_number, int pmt_number):
+        cdef double [:] E
+        if peak_number not in self.s2pmtd:
+            raise PeakNotFound
+        else:
+          E = self.s2pmtd[peak_number][pmt_number]
+          return Peak(self.peak_waveform(peak_number).t, np.asarray(E))
+
+    cpdef pmt_total_energy(self, int peak_number, int pmt_number):
+        """
+        For peak_number and and pmt_number return the integrated energy in that pmt in that peak
+        s2pmtd[peak_number][pmt_number].sum().
+        """
+        cdef double et
+        try:
+            et = np.sum(self.s2sid[peak_number][pmt_number])
+            return et
+        except KeyError:
+            raise PeakNotFound
+
+    cpdef store(self, table, event_number):
+        row = table.row
+        for peak, s2_pmts in self.s2sid.items():
+            for npmt, s2_pmt in enumerate(s2_pmt):
+                for E in s2_pmt:
+                    row["event"]   = event_number
+                    row["peak"]    = peak
+                    row["nsipm"]   = npmt
+                    row["ene"]     = E
+                    row.append()

--- a/invisible_cities/evm/pmaps_test.py
+++ b/invisible_cities/evm/pmaps_test.py
@@ -11,13 +11,14 @@ from hypothesis.extra.numpy import arrays
 
 from .. types.ic_types_c    import xy
 from .. types.ic_types_c    import minmax
+from .. core.exceptions     import SumNotEqualToSumOfParts
 
-from .. reco import  pmaps_functions as pmapf
 from .. reco.pmaps_functions_c import integrate_sipm_charges_in_peak
-
+from .. reco  import pmaps_functions as pmapf
 from .  pmaps import S1
 from .  pmaps import S2
 from .  pmaps import S2Si
+from .  pmaps import S2Pmt
 from .  pmaps import Peak
 from .  pmaps import check_s2d_and_s2sid_share_peaks
 
@@ -210,3 +211,16 @@ def test_check_s2d_and_s2sid_share_peaks():
     for pn in s2d_shared_peaks:
         assert pn in s2sid
         assert pn % 2 == 0
+
+
+def test_S2Pmt_raises_error_when_s2_peak_E_not_equal_to_sum_of_s2pmt_peak():
+    timebins = 10
+    npmts  = 12
+    s2pmtd = {0: np.random.random((npmts, timebins))}
+    s2d    = {0: np.array([list(range(timebins)), s2pmtd[0].sum(axis=0)])}
+    s2pmtd[0][-1, -1] += .001
+    try:
+        S2Pmt(s2d, s2pmtd)
+        assert False
+    except SumNotEqualToSumOfParts:
+        pass

--- a/invisible_cities/evm/pmaps_test.py
+++ b/invisible_cities/evm/pmaps_test.py
@@ -224,3 +224,43 @@ def test_S2Pmt_raises_error_when_s2_peak_E_not_equal_to_sum_of_s2pmt_peak():
         assert False
     except SumNotEqualToSumOfParts:
         pass
+
+
+def test_S2Pmt_pmt_waveform():
+    timebins = 10
+    npmts = 5
+    # construct dicts
+    for peak in range(3):
+        s2pmtd = {peak: np.random.random((npmts, timebins))}
+        s2d    = {peak: np.array([list(range(timebins)), s2pmtd[peak].sum(axis=0)])}
+    # get pmt s2pmt
+    s2pmt = S2Pmt(s2d, s2pmtd)
+    for pn in s2pmt.peaks:
+        for pmt in range(npmts):
+            assert (s2pmt.pmt_waveform(pn, pmt).t == s2d   [pn][  0]).all()
+            assert (s2pmt.pmt_waveform(pn, pmt).E == s2pmtd[pn][pmt]).all()
+
+
+def test_S2Pmt_pmt_total_energy_in_peak():
+    timebins = 10
+    npmts  = 12
+    s2pmtd = {0: np.random.random((npmts, timebins))}
+    s2d    = {0: np.array([list(range(timebins)), s2pmtd[0].sum(axis=0)])}
+    s2pmt  = S2Pmt(s2d, s2pmtd)
+    for pmt in range(npmts):
+        assert s2pmt.pmt_total_energy_in_peak(0, pmt) == s2pmtd[0][pmt].sum()
+
+
+def test_pmt_total_energy():
+    timebins = 10
+    npmts = 5
+    # construct dicts
+    for peak in range(3):
+        s2pmtd = {peak: np.random.random((npmts, timebins))}
+        s2d    = {peak: np.array([list(range(timebins)), s2pmtd[peak].sum(axis=0)])}
+    # get pmt s2pmt
+    s2pmt = S2Pmt(s2d, s2pmtd)
+    for pmt in range(npmts):
+        s = 0
+        for pn in s2pmt.peaks: s += s2pmt.pmt_total_energy_in_peak(pn, pmt)
+        assert s2pmt.pmt_total_energy(pmt) == s

--- a/invisible_cities/evm/pmaps_test.py
+++ b/invisible_cities/evm/pmaps_test.py
@@ -11,7 +11,7 @@ from hypothesis.extra.numpy import arrays
 
 from .. types.ic_types_c    import xy
 from .. types.ic_types_c    import minmax
-from .. core.exceptions     import SumNotEqualToSumOfParts
+from .. core.exceptions     import InconsistentS2dS2pmtd
 
 from .. reco.pmaps_functions_c import integrate_sipm_charges_in_peak
 from .. reco  import pmaps_functions as pmapf
@@ -218,11 +218,11 @@ def test_S2Pmt_raises_error_when_s2_peak_E_not_equal_to_sum_of_s2pmt_peak():
     npmts  = 12
     s2pmtd = {0: np.random.random((npmts, timebins))}
     s2d    = {0: np.array([list(range(timebins)), s2pmtd[0].sum(axis=0)])}
-    s2pmtd[0][-1, -1] += .001
+    s2pmtd[0][-1, -1] += .0001
     try:
         S2Pmt(s2d, s2pmtd)
         assert False
-    except SumNotEqualToSumOfParts:
+    except InconsistentS2dS2pmtd:
         pass
 
 

--- a/invisible_cities/reco/peak_functions.py
+++ b/invisible_cities/reco/peak_functions.py
@@ -172,55 +172,58 @@ def _rebin_waveform(ts, t_finish, wf, stride=40):
     return T, E
 
 
-def _select_peaks_of_allowed_length(pbounds, length=minmax(8, 1000000)):
+def _select_peaks_of_allowed_length(peak_bounds_temp, length=minmax(8, 1000000)):
     """
     Given a dictionary, pbounds, mapping potential peak number to potential peak, return a
     dictionary, bounds, mapping peak numbers (consecutive and starting from 0) to those peaks in
     pbounds of allowed length.
     """
     j=0
-    bounds = {}
-    for pbound in pbounds.values():
-        if length.min <= pbound[1] - pbound[0] < length.max:
-            bounds[j] = pbound
+    peak_bounds = {}
+    for bound_temp in peak_bounds_temp.values():
+        if length.min <= bound_temp[1] - bound_temp[0] < length.max:
+            peak_bounds[j] = bound_temp
             j+=1
-    return bounds
+    return peak_bounds
 
 
 def _find_peaks(index, time=minmax(0, 1e+6), length=minmax(8, 1000000), stride=4):
     """
-    _find_s12 was too big. First it found the start and stop times of an S12, then it created the S12L.
+    _find_s12 is too big. First it found the start and stop times of an S12, then it created the S12L.
     This can and should be performed by separate functions. This also enables us to find the S2Pmt.
+
+    Note: for now find_peaks cannot be used to find s2si peaks as time associated with indices is
+    assumed to be index*25ns in time_from_index function
     """
 
-    bounds = {}
+    peak_bounds = {}
     T = cpf._time_from_index(index)
     # Start end end index of S12, [start i, end i)
     i_min = int(time[0] / (25*units.ns))     # index in csum  corresponding to t.min
     i_i = np.where(index >= i_min)[0].min()  # index in index corresponding to t.min (or first
                                              # time not threshold suppressed)
-    bounds[0] = np.array([index[i_i], index[i_i] + 1], dtype=np.int32)
+    peak_bounds[0] = np.array([index[i_i], index[i_i] + 1], dtype=np.int32)
 
     j = 0
     for i in range(i_i + 1, len(index)):
         assert T[i] > time[0]
         if T[i] > time.max: break
-        # New pbounds, create new start and end index
+        # New peak_bounds, create new start and end index
         elif index[i] - stride > index[i-1]:
             j += 1
-            bounds[j] = np.array([index[i], index[i] + 1], dtype=np.int32)
+            peak_bounds[j] = np.array([index[i], index[i] + 1], dtype=np.int32)
         # Update end index in current S12
-        else: bounds[j][1] = index[i] + 1
-    return _select_peaks_of_allowed_length(bounds, length=length)
+        else: peak_bounds[j][1] = index[i] + 1
+    return _select_peaks_of_allowed_length(peak_bounds, length=length)
 
 
-def _extract_peaks_from_waveform(wf, bounds, rebin_stride=40):
+def _extract_peaks_from_waveform(wf, peak_bounds, rebin_stride=1):
     """
     given a waveform a a dictionary mapping peak_no to the indices in the waveform corresponding
     to that peak, return an S12L
     """
     S12L = {}
-    for peak_no, i_peak in bounds.items():
+    for peak_no, i_peak in peak_bounds.items():
         wf_peak = wf[i_peak[0]: i_peak[1]]
         if rebin_stride > 1:
             TR, ER = _rebin_waveform(*cpf._time_from_index(i_peak), wf_peak, stride=rebin_stride)

--- a/invisible_cities/reco/peak_functions.py
+++ b/invisible_cities/reco/peak_functions.py
@@ -234,6 +234,27 @@ def _extract_peaks_from_waveform(wf, peak_bounds, rebin_stride=1):
     return S12L
 
 
+def get_s2pmtd(CWF, peak_bounds, rebin_stride=40):
+    """
+    Given the corrected waveforms of all active pmts for one event, CWF, and the boundaries of
+    all of the s12 peaks found in the csum, peak_bounds, return the s2 peaks of the individual
+    pmts, s2pmtd.
+    """
+    # extract the peaks from the cwf of each pmt
+    S12Ls = [cpf.extract_peaks_from_waveform(cwf, peak_bounds, rebin_stride=rebin_stride) \
+             for cwf in CWF]
+
+    s2pmtd = {}
+    npmts  = len(S12Ls)
+    for pn in peak_bounds:
+        # initialize an the array of pmt energies with shape npmts, len(peak.t)
+        s2pmtd[pn] = np.empty((npmts, len(S12Ls[0][pn][0])), dtype=np.float32)
+        # fill the array of pmt s2 energies one pmt at a time
+        for pmt in range(npmts): s2pmtd[pn][pmt] = S12Ls[pmt][pn][1]
+
+    return s2pmtd
+
+
 def _find_s12(csum, index,
               time   = minmax(0, 1e+6),
               length = minmax(8, 1000000),

--- a/invisible_cities/reco/peak_functions.py
+++ b/invisible_cities/reco/peak_functions.py
@@ -214,7 +214,6 @@ def _find_peaks(index, time=minmax(0, 1e+6), stride=4):
             peak_bounds[j] = np.array([index[i], index[i] + 1], dtype=np.int32)
         # Update end index in current S12
         else: peak_bounds[j][1] = index[i] + 1
-    #return _select_peaks_of_allowed_length(peak_bounds, length=length)
     return peak_bounds
 
 

--- a/invisible_cities/reco/peak_functions.py
+++ b/invisible_cities/reco/peak_functions.py
@@ -199,7 +199,7 @@ def _find_peaks(index, time=minmax(0, 1e+6), length=minmax(8, 1000000), stride=4
     i_min = int(time[0] / (25*units.ns))     # index in csum  corresponding to t.min
     i_i = np.where(index >= i_min)[0].min()  # index in index corresponding to t.min (or first
                                              # time not threshold suppressed)
-    bounds[0] = np.array([index[i_i], index[i_i]+ 1], dtype=np.int32)
+    bounds[0] = np.array([index[i_i], index[i_i] + 1], dtype=np.int32)
 
     j = 0
     for i in range(i_i + 1, len(index)):
@@ -210,9 +210,8 @@ def _find_peaks(index, time=minmax(0, 1e+6), length=minmax(8, 1000000), stride=4
             j += 1
             bounds[j] = np.array([index[i], index[i] + 1], dtype=np.int32)
         # Update end index in current S12
-    else: bounds[j][1] = index[i] + 1
-
-    return _get_peaks_of_allowed_length(bounds, length=length)
+        else: bounds[j][1] = index[i] + 1
+    return _select_peaks_of_allowed_length(bounds, length=length)
 
 
 def _extract_peaks_from_waveform(wf, bounds, rebin_stride=40):
@@ -249,6 +248,7 @@ def _find_s12(csum, index,
     """
 
     S12  = {}
+    T = cpf._time_from_index(index)
 
     # Start end end index of S12, [start i, end i)
     i_min = int(time[0] / (25*units.ns))     # index in csum  corresponding to t.min
@@ -268,7 +268,7 @@ def _find_s12(csum, index,
         else: S12[j][1] = index[i] + 1
 
 
-    assert ribin_stride >= 1 and rebin_stride % 1 == 0
+    assert rebin_stride >= 1 and rebin_stride % 1 == 0
 
     S12L = {}
 

--- a/invisible_cities/reco/peak_functions.py
+++ b/invisible_cities/reco/peak_functions.py
@@ -215,6 +215,22 @@ def _find_peaks(index, time=minmax(0, 1e+6), length=minmax(8, 1000000), stride=4
     return _get_peaks_of_allowed_length(bounds, length=length)
 
 
+def _extract_peaks_from_waveform(wf, bounds, rebin_stride=40):
+    """
+    given a waveform a a dictionary mapping peak_no to the indices in the waveform corresponding
+    to that peak, return an S12L
+    """
+    S12L = {}
+    for peak_no, i_peak in bounds.items():
+        wf_peak = wf[i_peak[0]: i_peak[1]]
+        if rebin_stride > 1:
+            TR, ER = _rebin_waveform(*cpf._time_from_index(i_peak), wf_peak, stride=rebin_stride)
+            S12L[peak_no] = [TR, ER]
+        else:
+            S12L[peak_no] = [np.arange(*cpf._time_from_index(i_peak), 25*units.ns), wf_peak]
+    return S12L
+
+
 def _find_s12(csum, index,
               time   = minmax(0, 1e+6),
               length = minmax(8, 1000000),
@@ -262,7 +278,6 @@ def _find_s12(csum, index,
 
             S12wf = csum[i_peak[0]: i_peak[1]]
             if rebin_stride > 1:
-                timebounds[j] = i_peak
                 TR, ER = _rebin_waveform(*cpf._time_from_index(i_peak), S12wf, stride=rebin_stride)
                 S12L[j] = [TR, ER]
             else:

--- a/invisible_cities/reco/peak_functions.py
+++ b/invisible_cities/reco/peak_functions.py
@@ -258,7 +258,7 @@ def get_s2pmtd(CWF, peak_bounds, rebin_stride=40):
 def _find_s12(csum, index,
               time   = minmax(0, 1e+6),
               length = minmax(8, 1000000),
-              stride=4, rebin_stride=40):
+              stride=4, rebin=False, rebin_stride=40):
     """
     Find S1/S2 peaks.
     input:
@@ -271,6 +271,7 @@ def _find_s12(csum, index,
     accept the peak only if within [tmin, tmax)
     returns a dictionary of S12
     """
+    if not rebin: rebin_stride = 1
     return _extract_peaks_from_waveform(
         csum, _find_peaks(index, time=time, length=length, stride=stride), rebin_stride=rebin_stride)
 

--- a/invisible_cities/reco/peak_functions.py
+++ b/invisible_cities/reco/peak_functions.py
@@ -187,7 +187,7 @@ def _select_peaks_of_allowed_length(peak_bounds_temp, length=minmax(8, 1000000))
     return peak_bounds
 
 
-def _find_peaks(index, time=minmax(0, 1e+6), length=minmax(8, 1000000), stride=4):
+def _find_peaks(index, time=minmax(0, 1e+6), stride=4):
     """
     _find_s12 is too big. First it found the start and stop times of an S12, then it created the S12L.
     This can and should be performed by separate functions. This also enables us to find the S2Pmt.
@@ -214,7 +214,8 @@ def _find_peaks(index, time=minmax(0, 1e+6), length=minmax(8, 1000000), stride=4
             peak_bounds[j] = np.array([index[i], index[i] + 1], dtype=np.int32)
         # Update end index in current S12
         else: peak_bounds[j][1] = index[i] + 1
-    return _select_peaks_of_allowed_length(peak_bounds, length=length)
+    #return _select_peaks_of_allowed_length(peak_bounds, length=length)
+    return peak_bounds
 
 
 def _extract_peaks_from_waveform(wf, peak_bounds, rebin_stride=1):

--- a/invisible_cities/reco/peak_functions.py
+++ b/invisible_cities/reco/peak_functions.py
@@ -187,7 +187,7 @@ def _select_peaks_of_allowed_length(peak_bounds_temp, length=minmax(8, 1000000))
     return peak_bounds
 
 
-def _find_peaks(index, time=minmax(0, 1e+6), stride=4):
+def _find_peaks(index, time=minmax(0, 1e+6), length=minmax(8, 1000000), stride=4):
     """
     _find_s12 is too big. First it found the start and stop times of an S12, then it created the S12L.
     This can and should be performed by separate functions. This also enables us to find the S2Pmt.
@@ -214,7 +214,8 @@ def _find_peaks(index, time=minmax(0, 1e+6), stride=4):
             peak_bounds[j] = np.array([index[i], index[i] + 1], dtype=np.int32)
         # Update end index in current S12
         else: peak_bounds[j][1] = index[i] + 1
-    return peak_bounds
+
+    return _select_peaks_of_allowed_length(peak_bounds, length)
 
 
 def _extract_peaks_from_waveform(wf, peak_bounds, rebin_stride=1):

--- a/invisible_cities/reco/peak_functions_c.pxd
+++ b/invisible_cities/reco/peak_functions_c.pxd
@@ -15,7 +15,7 @@ by time.
 Note: for now find_peaks cannot be used to find s2si peaks as time associated with indices is
 assumed to be index*25ns in time_from_index function
 """
-cpdef find_peaks(int [:] index, time, int stride=*)
+cpdef find_peaks(int [:] index, time, length, int stride=*)
 
 
 

--- a/invisible_cities/reco/peak_functions_c.pxd
+++ b/invisible_cities/reco/peak_functions_c.pxd
@@ -7,6 +7,18 @@ cimport numpy as np
 import numpy as np
 from scipy import signal
 
+
+"""
+find_peaks finds the start and stop indices of all the peaks within the time boundaries prescribed
+by time.
+
+Note: for now find_peaks cannot be used to find s2si peaks as time associated with indices is
+assumed to be index*25ns in time_from_index function
+"""
+cpdef find_peaks(int [:] index, time, int stride=*)
+
+
+
 """
 computes the ZS calibrated sum of the PMTs
 after correcting the baseline with a MAU to suppress low frequency noise.

--- a/invisible_cities/reco/peak_functions_c.pxd
+++ b/invisible_cities/reco/peak_functions_c.pxd
@@ -9,6 +9,14 @@ from scipy import signal
 
 
 """
+Given a dictionary, pbounds, mapping potential peak number to potential peak, return a
+dictionary, bounds, mapping peak numbers (consecutive and starting from 0) to those peaks in
+pbounds of allowed length.
+"""
+cdef select_peaks_of_allowed_length(dict peak_bounds_temp, length)
+
+
+"""
 find_peaks finds the start and stop indices of all the peaks within the time boundaries prescribed
 by time.
 
@@ -17,6 +25,12 @@ assumed to be index*25ns in time_from_index function
 """
 cpdef find_peaks(int [:] index, time, length, int stride=*)
 
+
+"""
+given a waveform a a dictionary mapping peak_no to the indices in the waveform corresponding
+to that peak, return an S12L
+"""
+cpdef extract_peaks_from_waveform(double [:] wf, dict peak_bounds, int rebin_stride=*)
 
 
 """

--- a/invisible_cities/reco/peak_functions_c.pxd
+++ b/invisible_cities/reco/peak_functions_c.pxd
@@ -104,7 +104,7 @@ cpdef find_s2si(double [:, :] sipmzs, dict s2d, double thr)
 
 
 cpdef find_s12(double [:] csum,  int [:] index,
-               time, length, int stride, rebin_stride)
+               time, length, int stride, rebin, rebin_stride)
 
 
 cpdef correct_s1_ene(dict s1d, np.ndarray csum)

--- a/invisible_cities/reco/peak_functions_c.pxd
+++ b/invisible_cities/reco/peak_functions_c.pxd
@@ -12,10 +12,8 @@ from scipy import signal
 Given a dictionary, pbounds, mapping potential peak number to potential peak, return a
 dictionary, bounds, mapping peak numbers (consecutive and starting from 0) to those peaks in
 pbounds of allowed length.
-
-* Consider making cdef
 """
-cpdef select_peaks_of_allowed_length(dict peak_bounds_temp, length)
+cpdef  select_peaks_of_allowed_length(dict peak_bounds_temp, length)
 
 
 """
@@ -92,22 +90,6 @@ returns the times (in ns) corresponding to the indexes in indx
 cpdef _time_from_index(int [:] indx)
 
 
-"""
-Find S1/S2 peaks.
-input:
-wfzs:   a vector containining the zero supressed wf
-indx:   a vector of indexes
-returns a dictionary
-
-do not interrupt the peak if next sample comes within stride
-accept the peak only if within [l.min, l.max)
-accept the peak only if within [t.min, t.max)
-"""
-# cpdef find_S12(double [:] csum, int [:] index,
-#                time=*, length=*,
-#                int stride=*, rebin=*, rebin_stride=*)
-
-
 cpdef find_s1(double [:] csum,  int [:] index,
               time, length,
               int stride=*, rebin=*, rebin_stride=*)
@@ -122,7 +104,11 @@ cpdef find_s2si(double [:, :] sipmzs, dict s2d, double thr)
 
 
 cpdef find_s12(double [:] csum,  int [:] index,
-               time, length, int stride, rebin, rebin_stride)
+               time, length, int stride, rebin_stride)
+
+
+cpdef correct_s1_ene(dict s1d, np.ndarray csum)
+
 
 """
 rebins  a waveform according to stride
@@ -130,11 +116,6 @@ The input waveform is a vector such that the index expresses time bin and the
 contents expresses energy (e.g, in pes)
 The function returns a rebinned vector of T and E.
 """
-
-#cpdef correct_S1_ene(S1, np.ndarray csum)
-cpdef correct_s1_ene(dict s1d, np.ndarray csum)
-
-#cpdef rebin_waveform(double [:] t, double[:] e, int stride=*)
 cpdef rebin_waveform(int ts, int t_finish, double[:] wf, int stride=*)
 
 
@@ -143,7 +124,6 @@ subtracts the baseline
 Uses a MAU to set the signal threshold (thr, in PES)
 returns ZS waveforms for all SiPMs
 """
-
 cpdef signal_sipm(np.ndarray[np.int16_t, ndim=2] SIPM,
                   double [:] adc_to_pes, double thr,
                   int n_MAU=*)

--- a/invisible_cities/reco/peak_functions_c.pxd
+++ b/invisible_cities/reco/peak_functions_c.pxd
@@ -12,8 +12,10 @@ from scipy import signal
 Given a dictionary, pbounds, mapping potential peak number to potential peak, return a
 dictionary, bounds, mapping peak numbers (consecutive and starting from 0) to those peaks in
 pbounds of allowed length.
+
+* Consider making cdef
 """
-cdef select_peaks_of_allowed_length(dict peak_bounds_temp, length)
+cpdef select_peaks_of_allowed_length(dict peak_bounds_temp, length)
 
 
 """

--- a/invisible_cities/reco/peak_functions_c.pxd
+++ b/invisible_cities/reco/peak_functions_c.pxd
@@ -13,7 +13,7 @@ Given a dictionary, pbounds, mapping potential peak number to potential peak, re
 dictionary, bounds, mapping peak numbers (consecutive and starting from 0) to those peaks in
 pbounds of allowed length.
 """
-cpdef  select_peaks_of_allowed_length(dict peak_bounds_temp, length)
+cpdef  _select_peaks_of_allowed_length(dict peak_bounds_temp, length)
 
 
 """

--- a/invisible_cities/reco/peak_functions_c.pyx
+++ b/invisible_cities/reco/peak_functions_c.pyx
@@ -164,7 +164,7 @@ cpdef _time_from_index(int [:] indx):
     return np.asarray(tzs)
 
 
-cdef select_peaks_of_allowed_length(dict peak_bounds_temp, length):
+cpdef select_peaks_of_allowed_length(dict peak_bounds_temp, length):
     """
     Given a dictionary, pbounds, mapping potential peak number to potential peak, return a
     dictionary, bounds, mapping peak numbers (consecutive and starting from 0) to those peaks in
@@ -173,7 +173,7 @@ cdef select_peaks_of_allowed_length(dict peak_bounds_temp, length):
 
     cdef int j = 0
     cdef dict peak_bounds = {}
-    cdef bound_temp = int [:]
+    cdef int [:] bound_temp
     for bound_temp in peak_bounds_temp.values():
         if length.min <= bound_temp[1] - bound_temp[0] < length.max:
             peak_bounds[j] = bound_temp
@@ -222,9 +222,6 @@ cpdef extract_peaks_from_waveform(double [:] wf, dict peak_bounds, int rebin_str
         j += 1
 
     return S12L
-
-
-
 
 
 cpdef find_s1(double [:] csum,  int [:] index,

--- a/invisible_cities/reco/peak_functions_c.pyx
+++ b/invisible_cities/reco/peak_functions_c.pyx
@@ -164,7 +164,7 @@ cpdef _time_from_index(int [:] indx):
     return np.asarray(tzs)
 
 
-cpdef find_peaks(int [:] index, time, int stride=4):
+cpdef find_peaks(int [:] index, time, length, int stride=4):
     cdef double tmin, tmax
     cdef double [:] T = _time_from_index(index)
     cdef dict peak_bounds  = {}
@@ -173,7 +173,7 @@ cpdef find_peaks(int [:] index, time, int stride=4):
     lmin, lmax = length
 
     i_min = tmin / (25*units.ns)                          # index in csum  corresponding to t.min
-    i_i   = np.where(np.asarray(index) >= i_min)[0].min() # index in index corresponding to t.min 
+    i_i   = np.where(np.asarray(index) >= i_min)[0].min() # index in index corresponding to t.min
                                                           # (or first time not threshold suppressed)
     peak_bounds[0] = np.array([index[i_i], index[i_i] + 1], dtype=np.int32)
 

--- a/invisible_cities/reco/peak_functions_c.pyx
+++ b/invisible_cities/reco/peak_functions_c.pyx
@@ -231,7 +231,7 @@ cpdef find_s1(double [:] csum,  int [:] index,
     find s1 peaks and returns S1 objects
     """
 
-    return S1(find_s12(csum, index, time, length, stride, rebin_stride))
+    return S1(find_s12(csum, index, time, length, stride, rebin, rebin_stride))
 
 
 cpdef find_s2(double [:] csum,  int [:] index,
@@ -253,7 +253,7 @@ cpdef find_s2si(double [:, :] sipmzs, dict s2d, double thr):
 
 
 cpdef find_s12(double [:] csum,  int [:] index,
-               time, length, int stride, rebin_stride):
+               time, length, int stride, rebin, rebin_stride):
     """
     Find S1/S2 peaks.
     input:
@@ -265,6 +265,7 @@ cpdef find_s12(double [:] csum,  int [:] index,
     accept the peak only if within [tmin, tmax)
     returns a dictionary of S12
     """
+    if not rebin: rebin_stride = 1
     return extract_peaks_from_waveform(
         csum, find_peaks(index, time, length, stride=stride), rebin_stride=rebin_stride)
 

--- a/invisible_cities/reco/peak_functions_c.pyx
+++ b/invisible_cities/reco/peak_functions_c.pyx
@@ -164,7 +164,7 @@ cpdef _time_from_index(int [:] indx):
     return np.asarray(tzs)
 
 
-cpdef select_peaks_of_allowed_length(dict peak_bounds_temp, length):
+cpdef _select_peaks_of_allowed_length(dict peak_bounds_temp, length):
     """
     Given a dictionary, pbounds, mapping potential peak number to potential peak, return a
     dictionary, bounds, mapping peak numbers (consecutive and starting from 0) to those peaks in
@@ -205,7 +205,7 @@ cpdef find_peaks(int [:] index, time, length, int stride=4):
         # Update end index in current peak_bounds
         else: peak_bounds[j][1] = index[i] + 1
 
-    return select_peaks_of_allowed_length(peak_bounds, length)
+    return _select_peaks_of_allowed_length(peak_bounds, length)
 
 
 cpdef extract_peaks_from_waveform(double [:] wf, dict peak_bounds, int rebin_stride=1):

--- a/invisible_cities/reco/peak_functions_test.py
+++ b/invisible_cities/reco/peak_functions_test.py
@@ -442,3 +442,21 @@ def test_select_peaks_of_allowed_length():
         l = bounds[k][1] - bounds[k][0]
         assert l >= length.min
         assert l <  length.max
+
+def test_find_peaks_finds_peaks_when_index_spaced_by_less_than_or_equal_to_stride():
+    # explore a range of strides
+    for stride in range(2,8):
+        # for each stride create a index array with ints spaced by (1 to stride)
+        for s in range(1, stride + 1):
+            # the concatenated np.array checks that find peaks will find separated peaks
+            index = np.concatenate((np.arange(  0, 500, s, dtype=np.int32),
+                                    np.arange(600, 605, 1, dtype=np.int32)))
+            bounds = pf._find_peaks(index,
+                                    time   = minmax(0, 1e+6),
+                                    length = minmax(2, 1000000),
+                                    stride = stride)
+            assert len(bounds)  ==    2            # found both peaks
+            assert bounds[0][0] ==    0            # find correct start i for first  p
+            assert bounds[0][1] == (499//s)*s + 1  # find correct end   i for first  p
+            assert bounds[1][0] ==  600            # find correct start i for second p
+            assert bounds[1][1] ==  605            # find correct end   i for second p

--- a/invisible_cities/reco/peak_functions_test.py
+++ b/invisible_cities/reco/peak_functions_test.py
@@ -367,23 +367,23 @@ def test_csum_zs_s12():
     S12L2 = cpf.find_s12(csum, wfzs_indx,
              time   = minmax(0, 1e+6),
              length = minmax(0, 1000000),
-             stride=4, rebin=False, rebin_stride=40)
+             stride=4, rebin_stride=1)
 
-    pbs   = cpf.find_peaks(wfzs_indx, time=minmax(0, 1e+6), length=minmax(0, 1000000), stride=4)
-    S12L3 = cpf.extract_peaks_from_waveform(csum, pbs, rebin_stride=1)
+    #pbs   = cpf.find_peaks(wfzs_indx, time=minmax(0, 1e+6), length=minmax(0, 1000000), stride=4)
+    #S12L3 = cpf.extract_peaks_from_waveform(csum, pbs, rebin_stride=1)
 
     for i in S12L1:
         t1 = S12L1[i][0]
         e1 = S12L1[i][1]
         t2 = S12L2[i][0]
         e2 = S12L2[i][1]
-        t3 = S12L3[i][0]
-        e3 = S12L3[i][1]
+        #t3 = S12L3[i][0]
+        #e3 = S12L3[i][1]
 
         npt.assert_allclose(t1, t2)
         npt.assert_allclose(e1, e2)
-        npt.assert_allclose(t2, t3)
-        npt.assert_allclose(e2, e3)
+        #npt.assert_allclose(t2, t3)
+        #npt.assert_allclose(e2, e3)
 
     # toy yields 3 idential vectors of energy
     E = np.array([ 11,  12,  13,  14,  15,  16,  17,  18,  19,  20,

--- a/invisible_cities/reco/peak_functions_test.py
+++ b/invisible_cities/reco/peak_functions_test.py
@@ -460,3 +460,15 @@ def test_find_peaks_finds_peaks_when_index_spaced_by_less_than_or_equal_to_strid
             assert bounds[0][1] == (499//s)*s + 1  # find correct end   i for first  p
             assert bounds[1][0] ==  600            # find correct start i for second p
             assert bounds[1][1] ==  605            # find correct end   i for second p
+
+def test_find_peaks_finds_no_peaks_when_index_spaced_by_more_than_stride():
+        for stride in range(2,8):
+            index = np.concatenate((np.arange(  0, 500, stride + 1, dtype=np.int32),
+                                    np.arange(600, 605,          1, dtype=np.int32)))
+            bounds = pf._find_peaks(index,
+                                    time   = minmax(0, 1e+6),
+                                    length = minmax(5, 1000000),
+                                    stride = stride)
+            assert len(bounds)  ==    1
+            assert bounds[0][0] ==  600
+            assert bounds[0][1] ==  605

--- a/invisible_cities/reco/peak_functions_test.py
+++ b/invisible_cities/reco/peak_functions_test.py
@@ -449,12 +449,9 @@ def test_find_peaks_finds_peaks_when_index_spaced_by_less_than_or_equal_to_strid
         # for each stride create a index array with ints spaced by (1 to stride)
         for s in range(1, stride + 1):
             # the concatenated np.array checks that find peaks will find separated peaks
-            index = np.concatenate((np.arange(  0, 500, s, dtype=np.int32),
-                                    np.arange(600, 605, 1, dtype=np.int32)))
-            bounds = pf._find_peaks(index,
-                                    time   = minmax(0, 1e+6),
-                                    length = minmax(2, 1000000),
-                                    stride = stride)
+            index  = np.concatenate((np.arange(  0, 500, s, dtype=np.int32),
+                                     np.arange(600, 605, 1, dtype=np.int32)))
+            bounds = pf._find_peaks(index, time=minmax(0, 1e+6), stride=stride)
             assert len(bounds)  ==    2            # found both peaks
             assert bounds[0][0] ==    0            # find correct start i for first  p
             assert bounds[0][1] == (499//s)*s + 1  # find correct end   i for first  p
@@ -463,12 +460,9 @@ def test_find_peaks_finds_peaks_when_index_spaced_by_less_than_or_equal_to_strid
 
 def test_find_peaks_finds_no_peaks_when_index_spaced_by_more_than_stride():
     for stride in range(2,8):
-        index = np.concatenate((np.arange(  0, 500, stride + 1, dtype=np.int32),
-                                np.arange(600, 605,          1, dtype=np.int32)))
-        bounds = pf._find_peaks(index,
-                                time   = minmax(0, 1e+6),
-                                length = minmax(5, 1000000),
-                                stride = stride)
+        index  = np.concatenate((np.arange(  0, 500, stride + 1, dtype=np.int32),
+                                 np.arange(600, 605,          1, dtype=np.int32)))
+        bounds = pf._find_peaks(index, time=minmax(0, 1e+6), stride=stride)
         assert len(bounds)  ==    1
         assert bounds[0][0] ==  600
         assert bounds[0][1] ==  605

--- a/invisible_cities/reco/peak_functions_test.py
+++ b/invisible_cities/reco/peak_functions_test.py
@@ -362,12 +362,12 @@ def test_csum_zs_s12():
     S12L1 = pf._find_s12(csum, wfzs_indx,
              time   = minmax(0, 1e+6),
              length = minmax(0, 1000000),
-             stride=4, rebin_stride=1)
+             stride=4, rebin=False, rebin_stride=1)
 
     S12L2 = cpf.find_s12(csum, wfzs_indx,
              time   = minmax(0, 1e+6),
              length = minmax(0, 1000000),
-             stride=4, rebin_stride=1)
+             stride=4, rebin=False, rebin_stride=1)
 
     #pbs   = cpf.find_peaks(wfzs_indx, time=minmax(0, 1e+6), length=minmax(0, 1000000), stride=4)
     #S12L3 = cpf.extract_peaks_from_waveform(csum, pbs, rebin_stride=1)

--- a/invisible_cities/reco/peak_functions_test.py
+++ b/invisible_cities/reco/peak_functions_test.py
@@ -343,7 +343,7 @@ def test_csum_zs_s12():
     wfzs_ene, wfzs_indx = cpf.wfzs(csum, threshold=10)
     npt.assert_allclose(vsum_zs, wfzs_ene)
 
-    t1 =  cpf._time_from_index(wfzs_indx)
+    t1 = cpf._time_from_index(wfzs_indx)
     t2 = cpf._time_from_index(wfzs_indx)
     i0 = wfzs_indx[0]
     i1 = wfzs_indx[-1] + 1
@@ -369,13 +369,21 @@ def test_csum_zs_s12():
              length = minmax(0, 1000000),
              stride=4, rebin=False, rebin_stride=40)
 
+    pbs   = cpf.find_peaks(wfzs_indx, time=minmax(0, 1e+6), length=minmax(0, 1000000), stride=4)
+    S12L3 = cpf.extract_peaks_from_waveform(csum, pbs, rebin_stride=1)
+
     for i in S12L1:
         t1 = S12L1[i][0]
         e1 = S12L1[i][1]
         t2 = S12L2[i][0]
         e2 = S12L2[i][1]
+        t3 = S12L3[i][0]
+        e3 = S12L3[i][1]
+
         npt.assert_allclose(t1, t2)
         npt.assert_allclose(e1, e2)
+        npt.assert_allclose(t2, t3)
+        npt.assert_allclose(e2, e3)
 
     # toy yields 3 idential vectors of energy
     E = np.array([ 11,  12,  13,  14,  15,  16,  17,  18,  19,  20,

--- a/invisible_cities/reco/peak_functions_test.py
+++ b/invisible_cities/reco/peak_functions_test.py
@@ -444,7 +444,7 @@ def test_select_peaks_of_allowed_length():
         i_start = np.random.randint(999, dtype=np.int32)
         i_stop  = i_start + np.random.randint(length.max, 999, dtype=np.int32)
         pbounds[k] = np.array([i_start, i_stop], dtype=np.int32)
-    bounds = cpf.select_peaks_of_allowed_length(pbounds, length)
+    bounds = cpf._select_peaks_of_allowed_length(pbounds, length)
     for i, k in zip(range(15), bounds):
         assert k == i
         l = bounds[k][1] - bounds[k][0]

--- a/invisible_cities/reco/peak_functions_test.py
+++ b/invisible_cities/reco/peak_functions_test.py
@@ -425,18 +425,18 @@ def test_select_peaks_of_allowed_length():
     pbounds = {}
     length = minmax(5,10)
     for k in range(15):
-        i_start = np.random.randint(999)
-        i_stop  = i_start + np.random.randint(length.min)
-        pbounds[k] = [i_start, i_stop]
+        i_start = np.random.randint(999, dtype=np.int32)
+        i_stop  = i_start + np.random.randint(length.min, dtype=np.int32)
+        pbounds[k] = np.array([i_start, i_stop], dtype=np.int32)
     for k in range(15, 30):
-        i_start = np.random.randint(999)
-        i_stop  = i_start + np.random.randint(length.min, length.max)
-        pbounds[k] = [i_start, i_stop]
+        i_start = np.random.randint(999, dtype=np.int32)
+        i_stop  = i_start + np.random.randint(length.min, length.max, dtype=np.int32)
+        pbounds[k] = np.array([i_start, i_stop], dtype=np.int32)
     for k in range(30, 45):
-        i_start = np.random.randint(999)
-        i_stop  = i_start + np.random.randint(length.max, 999)
-        pbounds[k] = [i_start, i_stop]
-    bounds = pf._select_peaks_of_allowed_length(pbounds, length)
+        i_start = np.random.randint(999, dtype=np.int32)
+        i_stop  = i_start + np.random.randint(length.max, 999, dtype=np.int32)
+        pbounds[k] = np.array([i_start, i_stop], dtype=np.int32)
+    bounds = cpf.select_peaks_of_allowed_length(pbounds, length)
     for i, k in zip(range(15), bounds):
         assert k == i
         l = bounds[k][1] - bounds[k][0]
@@ -451,7 +451,7 @@ def test_find_peaks_finds_peaks_when_index_spaced_by_less_than_or_equal_to_strid
             # the concatenated np.array checks that find peaks will find separated peaks
             index  = np.concatenate((np.arange(  0, 500, s, dtype=np.int32),
                                      np.arange(600, 605, 1, dtype=np.int32)))
-            bounds = pf._find_peaks(index, time   = minmax(0, 1e+6),
+            bounds = cpf.find_peaks(index, time   = minmax(0, 1e+6),
                                            length = minmax(5, 9999),
                                            stride = stride)
             assert len(bounds)  ==    2            # found both peaks
@@ -464,7 +464,7 @@ def test_find_peaks_finds_no_peaks_when_index_spaced_by_more_than_stride():
     for stride in range(2,8):
         index  = np.concatenate((np.arange(  0, 500, stride + 1, dtype=np.int32),
                                  np.arange(600, 605,          1, dtype=np.int32)))
-        bounds = pf._find_peaks(index, time   = minmax(0, 1e+6),
+        bounds = cpf.find_peaks(index, time   = minmax(0, 1e+6),
                                        length = minmax(2, 9999),
                                        stride = stride)
         assert len(bounds)  ==    1
@@ -480,7 +480,7 @@ def test_extract_peaks_from_waveform():
         i_stop  = np.random.randint(i_start + 1, 52001)
         peak_bounds[k] = np.array([i_start, i_stop], dtype=np.int32)
     # Extract peaks
-    S12L = pf._extract_peaks_from_waveform(wf, peak_bounds, rebin_stride=1)
+    S12L = cpf.extract_peaks_from_waveform(wf, peak_bounds, rebin_stride=1)
     for k in peak_bounds:
         T = cpf._time_from_index(np.arange(peak_bounds[k][0], peak_bounds[k][1], dtype=np.int32))
         assert np.allclose(S12L[k][0], T)                                         # Check times

--- a/invisible_cities/reco/peak_functions_test.py
+++ b/invisible_cities/reco/peak_functions_test.py
@@ -451,7 +451,9 @@ def test_find_peaks_finds_peaks_when_index_spaced_by_less_than_or_equal_to_strid
             # the concatenated np.array checks that find peaks will find separated peaks
             index  = np.concatenate((np.arange(  0, 500, s, dtype=np.int32),
                                      np.arange(600, 605, 1, dtype=np.int32)))
-            bounds = pf._find_peaks(index, time=minmax(0, 1e+6), stride=stride)
+            bounds = pf._find_peaks(index, time   = minmax(0, 1e+6),
+                                           length = minmax(5, 9999),
+                                           stride = stride)
             assert len(bounds)  ==    2            # found both peaks
             assert bounds[0][0] ==    0            # find correct start i for first  p
             assert bounds[0][1] == (499//s)*s + 1  # find correct end   i for first  p
@@ -462,7 +464,9 @@ def test_find_peaks_finds_no_peaks_when_index_spaced_by_more_than_stride():
     for stride in range(2,8):
         index  = np.concatenate((np.arange(  0, 500, stride + 1, dtype=np.int32),
                                  np.arange(600, 605,          1, dtype=np.int32)))
-        bounds = pf._find_peaks(index, time=minmax(0, 1e+6), stride=stride)
+        bounds = pf._find_peaks(index, time   = minmax(0, 1e+6),
+                                       length = minmax(2, 9999),
+                                       stride = stride)
         assert len(bounds)  ==    1
         assert bounds[0][0] ==  600
         assert bounds[0][1] ==  605


### PR DESCRIPTION
These additions allow IC to find and interact with the s2s of individual pmts.

1.
`find_s12` has been broken up into 3 functions `find_peaks`, `select_peaks_of_allowed_length`, and `extract_peaks_from_waveform` (in python and cython). 
`find_s12` was too big. First it found peaks, then it selected peaks of the correct length, then it put those peaks into a dictionary. 
Without changing the inputs/outputs, adding flags, and other technical debt, `find_s12` would not allow us to efficiently find the s12s of individual pmts.
Note finding the s2s of individual pmts is not quite as simple as it first appears since we need to rebin each pmt `cwf` in the same exact way we rebinned the `csum`, so that the rebinned time bins of the s2pmtd match and sum to s2d for each peak.
Also, breaking `find_s12` into modular functions allows for much better testing. 

2. 
a class, `S2Pmt` has been added to `pmaps.pyx`. It is initialized with dictionaries `s2d` and `s2pmtd` which maps `peak_no -- > [[pmt0E], [pmt1E], ..., [pmtnE]]`. People should look at this and make sure they like the basic structure.

3. 
a function `get_s2pmtd` has been added to peak functions. It takes as input `CWF` and `peak_bounds`.  `peak_bounds`  is a dictionary mapping `peak_no --> i_start, i_stop` of the s2 peaks found in csum. Note `peak_bounds` is the output of `find_peaks`, and `get_s2pmtd` makes uses `extract_peaks_from_waveform` to construct s2pmtd --> tearing  `find_s12` apart was worth it. 

4. 
tests for all this stuff

`-----------`
I have only created the free functions, I have not yet started messing around with any of the cities or base cities, so I have not deleted find_s12. If people are happy i or whoever can update `pmap_city` and whatever else to use the new functions. 
