### PR TITLE
fix find_peaks to avoid error when no pmt signal after tmin

### DIFF
--- a/invisible_cities/reco/peak_functions.py
+++ b/invisible_cities/reco/peak_functions.py
@@ -198,10 +198,11 @@ def _find_peaks(index, time=minmax(0, 1e+6), length=minmax(8, 1000000), stride=4
 
     peak_bounds = {}
     T = cpf._time_from_index(index)
-    # Start end end index of S12, [start i, end i)
-    i_min = int(time[0] / (25*units.ns))     # index in csum  corresponding to t.min
-    i_i = np.where(index >= i_min)[0].min()  # index in index corresponding to t.min (or first
-                                             # time not threshold suppressed)
+    i_min = int(time[0] / (25*units.ns))             # index in csum corresponding to t.min
+    where_after_tmin = np.where(index >= i_min)[0]   # where, in index, time is >= tmin
+    if len(where_after_tmin) == 0: return {}         # find no peaks if no index after tmin
+    i_i = where_after_tmin.min()                     # index in index corresponding to t.min
+                                                     # (or first time not threshold suppressed)
     peak_bounds[0] = np.array([index[i_i], index[i_i] + 1], dtype=np.int32)
 
     j = 0

--- a/invisible_cities/reco/peak_functions_c.pyx
+++ b/invisible_cities/reco/peak_functions_c.pyx
@@ -186,12 +186,15 @@ cpdef find_peaks(int [:] index, time, length, int stride=4):
     cdef double [:] T = _time_from_index(index)
     cdef dict peak_bounds  = {}
     cdef int i, j, i_i, i_min
+    cdef np.ndarray where_after_tmin
     tmin, tmax = time
     lmin, lmax = length
 
-    i_min = tmin / (25*units.ns)                          # index in csum  corresponding to t.min
-    i_i   = np.where(np.asarray(index) >= i_min)[0].min() # index in index corresponding to t.min
-                                                          # (or first time not threshold suppressed)
+    i_min = tmin / (25*units.ns)                                # index in csum of tmin
+    where_after_tmin = np.where(np.asarray(index) >= i_min)[0]  # where, in index, time is >= tmin
+    if len(where_after_tmin) == 0 : return {}                   # find no peaks in this case
+    i_i = where_after_tmin.min()                                # index in index of tmin (or first
+                                                                # time not threshold suppressed)
     peak_bounds[0] = np.array([index[i_i], index[i_i] + 1], dtype=np.int32)
 
     j = 0

--- a/invisible_cities/reco/peak_functions_test.py
+++ b/invisible_cities/reco/peak_functions_test.py
@@ -479,6 +479,18 @@ def test_find_peaks_finds_no_peaks_when_index_spaced_by_more_than_stride():
         assert bounds[0][0] ==  600
         assert bounds[0][1] ==  605
 
+def test_find_peaks_when_no_index_after_tmin():
+    stride = 2
+    index = np.concatenate((np.arange(  0, 500, stride, dtype=np.int32),
+                            np.arange(600, 605,      1, dtype=np.int32)))
+    assert cpf.find_peaks(index, time   = minmax(9e9, 9e10),
+                                 length = minmax(2, 9999),
+                                 stride = stride) == {}
+    assert pf._find_peaks(index, time   = minmax(9e9, 9e10),
+                                 length = minmax(2, 9999),
+                                 stride = stride) == {}
+
+
 def test_extract_peaks_from_waveform():
     wf = np.random.uniform(size=52000)
     # Generate peak_bounds


### PR DESCRIPTION
There was very dumb bug in `find_peaks` that could cause irene to crash for 1 out of a few hundred or few thousand events depending on trigger conditions and irene.conf. find_peaks would raise an error when there was no pmt signal after tmin. 

This PR gives a small fix in python and cython `find_peaks` and is tested in both. The fix has also been checked by running IC-dev, with the fix, in canfranc and verifying that irene no longer crashes. 