### PR TITLE
Rename std to var

### DIFF
--- a/invisible_cities/evm/event_model.py
+++ b/invisible_cities/evm/event_model.py
@@ -163,7 +163,7 @@ class Voxel(BHit):
 
 class Cluster(BHit):
     """Represents a reconstructed cluster in the tracking plane"""
-    def __init__(self, Q, xy, xy_std, nsipm, z=ZANODE, E=NN):
+    def __init__(self, Q, xy, xy_var, nsipm, z=ZANODE, E=NN):
         if E == NN:
             super().__init__(xy.x, xy.y, z, Q)
         else:
@@ -171,23 +171,23 @@ class Cluster(BHit):
 
         self.Q       = Q
         self._xy     = xy
-        self._xy_std = xy_std
+        self._xy_var = xy_var
         self.nsipm   = nsipm
 
     @property
     def posxy (self): return self._xy.pos
 
     @property
-    def std (self): return self._xy_std
+    def var (self): return self._xy_var
 
     @property
     def XY  (self): return self._xy.XY
 
     @property
-    def Xrms(self): return np.sqrt(self._xy_std.x)
+    def Xrms(self): return np.sqrt(self._xy_var.x)
 
     @property
-    def Yrms(self): return np.sqrt(self._xy_std.y)
+    def Yrms(self): return np.sqrt(self._xy_var.y)
 
     @property
     def R   (self): return self._xy.R
@@ -208,7 +208,7 @@ class Hit(Cluster):
 
 
         super().__init__(cluster.Q,
-                         cluster._xy, cluster._xy_std,
+                         cluster._xy, cluster._xy_var,
                          cluster.nsipm, z, s2_energy)
 
         self.peak_number = peak_number

--- a/invisible_cities/evm/event_model_test.py
+++ b/invisible_cities/evm/event_model_test.py
@@ -50,11 +50,11 @@ def voxel_input(draw, min_value=0, max_value=100):
 def cluster_input(draw, min_value=0, max_value=100):
     x     = draw(floats  (  1,   5))
     y     = draw(floats  (-10,  10))
-    xstd  = draw(floats  (.01,  .5))
-    ystd  = draw(floats  (.10,  .9))
+    xvar  = draw(floats  (.01,  .5))
+    yvar  = draw(floats  (.10,  .9))
     Q     = draw(floats  ( 50, 100))
     nsipm = draw(integers(  1,  20))
-    return Q, x, y, xstd, ystd, nsipm
+    return Q, x, y, xvar, yvar, nsipm
 
 
 @composite
@@ -94,14 +94,14 @@ def test_event(test_class, event_pars):
 
 @given(cluster_input(1))
 def test_cluster(ci):
-    Q, x, y, xstd, ystd, nsipm = ci
-    xrms = np.sqrt(xstd)
-    yrms = np.sqrt(ystd)
+    Q, x, y, xvar, yvar, nsipm = ci
+    xrms = np.sqrt(xvar)
+    yrms = np.sqrt(yvar)
     r, phi =  np.sqrt(x ** 2 + y ** 2), np.arctan2(y, x)
     xyar   = (x, y)
-    stdar  = (xstd, ystd)
+    varar  = (xvar, yvar)
     pos    = np.stack(([x], [y]), axis=1)
-    c      = Cluster(Q, xy(x,y), xy(xstd,ystd), nsipm)
+    c      = Cluster(Q, xy(x,y), xy(xvar,yvar), nsipm)
 
     assert c.nsipm == nsipm
     np.isclose (c.Q   ,     Q, rtol=1e-4)
@@ -109,7 +109,7 @@ def test_cluster(ci):
     np.isclose (c.Y   ,     y, rtol=1e-4)
     np.isclose (c.Xrms,     xrms, rtol=1e-3)
     np.isclose (c.Yrms,     yrms, rtol=1e-3)
-    np.isclose (c.std.XY,   stdar, rtol=1e-4)
+    np.isclose (c.var.XY,   varar, rtol=1e-4)
     np.allclose(c.XY,       xyar, rtol=1e-4)
     np.isclose (c.R   ,     r, rtol=1e-4)
     np.isclose (c.Phi ,     phi, rtol=1e-4)
@@ -118,11 +118,11 @@ def test_cluster(ci):
 
 @given(cluster_input(1), hit_input(1))
 def test_hit(ci, hi):
-    Q, x, y, xstd, ystd, nsipm = ci
+    Q, x, y, xvar, yvar, nsipm = ci
     peak_number, E, z          = hi
     xyz = x, y, z
 
-    c = Cluster(Q, xy(x,y), xy(xstd,ystd), nsipm)
+    c = Cluster(Q, xy(x,y), xy(xvar,yvar), nsipm)
     h = Hit(peak_number, c, z, E)
 
     assert h.peak_number == peak_number

--- a/invisible_cities/reco/xy_algorithm_test.py
+++ b/invisible_cities/reco/xy_algorithm_test.py
@@ -67,7 +67,7 @@ def test_corona_barycenter_are_same_with_one_cluster(toy_sipm_signal):
     # assert len(c_cluster)  == len(b_cluster)
     # A cluster object has no length!
     np.array_equal(c_cluster.posxy, b_cluster.posxy)
-    np.array_equal(c_cluster.std.XY, b_cluster.std.XY)
+    np.array_equal(c_cluster.var.XY, b_cluster.var.XY)
     assert c_cluster.nsipm      == b_cluster.nsipm
     assert c_cluster.Q          == b_cluster.Q
     assert c_cluster.nsipm      == b_cluster.nsipm

--- a/invisible_cities/reco/xy_algorithms.py
+++ b/invisible_cities/reco/xy_algorithms.py
@@ -31,13 +31,13 @@ def barycenter(pos, qs):
     if not len(pos): raise SipmEmptyList
     if sum(qs) == 0: raise SipmZeroCharge
     mu  = np.average( pos           , weights=qs, axis=0)
-    std = np.average((pos - mu) ** 2, weights=qs, axis=0)
+    var = np.average((pos - mu) ** 2, weights=qs, axis=0)
     # For uniformity of interface, all xy algorithms should return a
     # list of clusters. barycenter always returns a single clusters,
     # but we still want it in a list.
-    return [Cluster(sum(qs), xy(*mu), xy(*std), len(qs))]
+    return [Cluster(sum(qs), xy(*mu), xy(*var), len(qs))]
 
-    #return [Cluster(sum(qs), XY(*mu), std, len(qs))]
+    #return [Cluster(sum(qs), XY(*mu), var, len(qs))]
 
 def discard_sipms(sis, pos, qs):
     return np.delete(pos, sis, axis=0), np.delete(qs, sis)


### PR DESCRIPTION
There are several places in the code where a variable is named ***std*** (for std deviation) when it actually refers to variance. This PR renames every ***std*** to ***var***. Closes #288.