### PR TITLE
Add function that returns the length of a track

### DIFF
--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -110,6 +110,9 @@ def find_extrema(distance : Dict[Voxel, Dict[Voxel, float]]) -> Tuple[Voxel, Vox
             first, last, max_distance = source, target, d
     return (first, last)
 
+def length(track_graph):
+    return len(shortest_paths(track_graph))
+
 
 def energy_within_radius(distances : Dict[Voxel, Dict[Voxel, float]], radius : float) -> float:
     return sum(v.E for (v, d) in distances.items() if d < radius)


### PR DESCRIPTION
@jacg I realized that in the paolina functions we miss a function that gives the length of the track. As far as I understand from the code, the shortest path is not available to the user (correct me if I'm wrong), therefore the user cannot calculate the length of a track by himself. On the contrary, the energy is accesible through the voxels. Is that true? Or am I missing the philosophy of it?