### PR TITLE
fix typo trheshold --> threshold

### DIFF
--- a/invisible_cities/evm/pmaps.pyx
+++ b/invisible_cities/evm/pmaps.pyx
@@ -49,14 +49,14 @@ cdef class Peak:
                                        np.any(np.isnan(self.E))
                                     else True)
 
-    def total_energy_above_trheshold(self, thr):
+    def total_energy_above_threshold(self, thr):
         eth = self.E[self.E > thr]
         if len(eth):
             return np.sum(eth)
         else:
             return 0
 
-    def width_above_trheshold(self, thr):
+    def width_above_threshold(self, thr):
         eth = self.E[self.E > thr]
         if len(eth):
             t0 = (loc_elem_1d(self.E, eth[0])
@@ -69,7 +69,7 @@ cdef class Peak:
         else:
             return 0
 
-    def height_above_trheshold(self, thr):
+    def height_above_threshold(self, thr):
         eth = self.E[self.E > thr]
         if len(eth):
             return np.max(eth)

--- a/invisible_cities/evm/pmaps_test.py
+++ b/invisible_cities/evm/pmaps_test.py
@@ -83,11 +83,11 @@ def test_peak_above_thr(peak_pars):
     else:
        assert  wf.good_waveform == True
 
-    np.isclose (wf.total_energy_above_trheshold(ethr) ,
+    np.isclose (wf.total_energy_above_threshold(ethr) ,
                 esum_thr, rtol=1e-4)
-    np.isclose (wf.height_above_trheshold(ethr),
+    np.isclose (wf.height_above_threshold(ethr),
                 height_thr, rtol=1e-4)
-    np.isclose (wf.width_above_trheshold(ethr),
+    np.isclose (wf.width_above_threshold(ethr),
                 w_thr, rtol=1e-4)
 
 

--- a/invisible_cities/filters/s1s2_filter.py
+++ b/invisible_cities/filters/s1s2_filter.py
@@ -36,9 +36,9 @@ class S12Selector:
 
         """
         #import pdb; pdb.set_trace()
-        f1 = energy.contains(peak.total_energy_above_trheshold(thr))
-        f2 = width.contains(peak.width_above_trheshold(thr))
-        f3 = height.contains(peak.height_above_trheshold(thr))
+        f1 = energy.contains(peak.total_energy_above_threshold(thr))
+        f2 = width.contains(peak.width_above_threshold(thr))
+        f3 = height.contains(peak.height_above_threshold(thr))
 
         return f1 and f2 and f3
 


### PR DESCRIPTION
This fixes a typo propagated from pmaps.peak to a few different places
in the repo. The method is tested. 

I think we should change this if it won't cause problems for anyone. @gonzaponte @jjgomezcadenas 