### PR TITLE
get rid of redundant rebin flag, we already have rebin_stride

### DIFF
--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -28,23 +28,23 @@ from .. core.random_sampling    import NoiseSampler as SiPMsNoiseSampler
 
 from .. database import load_db
 
-from ..io                       import pmap_io          as pio
-from ..io                       import pmap_io          as pio
-from .. io. dst_io              import load_dst
+from .. io                      import pmap_io          as pio
+from .. io                      import pmap_io          as pio
+from .. io.dst_io               import load_dst
 from .. io.fee_io               import write_FEE_table
 
-from ..reco                     import peak_functions_c as cpf
-from ..reco                     import sensor_functions as sf
-from ..reco                     import peak_functions   as pf
-from ..reco                     import pmaps_functions  as pmp
-from ..reco                     import pmaps_functions_c  as cpmp
-from ..reco                     import dst_functions    as dstf
-from ..reco                     import wfm_functions    as wfm
-from ..reco                     import tbl_functions    as tbl
+from .. reco                    import peak_functions_c as cpf
+from .. reco                    import sensor_functions as sf
+from .. reco                    import peak_functions   as pf
+from .. reco                    import pmaps_functions  as pmp
+from .. reco                    import pmaps_functions_c  as cpmp
+from .. reco                    import dst_functions    as dstf
+from .. reco                    import wfm_functions    as wfm
+from .. reco                    import tbl_functions    as tbl
 from .. reco.sensor_functions   import convert_channel_id_to_IC_id
-from ..reco.corrections         import Correction
-from ..reco.corrections         import Fcorrection
-from ..reco.xy_algorithms       import find_algorithm
+from .. reco.corrections        import Correction
+from .. reco.corrections        import Fcorrection
+from .. reco.xy_algorithms      import find_algorithm
 
 from .. evm.ic_containers       import S12Params
 from .. evm.ic_containers       import S12Sum
@@ -462,19 +462,20 @@ class PmapCity(CalibratedCity):
     def __init__(self, **kwds):
         super().__init__(**kwds)
         conf = self.conf
+        print(self.conf.s1_rebin_stride)
         self.s1_params = S12Params(time = minmax(min   = conf.s1_tmin,
                                                  max   = conf.s1_tmax),
                                    stride              = conf.s1_stride,
                                    length = minmax(min = conf.s1_lmin,
                                                    max = conf.s1_lmax),
-                                   rebin               = conf.s1_rebin)
+                                   rebin_stride        = conf.s1_rebin_stride)
 
         self.s2_params = S12Params(time = minmax(min   = conf.s2_tmin,
                                                  max   = conf.s2_tmax),
                                    stride              = conf.s2_stride,
                                    length = minmax(min = conf.s2_lmin,
                                                    max = conf.s2_lmax),
-                                   rebin               = conf.s2_rebin)
+                                   rebin_stride        = conf.s2_rebin_stride)
 
         self.thr_sipm_s2 = conf.thr_sipm_s2
 

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -31,32 +31,32 @@ def s12params():
                  length = minmax(min =   4,
                                  max =  20,),
                  stride              =   4,
-                 rebin               = False)
+                 rebin_stride        =   1)
 
     s2par = S12P(time = minmax(min   =    101 * units.mus,
                                max   =   1199 * units.mus),
                  length = minmax(min =     80,
                                  max = 200000),
                  stride              =     40,
-                 rebin               = True)
+                 rebin_stride        =     40)
     return s1par, s2par
 
 
 def unpack_s12params(s12params):
     s1par, s2par = s12params
-    return dict(s1_tmin   = s1par.time.min,
-                s1_tmax   = s1par.time.max,
-                s1_string = s1par.stride,
-                s1_rebin  = s1par.rebin,
-                s1_lmin   = s1par.length.min,
-                s1_lmax   = s1par.length.max,
+    return dict(s1_tmin          = s1par.time.min,
+                s1_tmax          = s1par.time.max,
+                s1_string        = s1par.stride,
+                s1_rebin_stride  = s1par.rebin_stride,
+                s1_lmin          = s1par.length.min,
+                s1_lmax          = s1par.length.max,
 
-                s2_tmin   = s2par.time.min,
-                s2_tmax   = s2par.time.max,
-                s2_string = s2par.stride,
-                s2_rebin  = s2par.rebin,
-                s2_lmin   = s2par.length.min,
-                s2_lmax   = s2par.length.max)
+                s2_tmin          = s2par.time.min,
+                s2_tmax          = s2par.time.max,
+                s2_string        = s2par.stride,
+                s2_rebin_stride  = s2par.rebin_stride,
+                s2_lmin          = s2par.length.min,
+                s2_lmax          = s2par.length.max)
 
 
 @fixture(scope='module')

--- a/invisible_cities/config/diomira.conf
+++ b/invisible_cities/config/diomira.conf
@@ -49,4 +49,4 @@ s2_tmax   =    799 * mus # end of the window
 s2_stride =     40       #  40 x 25 = 1   mus
 s2_lmin   =    100       # 100 x 25 = 2.5 mus
 s2_lmax   = 100000       # maximum value of S2 width
-s2_rebin  = False        # DO NOT! rebin the PMT waveform
+s2_rebin_stride  = 1     # DO NOT! rebin the PMT waveform

--- a/invisible_cities/config/pmap_city.conf
+++ b/invisible_cities/config/pmap_city.conf
@@ -8,20 +8,20 @@ include('$ICDIR/config/calibrated_city.conf')
 # Set parameters to search for S1
 # Notice that in MC file S1 is in t=100 mus
 
-s1_tmin   =  99 * mus # position of S1 in MC files at 100 mus
-s1_tmax   = 101 * mus # change tmin and tmax if S1 not at 100 mus
-s1_stride =   4       # minimum number of 25 ns bins in S1 searches
-s1_lmin   =   8       # 8 x 25 = 200 ns
-s1_lmax   =  20       # 20 x 25 = 500 ns
-s1_rebin  =  False    # Do not rebin S1 by default
+s1_tmin    =  99 * mus # position of S1 in MC files at 100 mus
+s1_tmax    = 101 * mus # change tmin and tmax if S1 not at 100 mus
+s1_stride  =   4       # minimum number of 25 ns bins in S1 searches
+s1_lmin    =   8       # 8 x 25 = 200 ns
+s1_lmax    =  20       # 20 x 25 = 500 ns
+s1_rebin_stride = 1    # Do not rebin S1 by default
 
 # Set parameters to search for S2
-s2_tmin   =    101 * mus # assumes S1 at 100 mus, change if S1 not at 100 mus
-s2_tmax   =   1199 * mus # end of the window
-s2_stride =     40       #  40 x 25 = 1   mus
-s2_lmin   =    100       # 100 x 25 = 2.5 mus
-s2_lmax   = 100000       # maximum value of S2 width
-s2_rebin  =  True        # Rebin by default
+s2_tmin    =    101 * mus # assumes S1 at 100 mus, change if S1 not at 100 mus
+s2_tmax    =   1199 * mus # end of the window
+s2_stride  =     40       #  40 x 25 = 1   mus
+s2_lmin    =    100       # 100 x 25 = 2.5 mus
+s2_lmax    = 100000       # maximum value of S2 width
+s2_rebin_stride = 40      # Rebin by default, 40 25 ns time bins to make one 1us time bin
 
 # Set S2Si parameters
 thr_sipm_s2 = 10 * pes  # Threshold for the full sipm waveform

--- a/invisible_cities/evm/ic_containers.py
+++ b/invisible_cities/evm/ic_containers.py
@@ -26,7 +26,7 @@ for name, attrs in (
         ('CalibParams'    , 'coeff_c, coeff_blr, adc_to_pes_pmt adc_to_pes_sipm'),
         ('DeconvParams'   , 'n_baseline thr_trigger'),
         ('CalibVectors'   , 'channel_id coeff_blr coeff_c adc_to_pes adc_to_pes_sipm pmt_active'),
-        ('S12Params'      , 'time stride length rebin'),
+        ('S12Params'      , 'time stride length rebin_stride'),
         ('PmapParams'     , 's1_params s2_params s1p_params s1_PMT_params s1p_PMT_params'),
         ('ThresholdParams', 'thr_s1 thr_s2 thr_MAU thr_sipm thr_SIPM'),
         ('CSum'           , 'csum csum_mau'),

--- a/invisible_cities/reco/peak_functions.py
+++ b/invisible_cities/reco/peak_functions.py
@@ -271,11 +271,8 @@ def _find_s12(csum, index,
     accept the peak only if within [tmin, tmax)
     returns a dictionary of S12
     """
-    if not rebin: rebin_stride = 1
     return _extract_peaks_from_waveform(
         csum, _find_peaks(index, time=time, length=length, stride=stride), rebin_stride=rebin_stride)
-
-
 
 
 def _sipm_s2_dict(SIPM, S2d, thr=5 * units.pes):

--- a/invisible_cities/reco/peak_functions_c.pxd
+++ b/invisible_cities/reco/peak_functions_c.pxd
@@ -92,19 +92,19 @@ cpdef _time_from_index(int [:] indx)
 
 cpdef find_s1(double [:] csum,  int [:] index,
               time, length,
-              int stride=*, rebin=*, rebin_stride=*)
+              int stride=*, rebin_stride=*)
 
 
 cpdef find_s2(double [:] csum,  int [:] index,
               time, length,
-              int stride=*, rebin=*, rebin_stride=*)
+              int stride=*, rebin_stride=*)
 
 
 cpdef find_s2si(double [:, :] sipmzs, dict s2d, double thr)
 
 
 cpdef find_s12(double [:] csum,  int [:] index,
-               time, length, int stride, rebin, rebin_stride)
+               time, length, int stride, rebin_stride)
 
 
 cpdef correct_s1_ene(dict s1d, np.ndarray csum)

--- a/invisible_cities/reco/peak_functions_c.pyx
+++ b/invisible_cities/reco/peak_functions_c.pyx
@@ -226,22 +226,20 @@ cpdef extract_peaks_from_waveform(double [:] wf, dict peak_bounds, int rebin_str
 
 cpdef find_s1(double [:] csum,  int [:] index,
               time, length,
-              int stride=4, rebin=False, rebin_stride=4):
+              int stride=4, rebin_stride=1):
     """
     find s1 peaks and returns S1 objects
     """
-
-    return S1(find_s12(csum, index, time, length, stride, rebin, rebin_stride))
+    return S1(find_s12(csum, index, time, length, stride, rebin_stride))
 
 
 cpdef find_s2(double [:] csum,  int [:] index,
               time, length,
-              int stride=40, rebin=True, rebin_stride=40):
+              int stride=40, rebin_stride=40):
     """
     find s2 peaks and returns S2 objects
     """
-
-    return S2(find_s12(csum, index, time, length, stride, rebin, rebin_stride))
+    return S2(find_s12(csum, index, time, length, stride, rebin_stride))
 
 
 cpdef find_s2si(double [:, :] sipmzs, dict s2d, double thr):
@@ -253,7 +251,7 @@ cpdef find_s2si(double [:, :] sipmzs, dict s2d, double thr):
 
 
 cpdef find_s12(double [:] csum,  int [:] index,
-               time, length, int stride, rebin, rebin_stride):
+               time, length, int stride, rebin_stride):
     """
     Find S1/S2 peaks.
     input:
@@ -265,7 +263,6 @@ cpdef find_s12(double [:] csum,  int [:] index,
     accept the peak only if within [tmin, tmax)
     returns a dictionary of S12
     """
-    if not rebin: rebin_stride = 1
     return extract_peaks_from_waveform(
         csum, find_peaks(index, time, length, stride=stride), rebin_stride=rebin_stride)
 

--- a/invisible_cities/reco/peak_functions_test.py
+++ b/invisible_cities/reco/peak_functions_test.py
@@ -188,14 +188,14 @@ def pmaps_electrons(electron_RWF_file):
                       length = minmax(min =   4,
                                       max =  20),
                       stride              =   4,
-                      rebin               = False)
+                      rebin_stride        =   1)
 
     s2par = S12Params(time = minmax(min   =    101 * units.mus,
                                     max   =   1199 * units.mus),
                       length = minmax(min =     80,
                                       max = 200000),
                       stride              =     40,
-                      rebin               = True)
+                      rebin_stride        =     40)
 
     thr = ThresholdParams(thr_s1   =  0.2 * units.pes,
                           thr_s2   =  1   * units.pes,
@@ -232,7 +232,7 @@ def pmaps_electrons(electron_RWF_file):
                                             pmtrwf,
                                             sipmrwf,
                                             s1par,
-                                            s2par._replace(rebin=False),
+                                            s2par._replace(rebin_stride=1),
                                             thr,
                                             calib,
                                             deconv)
@@ -362,12 +362,12 @@ def test_csum_zs_s12():
     S12L1 = pf._find_s12(csum, wfzs_indx,
              time   = minmax(0, 1e+6),
              length = minmax(0, 1000000),
-             stride=4, rebin=False, rebin_stride=1)
+             stride=4, rebin_stride=1)
 
     S12L2 = cpf.find_s12(csum, wfzs_indx,
              time   = minmax(0, 1e+6),
              length = minmax(0, 1000000),
-             stride=4, rebin=False, rebin_stride=1)
+             stride=4, rebin_stride=1)
 
     #pbs   = cpf.find_peaks(wfzs_indx, time=minmax(0, 1e+6), length=minmax(0, 1000000), stride=4)
     #S12L3 = cpf.extract_peaks_from_waveform(csum, pbs, rebin_stride=1)
@@ -397,7 +397,7 @@ def test_csum_zs_s12():
     S12L2 = cpf.find_s12(csum, wfzs_indx,
              time   = minmax(0, 1e+6),
              length = minmax(0, 1000000),
-             stride=10, rebin=True, rebin_stride=10)
+             stride=10, rebin_stride=10)
 
     E = np.array([155,  200,  155])
 
@@ -415,7 +415,7 @@ def test_find_s12_finds_first_correct_candidate_peak():
     S12L = cpf.find_s12(wf, ene,
                  time   = minmax(0, 1e+6),
                  length = minmax(0, 1000000),
-                 stride=10, rebin=True, rebin_stride=10)
+                 stride=10, rebin_stride=10)
     assert len(S12L) == 1
     assert np.allclose(S12L[0][0], np.array([2*25*units.ns + 25/2 *units.ns]))
     assert np.allclose(S12L[0][1], np.array([1]))


### PR DESCRIPTION
Our find s1/s2 algorithms took as input both `rebin_stride`, and a flag, `rebin`. The flag is redundant. 

Unfortunately this redundancy invaded many corners of IC including the config files for diomira and pmap_city, so I had to make a bunch of small changes. ^ This might be of particular interest to @jmbenlloch if he is in charge of the productions. 

The code passes the tests, I've checked to make sure that diomira does not try to rebin s2s, and again, I've run Irene over 1k events in a notebook and everything looks good. 

Now when `rebin_stride == 1` there is no rebinning, and we don't pass extra arguments to our peak finding algorithms.

