### PR TITLE
Dorothea small fixes

### DIFF
--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -655,14 +655,15 @@ class KrCity(PCity):
                 if len(clusters) == 1:
                     c = clusters[0]
                 else:
+                    cQ = [c.Q for c in clusters]
+                    self.cnt.increment_counter('n_events_more_than_1_cluster')
                     print('found case with more than one cluster')
-                    print('clusters charge = {}'.format(
-                          [c.Q for c in clusters]))
+                    print('clusters charge = {}'.format(cQ))
 
                     c_closest = np.amax([c.Q for c in clusters])
 
                     print('c_closest = {}'.format(c_closest))
-                    c = clusters[loc_elem_1d(clusters, c_closest)]
+                    c = clusters[loc_elem_1d(cQ, c_closest)]
                     print('c_chosen = {}'.format(c))
                 evt.Nsipm.append(c.nsipm)
                 evt.S2q  .append(c.Q)

--- a/invisible_cities/cities/dorothea.py
+++ b/invisible_cities/cities/dorothea.py
@@ -33,7 +33,13 @@ class Dorothea(KrCity):
         super().__init__(**kwds)
         self.cnt.set_name('dorothea')
         self.cnt.set_counter('nmax', value=self.conf.nmax)
-        self.cnt.init_counters(('n_events_tot', 'nevt_out'))
+        self.cnt.init_counters(('n_events_tot', 'nevt_out',
+                                'n_events_not_s1',
+                                'n_events_not_s2',
+                                'n_events_not_s2si',
+                                'n_events_rejected_filter',
+                                'n_events_more_than_1_cluster'
+                                ))
 
         self.drift_v = self.conf.drift_v
         self._s1s2_selector = S12Selector(**kwds)
@@ -66,10 +72,18 @@ class Dorothea(KrCity):
                                                       evt_number)
             # filtering
             # loop event away if any signal (s1, s2 or s2si) not present
-            if s1 == None or s2 == None or s2si == None:
+            if s1 == None:
+                self.cnt.increment_counter('n_events_not_s1')
+                continue
+            if s2 == None:
+                self.cnt.increment_counter('n_events_not_s2')
+                continue
+            if s2si == None:
+                self.cnt.increment_counter('n_events_not_s2si')
                 continue
             # loop event away if filter fails
             if not s1s2_filter(self._s1s2_selector, s1, s2, s2si):
+                self.cnt.increment_counter('n_events_more_than_1_cluster')
                 continue
             # event passed selection:
             self.cnt.increment_counter('nevt_out') # increment counter

--- a/invisible_cities/config/dorothea_kr_with_barycenter_low_threshold_mc_example.conf
+++ b/invisible_cities/config/dorothea_kr_with_barycenter_low_threshold_mc_example.conf
@@ -1,0 +1,84 @@
+#!/usr/bin/python
+# dorothea.conf
+
+# Dorothea computes a KDST after selecting PMAPS according to an S12 selector.
+# city.conf
+
+# set input and output files
+import os
+files_in = os.path.join(os.environ['IC_DATA'], 'NEXT_v1_00_05', 'Kr',
+                        'dst_NEXT_v1_00_05_Kr_ACTIVE_0_0_7bar_PMP_10000.h5')
+
+file_out = os.path.join(os.environ['IC_DATA'], 'NEXT_v1_00_05', 'Kr',
+                        'dst_NEXT_v1_00_05_Kr_ACTIVE_0_0_7bar_KDST_10.h5')
+
+#_dir_prod  = '/Users/jjgomezcadenas/Projects/ICDATA/MC_PreProd_July_2017/'
+
+#files_in = _dir_prod + 'dst_NEXT_v1_00_05_Kr_ACTIVE_0_0_7bar_PMP_1000.h5'
+#file_out = _dir_prod + 'dst_NEXT_v1_00_05_Kr_ACTIVE_0_0_7bar_KDST_1000.h5'
+
+# compression library
+compression = 'ZLIB4'
+
+# run number 0 is for MC
+run_number = -4446
+
+# How frequently to print events
+nprint = 1
+
+# max number of events to run
+nmax =  100
+
+# set to True if run all events in input files
+run_all = False
+
+verbosity = 0
+
+skip = 0
+
+# s12 selector
+drift_v = 1 * mm / mus # Expected drift velocity
+
+s1_nmin     =    1
+s1_nmax     =    1
+s1_emin     =    1 * pes # Min S1 energy integral
+s1_emax     = 1e+6 * pes # Max S1 energy integral
+s1_wmin     =  100 * ns # min width for S1
+s1_wmax     =  600 * ns # Max width
+s1_hmin     =    0 * pes # Min S1 height
+s1_hmax     = 1e+6 * pes # Max S1 height
+s1_ethr     =  0.5 * pes # Energy threshold for S1
+
+s2_nmin     =     1
+s2_nmax     =     10       # Max number of S2 signals
+s2_emin     =  1e+3 * pes # Min S2 energy integral
+s2_emax     =  1e+6 * pes # Max S2 energy integral in pes
+s2_wmin     =     3 * mus # Min width
+s2_wmax     =   500 * ms  # Max width IN MS!!!
+s2_hmin     =     0 * pes # Min S2 height
+s2_hmax     =  1e+6 * pes # Max S2 height
+s2_nsipmmin =     1       # Min number of SiPMs touched
+s2_nsipmmax =   100       # Max number of SiPMs touched
+s2_ethr     =     1 * pes # Energy threshold for S2
+
+
+qthr           =   1 * pes # charge threshold, ignore all SiPMs with less than Qthr pes
+qlm            =   5 * pes # every Cluster must contain at least one SiPM with charge >= Qlm. This cut is irrelevant if one uses barycenter
+
+# lm_radius = radius, find new_local_maximum by taking the barycenter of SiPMs within
+#             lm_radius of the max sipm. new_local_maximum is new in the sense that the
+#             prev loc max was the position of hottest_sipm. (Then allow all SiPMs with
+#             new_local_maximum of new_local_maximum to contribute to the pos and q of the
+#             new cluster).
+
+# ***In general lm_radius should typically be set to 0, or some value slightly
+# larger than pitch or pitch*sqrt(2).***
+#
+# ***If lm_radius is set to a negative number, the algorithm will simply return
+# the overall barycenter all the SiPms above threshold.***
+lm_radius      =   -1 * mm  # by default, use 3x3 corona. Set this number to -1 to use barycenter
+
+# new_lm_radius = radius, find a new cluster by calling barycenter() on pos/qs of SiPMs within
+#                 new_lm_radius of new_local_maximum
+new_lm_radius  =  15 * mm  # by default, use 3 x3 corona. Set to -1 to use barycenter.
+msipm          =   1 # minimum number of SiPMs in a Cluster

--- a/invisible_cities/config/dorothea_kr_with_corona_high_threshold_mc_example.conf
+++ b/invisible_cities/config/dorothea_kr_with_corona_high_threshold_mc_example.conf
@@ -1,0 +1,84 @@
+#!/usr/bin/python
+# dorothea.conf
+
+# Dorothea computes a KDST after selecting PMAPS according to an S12 selector.
+# city.conf
+
+# set input and output files
+import os
+files_in = os.path.join(os.environ['IC_DATA'], 'NEXT_v1_00_05', 'Kr',
+                        'dst_NEXT_v1_00_05_Kr_ACTIVE_0_0_7bar_PMP_10000.h5')
+
+file_out = os.path.join(os.environ['IC_DATA'], 'NEXT_v1_00_05', 'Kr',
+                        'dst_NEXT_v1_00_05_Kr_ACTIVE_0_0_7bar_KDST_10.h5')
+
+#_dir_prod  = '/Users/jjgomezcadenas/Projects/ICDATA/MC_PreProd_July_2017/'
+
+#files_in = _dir_prod + 'dst_NEXT_v1_00_05_Kr_ACTIVE_0_0_7bar_PMP_1000.h5'
+#file_out = _dir_prod + 'dst_NEXT_v1_00_05_Kr_ACTIVE_0_0_7bar_KDST_1000.h5'
+
+# compression library
+compression = 'ZLIB4'
+
+# run number 0 is for MC
+run_number = -4446
+
+# How frequently to print events
+nprint = 1
+
+# max number of events to run
+nmax =  100
+
+# set to True if run all events in input files
+run_all = False
+
+verbosity = 0
+
+skip = 0
+
+# s12 selector
+drift_v = 1 * mm / mus # Expected drift velocity
+
+s1_nmin     =    1
+s1_nmax     =    1
+s1_emin     =    1 * pes # Min S1 energy integral
+s1_emax     = 1e+6 * pes # Max S1 energy integral
+s1_wmin     =  100 * ns # min width for S1
+s1_wmax     =  600 * ns # Max width
+s1_hmin     =    0 * pes # Min S1 height
+s1_hmax     = 1e+6 * pes # Max S1 height
+s1_ethr     =  0.5 * pes # Energy threshold for S1
+
+s2_nmin     =     1
+s2_nmax     =     10       # Max number of S2 signals
+s2_emin     =  1e+3 * pes # Min S2 energy integral
+s2_emax     =  1e+6 * pes # Max S2 energy integral in pes
+s2_wmin     =     3 * mus # Min width
+s2_wmax     =   500 * ms  # Max width IN MS!!!
+s2_hmin     =     0 * pes # Min S2 height
+s2_hmax     =  1e+6 * pes # Max S2 height
+s2_nsipmmin =     1       # Min number of SiPMs touched
+s2_nsipmmax =   100       # Max number of SiPMs touched
+s2_ethr     =     1 * pes # Energy threshold for S2
+
+
+qthr           =   2 * pes # charge threshold, ignore all SiPMs with less than Qthr pes
+qlm            =   25 * pes # every Cluster must contain at least one SiPM with charge >= Qlm. This cut is irrelevant if one uses barycenter
+
+# lm_radius = radius, find new_local_maximum by taking the barycenter of SiPMs within
+#             lm_radius of the max sipm. new_local_maximum is new in the sense that the
+#             prev loc max was the position of hottest_sipm. (Then allow all SiPMs with
+#             new_local_maximum of new_local_maximum to contribute to the pos and q of the
+#             new cluster).
+
+# ***In general lm_radius should typically be set to 0, or some value slightly
+# larger than pitch or pitch*sqrt(2).***
+#
+# ***If lm_radius is set to a negative number, the algorithm will simply return
+# the overall barycenter all the SiPms above threshold.***
+lm_radius      =   0 * mm  # by default, use 3x3 corona. Set this number to -1 to use barycenter
+
+# new_lm_radius = radius, find a new cluster by calling barycenter() on pos/qs of SiPMs within
+#                 new_lm_radius of new_local_maximum
+new_lm_radius  =  15 * mm  # by default, use 3 x3 corona. Set to -1 to use barycenter.
+msipm          =   1 # minimum number of SiPMs in a Cluster

--- a/invisible_cities/config/dorothea_kr_with_corona_low_threshold_mc_example.conf
+++ b/invisible_cities/config/dorothea_kr_with_corona_low_threshold_mc_example.conf
@@ -1,0 +1,84 @@
+#!/usr/bin/python
+# dorothea.conf
+
+# Dorothea computes a KDST after selecting PMAPS according to an S12 selector.
+# city.conf
+
+# set input and output files
+import os
+files_in = os.path.join(os.environ['IC_DATA'], 'NEXT_v1_00_05', 'Kr',
+                        'dst_NEXT_v1_00_05_Kr_ACTIVE_0_0_7bar_PMP_10000.h5')
+
+file_out = os.path.join(os.environ['IC_DATA'], 'NEXT_v1_00_05', 'Kr',
+                        'dst_NEXT_v1_00_05_Kr_ACTIVE_0_0_7bar_KDST_10.h5')
+
+#_dir_prod  = '/Users/jjgomezcadenas/Projects/ICDATA/MC_PreProd_July_2017/'
+
+#files_in = _dir_prod + 'dst_NEXT_v1_00_05_Kr_ACTIVE_0_0_7bar_PMP_1000.h5'
+#file_out = _dir_prod + 'dst_NEXT_v1_00_05_Kr_ACTIVE_0_0_7bar_KDST_1000.h5'
+
+# compression library
+compression = 'ZLIB4'
+
+# run number 0 is for MC
+run_number = -4446
+
+# How frequently to print events
+nprint = 1
+
+# max number of events to run
+nmax =  100
+
+# set to True if run all events in input files
+run_all = False
+
+verbosity = 0
+
+skip = 0
+
+# s12 selector
+drift_v = 1 * mm / mus # Expected drift velocity
+
+s1_nmin     =    1
+s1_nmax     =    1
+s1_emin     =    1 * pes # Min S1 energy integral
+s1_emax     = 1e+6 * pes # Max S1 energy integral
+s1_wmin     =  100 * ns # min width for S1
+s1_wmax     =  600 * ns # Max width
+s1_hmin     =    0 * pes # Min S1 height
+s1_hmax     = 1e+6 * pes # Max S1 height
+s1_ethr     =  0.5 * pes # Energy threshold for S1
+
+s2_nmin     =     1
+s2_nmax     =     10       # Max number of S2 signals
+s2_emin     =  1e+3 * pes # Min S2 energy integral
+s2_emax     =  1e+6 * pes # Max S2 energy integral in pes
+s2_wmin     =     3 * mus # Min width
+s2_wmax     =   500 * ms  # Max width IN MS!!!
+s2_hmin     =     0 * pes # Min S2 height
+s2_hmax     =  1e+6 * pes # Max S2 height
+s2_nsipmmin =     1       # Min number of SiPMs touched
+s2_nsipmmax =   100       # Max number of SiPMs touched
+s2_ethr     =     1 * pes # Energy threshold for S2
+
+
+qthr           =   1 * pes # charge threshold, ignore all SiPMs with less than Qthr pes
+qlm            =   5 * pes # every Cluster must contain at least one SiPM with charge >= Qlm. This cut is irrelevant if one uses barycenter
+
+# lm_radius = radius, find new_local_maximum by taking the barycenter of SiPMs within
+#             lm_radius of the max sipm. new_local_maximum is new in the sense that the
+#             prev loc max was the position of hottest_sipm. (Then allow all SiPMs with
+#             new_local_maximum of new_local_maximum to contribute to the pos and q of the
+#             new cluster).
+
+# ***In general lm_radius should typically be set to 0, or some value slightly
+# larger than pitch or pitch*sqrt(2).***
+#
+# ***If lm_radius is set to a negative number, the algorithm will simply return
+# the overall barycenter all the SiPms above threshold.***
+lm_radius      =   0 * mm  # by default, use 3x3 corona. Set this number to -1 to use barycenter
+
+# new_lm_radius = radius, find a new cluster by calling barycenter() on pos/qs of SiPMs within
+#                 new_lm_radius of new_local_maximum
+new_lm_radius  =  15 * mm  # by default, use 3 x3 corona. Set to -1 to use barycenter.
+msipm          =   1 # minimum number of SiPMs in a Cluster

--- a/invisible_cities/io/dst_io.py
+++ b/invisible_cities/io/dst_io.py
@@ -24,7 +24,7 @@ def hits_writer(hdf5_file, *, compression='ZLIB4'):
                              compression = compression)
 
     hits_table.cols.event.create_index()
-
+    
     def write_hits(hits_event):
         hits_event.store(hits_table)
     return write_hits


### PR DESCRIPTION
The possibility of using corona instead of barycenter when processing "point like" events (e.g, Krypton events, implies that some times more than one cluster is produced by the algorithm. It is important to keep track of how many times this happens, in order to maximize the corona parameters for Krypton events. For example, if one runs corona ( 3 x 3) with a low SiPM threshold (e.g, less than 25 pes), about 10 % of the times 2 clusters are produced, while with a high SiPM threshold only 1% of the times a cluster is produced. Since the typical charge of a Krypton event in the anode is of the order of 300, a cut on 25 pes appears OK.

In order to keep tracks of the number of times that we have two hits a counter is introduced. In the same go, a few other counters are introduced to improve the book keeping of Dorothea. 

Finally, examples of configurations files to run Dorothea with barycenter or with corona are added to config. 
