### PR TITLE
Imports SipmZeroCharge exception

### DIFF
--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -23,6 +23,7 @@ from .. core.exceptions         import UnknownRWF
 from .. core.exceptions         import FileLoopMethodNotSet
 from .. core.exceptions         import EventLoopMethodNotSet
 from .. core.exceptions         import SipmEmptyList
+from .. core.exceptions         import SipmZeroCharge
 from .. core.exceptions         import ClusterEmptyList
 from .. core.system_of_units_c  import units
 from .. core.random_sampling    import NoiseSampler as SiPMsNoiseSampler


### PR DESCRIPTION
Penthesilea does run properly when this exception is thrown because it was not imported