### PR TITLE
Xy algos

### DIFF
--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -16,6 +16,7 @@ import numpy  as np
 import tables as tb
 
 from .. core.core_functions     import merge_two_dicts
+from .. core.core_functions     import loc_elem_1d
 from .. core.configure          import configure
 from .. core.exceptions         import NoInputFiles
 from .. core.exceptions         import NoOutputFile
@@ -25,6 +26,7 @@ from .. core.exceptions         import EventLoopMethodNotSet
 from .. core.exceptions         import SipmEmptyList
 from .. core.exceptions         import SipmZeroCharge
 from .. core.exceptions         import ClusterEmptyList
+from .. core.exceptions         import XYRecoFail
 from .. core.system_of_units_c  import units
 from .. core.random_sampling    import NoiseSampler as SiPMsNoiseSampler
 
@@ -47,7 +49,7 @@ from .. reco                    import tbl_functions    as tbl
 from .. reco.sensor_functions   import convert_channel_id_to_IC_id
 from .. reco.corrections        import Correction
 from .. reco.corrections        import Fcorrection
-from .. reco.xy_algorithms      import find_algorithm
+from .. reco.xy_algorithms      import corona
 from .. reco.xy_algorithms      import barycenter
 
 from .. evm.ic_containers       import S12Params
@@ -580,7 +582,7 @@ class KrCity(PCity):
 
     def __init__(self, **kwds):
         super().__init__(**kwds)
-        self.reco_algorithm = find_algorithm(self.conf.reco_algorithm)
+        #self.reco_algorithm = find_algorithm(self.conf.reco_algorithm)
 
 
     def compute_xy_position(self, s2si, peak_no):
@@ -590,7 +592,13 @@ class KrCity(PCity):
         """
         IDs, Qs = cpmp.integrate_sipm_charges_in_peak(s2si, peak_no)
         xs, ys   = self.xs[IDs], self.ys[IDs]
-        return self.reco_algorithm(np.stack((xs, ys)).T, Qs)
+        #return self.reco_algorithm(np.stack((xs, ys)).T, Qs)
+        return corona(np.stack((xs, ys)).T, Qs,
+                      Qthr           =  self.conf.qthr,
+                      Qlm            =  self.conf.qlm,
+                      lm_radius      =  self.conf.lm_radius,
+                      new_lm_radius  =  self.conf.new_lm_radius,
+                      msipm          =  self.conf.msipm)
 
     def compute_z_and_dt(self, ts2, ts1):
         """
@@ -628,6 +636,7 @@ class KrCity(PCity):
             evt.S1t.append(peak.tpeak)
 
         evt.nS2 = s2si.number_of_peaks
+
         for i, peak_no in enumerate(s2si.peak_collection()):
             peak = s2si.peak_waveform(peak_no)
             evt.S2w.append(peak.width/units.mus)
@@ -637,20 +646,15 @@ class KrCity(PCity):
 
             try:
                 clusters = self.compute_xy_position(s2si, peak_no)
-            except SipmEmptyList:
-                evt.Nsipm.append(NN)
-                evt.S2q  .append(NN)
-                evt.X    .append(NN)
-                evt.Y    .append(NN)
-                evt.Xrms .append(NN)
-                evt.Yrms .append(NN)
-                evt.R    .append(NN)
-                evt.Phi  .append(NN)
-                evt.DT   .append(NN)
-                evt.Z    .append(NN)
-            else:
-                assert len(clusters) == 1 #only one cluster
-                c = clusters[0]
+                # if there is more than one cluster compare the energy measured
+                # in the tracking plane with the energy measured in the energy plane
+                # and thake the cluster where both energies are closer.
+                c = 0
+                if len(clusters) == 1:
+                    c = clusters[0]
+                else:
+                    c_closest = np.amin([abs(c.Q - peak.total_energy) for c in clusters])
+                    c = clusters[loc_elem_1d(clusters, c_closest)]
                 evt.Nsipm.append(c.nsipm)
                 evt.S2q  .append(c.Q)
                 evt.X    .append(c.X)
@@ -662,7 +666,18 @@ class KrCity(PCity):
                 z, dt = self.compute_z_and_dt(evt.S2t[i], evt.S1t[0])
                 evt.DT   .append(dt)
                 evt.Z    .append(z)
-
+            except XYRecoFail:
+                evt.Nsipm.append(NN)
+                evt.S2q  .append(NN)
+                evt.X    .append(NN)
+                evt.Y    .append(NN)
+                evt.Xrms .append(NN)
+                evt.Yrms .append(NN)
+                evt.R    .append(NN)
+                evt.Phi  .append(NN)
+                evt.DT   .append(NN)
+                evt.Z    .append(NN)
+            
         return evt
 
 
@@ -684,12 +699,6 @@ class HitCity(KrCity):
         qs = np.array([c.Q for c in clusters])
         return e * qs / np.sum(qs)
 
-    def compute_xy_position(self, s2sid_peak, slice_no):
-        """Compute x-y position for each time slice. """
-        #import pdb; pdb.set_trace()
-        IDs, Qs  = cpmp.sipm_ids_and_charges_in_slice(s2sid_peak, slice_no)
-        xs, ys   = self.xs[IDs], self.ys[IDs]
-        return self.reco_algorithm(np.stack((xs, ys)).T, Qs)
 
     def create_hits_event(self, pmapVectors):
         """Create a hits_event:
@@ -718,28 +727,23 @@ class HitCity(KrCity):
         # be set by parameter to a factor x pmaps-rebin.
         s2, s2si = self.rebin_s2si(s2, s2si, self.rebin)
 
-        npeak = 0
+        # here hits are computed for each peak and each slice.
+        # In case of an exception, a hit is still created with a NN cluster.
+        # (NN cluster is a cluster where the energy is an IC not number NN)
+        # this allows to keep track of the energy associated to non reonstructed hits.
         for peak_no, (t_peak, e_peak) in sorted(s2si.s2d.items()):
             for slice_no, (t_slice, e_slice) in enumerate(zip(t_peak, e_peak)):
+                z        = (t_slice - s1_t) * units.ns * self.drift_v
                 try:
                     clusters = self.compute_xy_position(s2si.s2sid[peak_no], slice_no)
-                except SipmEmptyList:
-                    continue
-                except SipmZeroCharge:
-                    continue
-                # this cannot happen with the barycenter algorithm by construction
-                except ClusterEmptyList:
-                    IDs, Qs  = cpmp.sipm_ids_and_charges_in_slice(s2si.s2sid[peak_no], slice_no)
-                    xs, ys   = self.xs[IDs], self.ys[IDs]
-                    clusters = barycenter(np.stack((xs, ys)).T, Qs)
-
-                # create hits only for those slices with OK clusters
-                es       = self.split_energy(e_slice, clusters)
-                z        = (t_slice - s1_t) * units.ns * self.drift_v
-                for c, e in zip(clusters, es):
-                    hit       = Hit(npeak, c, z, e)
+                    es       = self.split_energy(e_slice, clusters)
+                    for c, e in zip(clusters, es):
+                        hit       = Hit(peak_no, c, z, e)
+                        hitc.hits.append(hit)
+                except XYRecoFail:
+                    c = Cluster(NN, 0, 0, 0)
+                    hit       = Hit(peak_no, c, z, e_slice)
                     hitc.hits.append(hit)
-            npeak += 1
 
         return hitc
 

--- a/invisible_cities/config/hit_city.conf
+++ b/invisible_cities/config/hit_city.conf
@@ -4,4 +4,22 @@
 include('$ICDIR/config/kr_city.conf')
 
 rebin = 1  # if set to 1 no rebin is set to n rebin n times the wfm
-reco_algorithm = 'corona'
+qthr           =   2 * pes # charge threshold, ignore all SiPMs with less than Qthr pes
+qlm            =   5 * pes # every Cluster must contain at least one SiPM with charge >= Qlm
+
+# lm_radius = radius, find new_local_maximum by taking the barycenter of SiPMs within
+#             lm_radius of the max sipm. new_local_maximum is new in the sense that the
+#             prev loc max was the position of hottest_sipm. (Then allow all SiPMs with
+#             new_local_maximum of new_local_maximum to contribute to the pos and q of the
+#             new cluster).
+
+# ***In general lm_radius should typically be set to 0, or some value slightly
+# larger than pitch or pitch*sqrt(2).***
+#
+# ***If lm_radius is set to a negative number, the algorithm will simply return
+# the overall barycenter all the SiPms above threshold.***
+lm_radius      =   0 * mm  # by default, use 3x3 corona
+
+# new_lm_radius = radius, find a new cluster by calling barycenter() on pos/qs of SiPMs within
+#                 new_lm_radius of new_local_maximum
+new_lm_radius  =  15 * mm  # by default, use 3 x3 corona

--- a/invisible_cities/config/kr_city.conf
+++ b/invisible_cities/config/kr_city.conf
@@ -3,4 +3,25 @@
 
 include('$ICDIR/config/city.conf')
 
-reco_algorithm = 'barycenter'
+#reco_algorithm = 'barycenter'
+qthr           =   1 * pes # charge threshold, ignore all SiPMs with less than Qthr pes
+qlm            =   0 * pes # every Cluster must contain at least one SiPM with charge >= Qlm
+
+# lm_radius = radius, find new_local_maximum by taking the barycenter of SiPMs within
+#             lm_radius of the max sipm. new_local_maximum is new in the sense that the
+#             prev loc max was the position of hottest_sipm. (Then allow all SiPMs with
+#             new_local_maximum of new_local_maximum to contribute to the pos and q of the
+#             new cluster).
+
+# ***In general lm_radius should typically be set to 0, or some value slightly
+# larger than pitch or pitch*sqrt(2).***
+#
+# ***If lm_radius or new_lm_radius is set to a negative number, the algorithm will simply return
+# the overall barycenter all the SiPms above threshold.***
+
+lm_radius      =   -1  # by default, use overall barycenter for KrCity
+
+# new_lm_radius = radius, find a new cluster by calling barycenter() on pos/qs of SiPMs within
+#                 new_lm_radius of new_local_maximum
+new_lm_radius  =  -1 # by default, use overall barycenter for KrCity
+msipm          =   1 # minimum number of SiPMs in a Cluster

--- a/invisible_cities/config/penthesilea.conf
+++ b/invisible_cities/config/penthesilea.conf
@@ -23,4 +23,3 @@ s2_ethr     =     0.5 * pes # Energy threshold for S2
 # override hit_collection parameters
 
 rebin = 1  # if set to 1 no rebin is set to n rebin n times the wfm
-reco_algorithm = 'barycenter'   # here one could try "corona"

--- a/invisible_cities/core/exceptions.py
+++ b/invisible_cities/core/exceptions.py
@@ -30,16 +30,25 @@ class ParameterNotSet(ICException):
 class PeakNotFound(ICException):
     pass
 
-class SipmEmptyList(ICException):
+class XYRecoFail(ICException):
     pass
 
-class ClusterEmptyList(ICException):
+class SipmEmptyList(XYRecoFail):
     pass
 
-class SipmNotFound(ICException):
+class SipmEmptyListAboveQthr(XYRecoFail):
     pass
 
-class SipmZeroCharge(ICException):
+class ClusterEmptyList(XYRecoFail):
+    pass
+
+class SipmNotFound(XYRecoFail):
+    pass
+
+class SipmZeroCharge(XYRecoFail):
+    pass
+
+class SipmZeroChargeAboveQthr(XYRecoFail):
     pass
 
 class NoHits(ICException):

--- a/invisible_cities/evm/event_model.py
+++ b/invisible_cities/evm/event_model.py
@@ -143,7 +143,7 @@ class Cluster(BHit):
 
     def __str__(self):
         return """< nsipm = {} Q = {}
-                    xy = {}. 3dHit = {}  >""".format(self.nsipm, self.Q, self._xy,
+                    xy = {} 3dHit = {}  >""".format(self.nsipm, self.Q, self._xy,
                                                      super().__str__())
     __repr__ =     __str__
 

--- a/invisible_cities/reco/xy_algorithms.py
+++ b/invisible_cities/reco/xy_algorithms.py
@@ -125,7 +125,6 @@ def corona(pos, qs,
     if not len(pos): raise SipmEmptyList
     if sum(qs) == 0: raise SipmZeroCharge
 
-
     above_threshold = np.where(qs >= Qthr)[0]            # Find SiPMs with qs at least Qthr
     pos, qs = pos[above_threshold], qs[above_threshold]  # Discard SiPMs with qs less than Qthr
 
@@ -136,9 +135,11 @@ def corona(pos, qs,
     if lm_radius < 0 or new_lm_radius < 0:
         return barycenter(pos, qs)
 
+
     c  = []
     # While there are more local maxima
     while len(qs) > 0:
+
         hottest_sipm = np.argmax(qs)       # SiPM with largest Q
         if qs[hottest_sipm] < Qlm: break   # largest Q remaining is negligible
 

--- a/invisible_cities/types/ic_types.py
+++ b/invisible_cities/types/ic_types.py
@@ -82,7 +82,7 @@ class xy:
     def Phi(self): return np.arctan2(self.y, self.x)
 
     def __str__(self):
-        return 'xy(x={.x}, max={.y})'.format(self, self)
+        return 'xy(x={.x}, y={.y})'.format(self, self)
     __repr__ = __str__
 
     def __getitem__(self, n):


### PR DESCRIPTION
This PR refactors the XY reconstruction algorithms.


1.- The code no longer calls two algorithms (barycenter or corona)
which had to be selected by config, but a single algorithm (corona) with
a number of parameters. In particular, lm_radius can be set to a
negative number in which case corona will return an overall
barycenter (using all SiPms above Qthr threshold).

2. The condition imposing a single cluster when filling a kr_event has
been removed. That condition assumed that an overall barycenter
returning a single cluster *had to be used* in kr_city (e.g, to
compute KDSTs and maps). However, this is not a must and in fact,
better (less biased) results can in principle be obtained using a
corona algorithm which uses a limited number of SiPms around the local
maximum. On the other hand, the use of a corona may result in more
than one cluster in the tracking plane, even in the case of
single-particles (e.g, X-rays or Krypton), due, for example, to noisiy
SiPMs. In this case the physical cluster is expected to have more energy than the satellite and this is the criterium used to choose.

3. In the case of hit_city, if there is a reconstruction failure a hit
is still formed using a "NN cluster" (a Non-Numeric cluster). This
allows to keep track of the energy of the slice that failed to produce
a cluster. 

The new code passes all the tests. In addition, we have run many events using Penthesilea to check that there are no running failures. Since there is no new functionality (no new algorithms) but a refactor of existing ones, new tests do not appear to be a must (in fact, existing tests caught a bug introduced by accident when refactoring and allowed for immediate correction).


