### PR TITLE
Allow icusers to study s1s of individual pmts

### DIFF
--- a/invisible_cities/core/exceptions.py
+++ b/invisible_cities/core/exceptions.py
@@ -45,5 +45,5 @@ class NoHits(ICException):
 class NoVoxels(ICException):
     pass
 
-class InconsistentS2dS2pmtd(ICException):
+class InconsistentS12dPmtsd(ICException):
     pass

--- a/invisible_cities/evm/pmaps.pxd
+++ b/invisible_cities/evm/pmaps.pxd
@@ -61,9 +61,9 @@ cdef class S2Si(S2):
 cpdef check_s2d_and_s2sid_share_peaks(dict s2d, dict s2sid)
 
 
-cdef class S2Pmt(S2):
-    cdef public s2pmtd
-    cdef  dict _s2pmtd
+cdef class S12Pmt(S12):
+    cdef public pmtsd
+    cdef  dict _pmtsd
     cpdef pmt_waveform(self, int peak_number, int pmt_number)
     cpdef pmt_total_energy_in_peak(self, int peak_number, int pmt_number)
     cpdef pmt_total_energy(self, int pmt_number)

--- a/invisible_cities/evm/pmaps.pxd
+++ b/invisible_cities/evm/pmaps.pxd
@@ -68,3 +68,11 @@ cdef class S12Pmt(S12):
     cpdef pmt_total_energy_in_peak(self, int peak_number, int pmt_number)
     cpdef pmt_total_energy(self, int pmt_number)
     cpdef store(self, table, event_number)
+
+
+cdef class S1Pmt(S12Pmt):
+    cdef public s1d
+
+
+cdef class S2Pmt(S12Pmt):
+    cdef public s2d

--- a/invisible_cities/evm/pmaps.pyx
+++ b/invisible_cities/evm/pmaps.pyx
@@ -8,7 +8,7 @@ from .. core.exceptions        import PeakNotFound
 from .. core.exceptions        import SipmEmptyList
 from .. core.exceptions        import SipmNotFound
 from .. core.core_functions    import loc_elem_1d
-from .. core.exceptions        import InconsistentS2dS2pmtd
+from .. core.exceptions        import InconsistentS12dPmtsd
 from .. core.system_of_units_c import units
 
 
@@ -302,7 +302,7 @@ cdef class S12Pmt(S12):
         # Check that energies in s12d are sum of pmtsd across pmts for each peak
         for peak, s12_pmts in zip(s12d.values(), pmtsd.values()):
             if not np.allclose(peak[1], s12_pmts.sum(axis=0)):
-                raise InconsistentS2dS2pmtd
+                raise InconsistentS12dPmtsd
 
         S12.__init__(self, s12d)
         self.pmtsd = pmtsd

--- a/invisible_cities/evm/pmaps.pyx
+++ b/invisible_cities/evm/pmaps.pyx
@@ -123,7 +123,7 @@ cdef class S12:
 cdef class S1(S12):
     def __init__(self, s1d):
         self.s1d = s1d
-        super(S1,self).__init__(s1d)
+        super(S1, self).__init__(s1d)
 
     def __str__(self):
         s =  "S1 (number of peaks = {})\n".format(self.number_of_peaks)
@@ -350,3 +350,15 @@ cdef class S12Pmt(S12):
                     row["nsipm"]   = npmt
                     row["ene"]     = E
                     row.append()
+
+
+cdef class S1Pmt(S12Pmt):
+    def __init__(self, s1d, pmtsd):
+        self.s1d = s1d
+        S12Pmt.__init__(self, s1d, pmtsd)
+
+
+cdef class S2Pmt(S12Pmt):
+    def __init__(self, s2d, pmtsd):
+        self.s2d = s2d
+        S12Pmt.__init__(self, s2d, pmtsd)

--- a/invisible_cities/evm/pmaps_test.py
+++ b/invisible_cities/evm/pmaps_test.py
@@ -11,7 +11,7 @@ from hypothesis.extra.numpy import arrays
 
 from .. types.ic_types_c    import xy
 from .. types.ic_types_c    import minmax
-from .. core.exceptions     import InconsistentS2dS2pmtd
+from .. core.exceptions     import InconsistentS12dPmtsd
 
 from .. reco.pmaps_functions_c import integrate_sipm_charges_in_peak
 from .. reco  import pmaps_functions as pmapf
@@ -222,7 +222,7 @@ def test_S12Pmt_raises_error_when_s2_peak_E_not_equal_to_sum_of_s12pmt_peak():
     try:
         S12Pmt(s12d, pmtsd)
         assert False
-    except InconsistentS2dS2pmtd:
+    except InconsistentS12dPmtsd:
         pass
 
 

--- a/invisible_cities/evm/pmaps_test.py
+++ b/invisible_cities/evm/pmaps_test.py
@@ -18,7 +18,7 @@ from .. reco  import pmaps_functions as pmapf
 from .  pmaps import S1
 from .  pmaps import S2
 from .  pmaps import S2Si
-from .  pmaps import S2Pmt
+from .  pmaps import S12Pmt
 from .  pmaps import Peak
 from .  pmaps import check_s2d_and_s2sid_share_peaks
 
@@ -213,42 +213,42 @@ def test_check_s2d_and_s2sid_share_peaks():
         assert pn % 2 == 0
 
 
-def test_S2Pmt_raises_error_when_s2_peak_E_not_equal_to_sum_of_s2pmt_peak():
+def test_S12Pmt_raises_error_when_s2_peak_E_not_equal_to_sum_of_s12pmt_peak():
     timebins = 10
     npmts  = 12
-    s2pmtd = {0: np.random.random((npmts, timebins))}
-    s2d    = {0: np.array([list(range(timebins)), s2pmtd[0].sum(axis=0)])}
-    s2pmtd[0][-1, -1] += .0001
+    pmtsd = {0: np.random.random((npmts, timebins))}
+    s12d    = {0: np.array([list(range(timebins)), pmtsd[0].sum(axis=0)])}
+    pmtsd[0][-1, -1] += .0001
     try:
-        S2Pmt(s2d, s2pmtd)
+        S12Pmt(s12d, pmtsd)
         assert False
     except InconsistentS2dS2pmtd:
         pass
 
 
-def test_S2Pmt_pmt_waveform():
+def test_S12Pmt_pmt_waveform():
     timebins = 10
     npmts = 5
     # construct dicts
     for peak in range(3):
-        s2pmtd = {peak: np.random.random((npmts, timebins))}
-        s2d    = {peak: np.array([list(range(timebins)), s2pmtd[peak].sum(axis=0)])}
-    # get pmt s2pmt
-    s2pmt = S2Pmt(s2d, s2pmtd)
-    for pn in s2pmt.peaks:
+        pmtsd = {peak: np.random.random((npmts, timebins))}
+        s12d    = {peak: np.array([list(range(timebins)), pmtsd[peak].sum(axis=0)])}
+    # get pmt s12pmt
+    s12pmt = S12Pmt(s12d, pmtsd)
+    for pn in s12pmt.peaks:
         for pmt in range(npmts):
-            assert (s2pmt.pmt_waveform(pn, pmt).t == s2d   [pn][  0]).all()
-            assert (s2pmt.pmt_waveform(pn, pmt).E == s2pmtd[pn][pmt]).all()
+            assert (s12pmt.pmt_waveform(pn, pmt).t == s12d   [pn][  0]).all()
+            assert (s12pmt.pmt_waveform(pn, pmt).E == pmtsd[pn][pmt]).all()
 
 
-def test_S2Pmt_pmt_total_energy_in_peak():
+def test_S12Pmt_pmt_total_energy_in_peak():
     timebins = 10
     npmts  = 12
-    s2pmtd = {0: np.random.random((npmts, timebins))}
-    s2d    = {0: np.array([list(range(timebins)), s2pmtd[0].sum(axis=0)])}
-    s2pmt  = S2Pmt(s2d, s2pmtd)
+    pmtsd = {0: np.random.random((npmts, timebins))}
+    s12d    = {0: np.array([list(range(timebins)), pmtsd[0].sum(axis=0)])}
+    s12pmt  = S12Pmt(s12d, pmtsd)
     for pmt in range(npmts):
-        assert s2pmt.pmt_total_energy_in_peak(0, pmt) == s2pmtd[0][pmt].sum()
+        assert s12pmt.pmt_total_energy_in_peak(0, pmt) == pmtsd[0][pmt].sum()
 
 
 def test_pmt_total_energy():
@@ -256,11 +256,11 @@ def test_pmt_total_energy():
     npmts = 5
     # construct dicts
     for peak in range(3):
-        s2pmtd = {peak: np.random.random((npmts, timebins))}
-        s2d    = {peak: np.array([list(range(timebins)), s2pmtd[peak].sum(axis=0)])}
-    # get pmt s2pmt
-    s2pmt = S2Pmt(s2d, s2pmtd)
+        pmtsd = {peak: np.random.random((npmts, timebins))}
+        s12d    = {peak: np.array([list(range(timebins)), pmtsd[peak].sum(axis=0)])}
+    # get pmt s12pmt
+    s12pmt = S12Pmt(s12d, pmtsd)
     for pmt in range(npmts):
         s = 0
-        for pn in s2pmt.peaks: s += s2pmt.pmt_total_energy_in_peak(pn, pmt)
-        assert s2pmt.pmt_total_energy(pmt) == s
+        for pn in s12pmt.peaks: s += s12pmt.pmt_total_energy_in_peak(pn, pmt)
+        assert s12pmt.pmt_total_energy(pmt) == s

--- a/invisible_cities/reco/peak_functions.py
+++ b/invisible_cities/reco/peak_functions.py
@@ -234,25 +234,25 @@ def _extract_peaks_from_waveform(wf, peak_bounds, rebin_stride=1):
     return S12L
 
 
-def get_s2pmtd(CWF, peak_bounds, rebin_stride=40):
+def get_s12pmtd(cCWF, peak_bounds, rebin_stride=1):
     """
-    Given the corrected waveforms of all active pmts for one event, CWF, and the boundaries of
-    all of the s12 peaks found in the csum, peak_bounds, return the s2 peaks of the individual
-    pmts, s2pmtd.
+    Given the calibrated corrected waveforms of all active pmts for one event, CWF, and the
+    boundaries of all of the s12 peaks found in the csum, peak_bounds, return the s12 peaks of the
+    individual pmts, s12pmtd.
     """
     # extract the peaks from the cwf of each pmt
-    S12Ls = [cpf.extract_peaks_from_waveform(cwf, peak_bounds, rebin_stride=rebin_stride) \
-             for cwf in CWF]
+    S12Ls = [cpf.extract_peaks_from_waveform(ccwf, peak_bounds, rebin_stride=rebin_stride) \
+             for ccwf in cCWF]
 
-    s2pmtd = {}
+    s12pmtd = {}
     npmts  = len(S12Ls)
     for pn in peak_bounds:
         # initialize an the array of pmt energies with shape npmts, len(peak.t)
-        s2pmtd[pn] = np.empty((npmts, len(S12Ls[0][pn][0])), dtype=np.float32)
+        s12pmtd[pn] = np.empty((npmts, len(S12Ls[0][pn][0])), dtype=np.float32)
         # fill the array of pmt s2 energies one pmt at a time
-        for pmt in range(npmts): s2pmtd[pn][pmt] = S12Ls[pmt][pn][1]
+        for pmt in range(npmts): s12pmtd[pn][pmt] = S12Ls[pmt][pn][1]
 
-    return s2pmtd
+    return s12pmtd
 
 
 def _find_s12(csum, index,

--- a/invisible_cities/reco/peak_functions_test.py
+++ b/invisible_cities/reco/peak_functions_test.py
@@ -496,24 +496,26 @@ def test_extract_peaks_from_waveform():
     # Check that _extract... did not return extra peaks
     assert len(peak_bounds) == len(S12L)
 
-def test_get_s2pmtd():
+def test_get_s12pmtd():
     npmts  = 4
     ntbins = 52000
-    CWF    = np.random.random(size=(npmts, ntbins)) # generate wfs for pmts
-    csum   = CWF.sum(axis=0)                 # and their sum
+    cCWF    = np.random.random(size=(npmts, ntbins)) # generate wfs for pmts
+    csum   = cCWF.sum(axis=0)                 # and their sum
     npeaks = 20
     peak_bounds  = {}
-    rebin_stride = 40
+    rebin_strides = [1,7,40]
+
     for pn in range(npeaks):
         start = np.random.randint(      0, ntbins  )
         stop  = np.random.randint(1+start, ntbins+1)
         peak_bounds[pn] = np.array([start, stop], dtype=np.int32) # generate some peak_bounds
 
-    # extract the peaks from the csum, and for each pmt extract the peaks from the CWF
-    S12L   = cpf.extract_peaks_from_waveform(csum, peak_bounds, rebin_stride=rebin_stride)
-    s2pmtd = pf.get_s2pmtd(CWF, peak_bounds, rebin_stride=rebin_stride)
-    for s12l, s2_pmts, i_peak in zip(S12L.values(), s2pmtd.values(), peak_bounds.values()):
-        # check that the sum of the individual pmt s2s equals the total s2, at each time bin
-        assert np.allclose(s12l[1], s2_pmts.sum(axis=0))
-        # check that the correct energy is in each pmt
-        assert np.allclose(s2_pmts.sum(axis=1), CWF[:, i_peak[0]: i_peak[1]].sum(axis=1))
+    for rebin_stride in rebin_strides:
+        # extract the peaks from the csum, and for each pmt extract the peaks from the cCWF
+        S12L   = cpf.extract_peaks_from_waveform(csum, peak_bounds, rebin_stride=rebin_stride)
+        s12pmtd = pf.get_s12pmtd(cCWF, peak_bounds, rebin_stride=rebin_stride)
+        for s12l, s12_pmts, i_peak in zip(S12L.values(), s12pmtd.values(), peak_bounds.values()):
+            # check that the sum of the individual pmt s12s equals the total s12, at each time bin
+            assert np.allclose(s12l[1], s12_pmts.sum(axis=0))
+            # check that the correct energy is in each pmt
+            assert np.allclose(s12_pmts.sum(axis=1), cCWF[:, i_peak[0]: i_peak[1]].sum(axis=1))


### PR DESCRIPTION
Before we could only look at the s2s of individual pmts, even though the code had all the functionality necessary to look at the s1s of individual pmts. 

Even though we will not typically use/save this data, it is useful for some analysis and can help us better understand our detector and make cool plots, and it costs nothing.