### PR TITLE
add functions for increasing s2si thresholds + tests

### DIFF
--- a/invisible_cities/core/exceptions.py
+++ b/invisible_cities/core/exceptions.py
@@ -59,3 +59,6 @@ class NoVoxels(ICException):
 
 class InconsistentS12dPmtsd(ICException):
     pass
+
+class NegativeThresholdNotAllowed(ICException):
+    pass

--- a/invisible_cities/reco/pmaps_functions.py
+++ b/invisible_cities/reco/pmaps_functions.py
@@ -96,33 +96,6 @@ def rebin_s2si_peak(t, e, sipms, stride):
       {sipm: ccf.rebin_array(qs, stride, remainder=True) for sipm, qs in sipms.items()}
 
 
-def _impose_thr_sipm_destructive(s2si_dict: Dict[int, S2Si],
-                                 thr_sipm : float           ) -> Dict[int, S2Si]:
-    """imposes a thr_sipm on s2si_dict"""
-    for s2si in s2si_dict.values():                   # iter over events
-        for si_peak in s2si.s2sid.values():           # iter over peaks
-            for sipm in list(si_peak.keys()):         # iter over sipms ** avoid mod while iter
-                for i, q in enumerate(si_peak[sipm]): # iter over timebins
-                    if q < thr_sipm:                  # impose threshold
-                        si_peak[sipm][i] = 0
-                if si_peak[sipm].sum() == 0:          # Delete SiPMs with integral
-                    del si_peak[sipm]                 # charge equal to 0
-    return s2si_dict
-
-
-def _impose_thr_sipm_s2_destructive(s2si_dict   : Dict[int, S2Si],
-                                    thr_sipm_s2 : float           ) -> Dict[int, S2Si]:
-    """imposes a thr_sipm_s2 on s2si_dict. deletes keys (sipms) from each s2sid peak if sipm
-       integral charge is less than thr_sipm_s2"""
-    for s2si in s2si_dict.values():
-        for si_peak in s2si.s2sid.values():
-            for sipm, qs in list(si_peak.items()): # ** avoid modifying while iterating
-                sipm_integral_charge = qs.sum()
-                if sipm_integral_charge < thr_sipm_s2:
-                    del si_peak[sipm]
-    return s2si_dict
-
-
 def _delete_empty_s2si_peaks(s2si_dict : Dict[int, S2Si]) -> Dict[int, S2Si]:
     """makes sure there are no empty peaks stored in an s2sid
         (s2sid[pn] != {} for all pn in s2sid and all s2sid in s2si_dict)

--- a/invisible_cities/reco/pmaps_functions.py
+++ b/invisible_cities/reco/pmaps_functions.py
@@ -96,29 +96,6 @@ def rebin_s2si_peak(t, e, sipms, stride):
       {sipm: ccf.rebin_array(qs, stride, remainder=True) for sipm, qs in sipms.items()}
 
 
-def _delete_empty_s2si_peaks(s2si_dict : Dict[int, S2Si]) -> Dict[int, S2Si]:
-    """makes sure there are no empty peaks stored in an s2sid
-        (s2sid[pn] != {} for all pn in s2sid and all s2sid in s2si_dict)
-        ** Also deletes corresponding peak in s2si.s2d! """
-    for ev in list(s2si_dict.keys()):
-        for pn in list(s2si_dict[ev].s2sid.keys()):
-            if len(s2si_dict[ev].s2sid[pn]) == 0:
-                del s2si_dict[ev].s2sid[pn]
-                del s2si_dict[ev].s2d  [pn]
-                # It is not sufficient to just delete the peaks because the S2Si class instance
-                # will still think it has peak pn even though its base dictionary does not
-                s2si_dict[ev] = S2Si(s2si_dict[ev].s2d, s2si_dict[ev].s2sid)
-    return s2si_dict
-
-
-def _delete_empty_s2si_dict_events(s2si_dict: Dict[int, S2Si]) -> Dict[int, S2Si]:
-    """ delete all events from s2si_dict with empty s2sid"""
-    for ev in list(s2si_dict.keys()):
-        if len(s2si_dict[ev].s2sid) == 0:
-            del s2si_dict[ev]
-    return s2si_dict
-
-
 def copy_s2si(s2si_original : S2Si) -> S2Si:
     """ return an identical copy of an s2si. ** note these must be deepcopies, and a deepcopy of
     the s2si itself does not seem to work. """

--- a/invisible_cities/reco/pmaps_functions.py
+++ b/invisible_cities/reco/pmaps_functions.py
@@ -9,6 +9,7 @@ Last revised, JJGC, July, 2017.
 """
 import copy
 import numpy  as     np
+from .. reco import pmaps_functions_c as pmpc
 from .. core import core_functions_c as ccf
 from .. core.system_of_units_c      import units
 from .. core.exceptions             import NegativeThresholdNotAllowed
@@ -177,13 +178,13 @@ def raise_s2si_thresholds(s2si_dict_original: Dict[int, S2Si],
 
     # Impose thresholds
     if thr_sipm    > 0:
-        s2si_dict  = _impose_thr_sipm_destructive   (s2si_dict, thr_sipm   )
+        s2si_dict  = pmpc._impose_thr_sipm_destructive   (s2si_dict, thr_sipm   )
     if thr_sipm_s2 > 0:
-        s2si_dict  = _impose_thr_sipm_s2_destructive(s2si_dict, thr_sipm_s2)
+        s2si_dict  = pmpc._impose_thr_sipm_s2_destructive(s2si_dict, thr_sipm_s2)
     # Get rid of any empty dictionaries
     if thr_sipm > 0 or thr_sipm_s2 > 0:
-        s2si_dict  = _delete_empty_s2si_peaks      (s2si_dict)
-        s2si_dict  = _delete_empty_s2si_dict_events(s2si_dict)
+        s2si_dict  = pmpc._delete_empty_s2si_peaks      (s2si_dict)
+        s2si_dict  = pmpc._delete_empty_s2si_dict_events(s2si_dict)
     return s2si_dict
 
 

--- a/invisible_cities/reco/pmaps_functions.py
+++ b/invisible_cities/reco/pmaps_functions.py
@@ -14,6 +14,7 @@ from .. core.system_of_units_c      import units
 from .. core.exceptions             import NegativeThresholdNotAllowed
 from .. evm.pmaps                   import S2, S2Si, Peak
 
+from typing import Dict
 
 def _integrate_sipm_charges_in_peak_as_dict(s2si):
     """Return dict of integrated charges from a SiPM dictionary.
@@ -94,7 +95,8 @@ def rebin_s2si_peak(t, e, sipms, stride):
       {sipm: ccf.rebin_array(qs, stride, remainder=True) for sipm, qs in sipms.items()}
 
 
-def _impose_thr_sipm_destructive(s2si_dict, thr_sipm):
+def _impose_thr_sipm_destructive(s2si_dict: Dict[int, S2Si],
+                                 thr_sipm : float           ) -> Dict[int, S2Si]:
     """imposes a thr_sipm on s2si_dict"""
     for s2si in s2si_dict.values():                   # iter over events
         for si_peak in s2si.s2sid.values():           # iter over peaks
@@ -107,7 +109,8 @@ def _impose_thr_sipm_destructive(s2si_dict, thr_sipm):
     return s2si_dict
 
 
-def _impose_thr_sipm_s2_destructive(s2si_dict, thr_sipm_s2):
+def _impose_thr_sipm_s2_destructive(s2si_dict   : Dict[int, S2Si],
+                                    thr_sipm_s2 : float           ) -> Dict[int, S2Si]:
     """imposes a thr_sipm_s2 on s2si_dict. deletes keys (sipms) from each s2sid peak if sipm
        integral charge is less than thr_sipm_s2"""
     for s2si in s2si_dict.values():
@@ -119,7 +122,7 @@ def _impose_thr_sipm_s2_destructive(s2si_dict, thr_sipm_s2):
     return s2si_dict
 
 
-def _delete_empty_s2si_peaks(s2si_dict):
+def _delete_empty_s2si_peaks(s2si_dict : Dict[int, S2Si]) -> Dict[int, S2Si]:
     """makes sure there are no empty peaks stored in an s2sid
         (s2sid[pn] != {} for all pn in s2sid and all s2sid in s2si_dict)
         ** Also deletes corresponding peak in s2si.s2d! """
@@ -134,7 +137,7 @@ def _delete_empty_s2si_peaks(s2si_dict):
     return s2si_dict
 
 
-def _delete_empty_s2si_dict_events(s2si_dict):
+def _delete_empty_s2si_dict_events(s2si_dict: Dict[int, S2Si]) -> Dict[int, S2Si]:
     """ delete all events from s2si_dict with empty s2sid"""
     for ev in list(s2si_dict.keys()):
         if len(s2si_dict[ev].s2sid) == 0:
@@ -142,19 +145,21 @@ def _delete_empty_s2si_dict_events(s2si_dict):
     return s2si_dict
 
 
-def copy_s2si(s2si_original):
+def copy_s2si(s2si_original : S2Si) -> S2Si:
     """ return an identical copy of an s2si. ** note these must be deepcopies, and a deepcopy of
     the s2si itself does not seem to work. """
     return S2Si(copy.deepcopy(s2si_original.s2d),
                 copy.deepcopy(s2si_original.s2sid))
 
 
-def copy_s2si_dict(s2si_dict_original):
+def copy_s2si_dict(s2si_dict_original: Dict[int, S2Si]) -> Dict[int, S2Si]:
     """ returns an identical copy of the input s2si_dict """
     return {ev: copy_s2si(s2si) for ev, s2si in s2si_dict_original.items()}
 
 
-def raise_s2si_thresholds(s2si_dict_original, thr_sipm, thr_sipm_s2):
+def raise_s2si_thresholds(s2si_dict_original: Dict[int, S2Si],
+                         thr_sipm           : float,
+                         thr_sipm_s2        : float) -> Dict[int, S2Si]:
     """
     returns s2si_dict after imposing more thr_sipm and/or thr_sipm_s2 thresholds.
     ** NOTE:

--- a/invisible_cities/reco/pmaps_functions_c.pxd
+++ b/invisible_cities/reco/pmaps_functions_c.pxd
@@ -31,3 +31,22 @@ Returns (np.array[nsipm_1 , nsipm_2, ...],
          np.array[q_k from nsipm_1, q_k from nsipm_2, ...]]) when slice_no=k
  """
 cpdef sipm_ids_and_charges_in_slice(dict s2sid_peak, int slice_no)
+
+
+"""imposes a thr_sipm on s2si_dict"""
+cpdef _impose_thr_sipm_destructive(dict s2si_dict, float thr_sipm)
+
+
+"""imposes a thr_sipm_s2 on s2si_dict. deletes keys (sipms) from each s2sid peak if sipm
+   integral charge is less than thr_sipm_s2"""
+cpdef _impose_thr_sipm_s2_destructive(dict s2si_dict, float thr_sipm_s2)
+
+
+"""makes sure there are no empty peaks stored in an s2sid
+    (s2sid[pn] != {} for all pn in s2sid and all s2sid in s2si_dict)
+    ** Also deletes corresponding peak in s2si.s2d! """
+cpdef _delete_empty_s2si_peaks(dict s2si_dict)
+
+
+""" delete all events from s2si_dict with empty s2sid"""
+cpdef _delete_empty_s2si_dict_events(dict s2si_dict)

--- a/invisible_cities/reco/pmaps_functions_test.py
+++ b/invisible_cities/reco/pmaps_functions_test.py
@@ -12,10 +12,10 @@ from .. core             import system_of_units as units
 from . pmaps_functions   import rebin_s2si
 from . pmaps_functions   import copy_s2si
 from . pmaps_functions   import copy_s2si_dict
-from . pmaps_functions   import _impose_thr_sipm_destructive
-from . pmaps_functions   import _impose_thr_sipm_s2_destructive
-from . pmaps_functions   import _delete_empty_s2si_peaks
-from . pmaps_functions   import _delete_empty_s2si_dict_events
+from . pmaps_functions_c   import _impose_thr_sipm_destructive
+from . pmaps_functions_c   import _impose_thr_sipm_s2_destructive
+from . pmaps_functions_c   import _delete_empty_s2si_peaks
+from . pmaps_functions_c   import _delete_empty_s2si_dict_events
 from . pmaps_functions   import raise_s2si_thresholds
 from . pmaps_functions_c import df_to_s1_dict
 from . pmaps_functions_c import df_to_s2_dict


### PR DESCRIPTION
These are functions we can use to increase the cuts on the SiPMs: `thr_sipm` and `thr_sipm_s2`

The idea is that maybe we could initially run irene with cuts on the SiPMs on the low side, and have the ability to quickly increase them whenever we want without having to rerun all of irene. 

This is a work in progress -- I'm using these functions extensively now to debug them and to look more into where we should put our cuts. I still need to cythonize them and maybe add more tests. I am opening the PR now just so people can have a look if they want to! 