### PR TITLE
Fix event number in MCTrack table

### DIFF
--- a/invisible_cities/cities/diomira_test.py
+++ b/invisible_cities/cities/diomira_test.py
@@ -123,8 +123,6 @@ def test_diomira_copy_mc_and_offset(config_tmpdir):
             first_evt_number = h5out.root.MC.MCTracks[ 0][0]
             last_evt_number  = h5out.root.MC.MCTracks[-1][0]
             assert first_evt_number != last_evt_number
-            print(first_evt_number, last_evt_number)
-            assert false
 
 @mark.parametrize('filename, first_evt',
              (('dst_NEXT_v0_08_09_Co56_INTERNALPORTANODE_74_0_7bar_MCRD_10000.root.h5',

--- a/invisible_cities/cities/diomira_test.py
+++ b/invisible_cities/cities/diomira_test.py
@@ -119,6 +119,13 @@ def test_diomira_copy_mc_and_offset(config_tmpdir):
             for e in zip(mctracks_in[1:], mctracks_out[1:]):
                 np.testing.assert_array_equal(e[0],e[1])
 
+            # check event number is different for each event
+            first_evt_number = h5out.root.MC.MCTracks[ 0][0]
+            last_evt_number  = h5out.root.MC.MCTracks[-1][0]
+            assert first_evt_number != last_evt_number
+            print(first_evt_number, last_evt_number)
+            assert false
+
 @mark.parametrize('filename, first_evt',
              (('dst_NEXT_v0_08_09_Co56_INTERNALPORTANODE_74_0_7bar_MCRD_10000.root.h5',
                740000),

--- a/invisible_cities/io/mc_io.py
+++ b/invisible_cities/io/mc_io.py
@@ -28,6 +28,8 @@ class mc_track_writer:
 
     def __call__(self, mctracks, evt_number):
         for r in mctracks.iterrows(start=self.last_row):
+            if r['event_indx'] != evt_number:
+                break
             self.last_row += 1
             evt = (evt_number,) + r[1:]
             self.mc_table.append([evt])


### PR DESCRIPTION
There was a bug in the mc_track_writer that was setting all event numbers to zero. It is now fixed and one test has been updated to check this condition.

This closes #287.