### PR TITLE
pmap classes raise exception if initialized with empty dicts

### DIFF
--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -27,6 +27,7 @@ from .. core.exceptions         import SipmEmptyList
 from .. core.exceptions         import SipmZeroCharge
 from .. core.exceptions         import ClusterEmptyList
 from .. core.exceptions         import XYRecoFail
+from .. core.exceptions         import InitializedEmptyPmapObject
 from .. core.system_of_units_c  import units
 from .. core.random_sampling    import NoiseSampler as SiPMsNoiseSampler
 
@@ -519,12 +520,10 @@ class PmapCity(CalibratedCity):
                     )
 
 
-
     def pmaps(self, s1_indx, s2_indx, csum, sipmzs):
         """Computes s1, s2 and s2si objects (PMAPS)"""
-
-        s1 = cpf.find_s1(csum, s1_indx, **self.s1_params._asdict())
-        s2 = cpf.find_s2(csum, s2_indx, **self.s2_params._asdict())
+        s1   = cpf.find_s1(csum, s1_indx, **self.s1_params._asdict())
+        s2   = cpf.find_s2(csum, s2_indx, **self.s2_params._asdict())
         s2si = cpf.find_s2si(sipmzs, s2.s2d, thr = self.thr_sipm_s2)
         return s1, s2, s2si
 

--- a/invisible_cities/core/exceptions.py
+++ b/invisible_cities/core/exceptions.py
@@ -62,3 +62,6 @@ class InconsistentS12dIpmtd(ICException):
 
 class NegativeThresholdNotAllowed(ICException):
     pass
+
+class InitializedEmptyPmapObject(ICException):
+    pass

--- a/invisible_cities/evm/pmaps.pyx
+++ b/invisible_cities/evm/pmaps.pyx
@@ -9,6 +9,7 @@ from .. core.exceptions        import SipmEmptyList
 from .. core.exceptions        import SipmNotFound
 from .. core.core_functions    import loc_elem_1d
 from .. core.exceptions        import InconsistentS12dIpmtd
+from .. core.exceptions        import InitializedEmptyPmapObject
 from .. core.system_of_units_c import units
 
 
@@ -23,6 +24,7 @@ cdef class Peak:
     def __init__(self, np.ndarray[double, ndim=1] t,
                        np.ndarray[double, ndim=1] E):
 
+        if len(t) == 0 or len(E) == 0: raise InitializedEmptyPmapObject
         cdef int i_t
         assert len(t) == len(E)
         self.t              = t
@@ -105,6 +107,7 @@ cdef class S12:
     """
     def __init__(self, dict s12d):
 
+        if len(s12d) == 0: raise InitializedEmptyPmapObject
         cdef int peak_no
         cdef np.ndarray[double, ndim=1] t
         cdef np.ndarray[double, ndim=1] E
@@ -148,6 +151,8 @@ cdef class S12:
 
 cdef class S1(S12):
     def __init__(self, s1d):
+
+        if len(s1d) == 0: raise InitializedEmptyPmapObject
         self.s1d = s1d
         super(S1, self).__init__(s1d)
 
@@ -162,7 +167,9 @@ cdef class S1(S12):
 
 
 cdef class S2(S12):
+
     def __init__(self, s2d):
+        if len(s2d) == 0: raise InitializedEmptyPmapObject
         self.s2d = s2d
         super(S2, self).__init__(s2d)
 
@@ -201,6 +208,7 @@ cdef class S2Si(S2):
            Q is the energy in each SiPM sample
         """
 
+        if len(s2sid) == 0 or len(s2d) == 0: raise InitializedEmptyPmapObject
         S2.__init__(self, check_s2d_and_s2sid_share_peaks(s2d, s2sid))
         self.s2sid = s2sid
 
@@ -325,7 +333,8 @@ cdef class S12Pmt(S12):
         s12d  = { peak_number: [[t], [E]]}
         ipmtd = { peak_number: [[Epmt0], [Epmt1], ... ,[EpmtN]] }
         """
-        cdef int npmts
+
+        if len(ipmtd) == 0 or len(s12d) == 0: raise InitializedEmptyPmapObject
         # Check that energies in s12d are sum of ipmtd across pmts for each peak
         for peak, s12_pmts in zip(s12d.values(), ipmtd.values()):
             if not np.allclose(peak[1], s12_pmts.sum(axis=0)):
@@ -333,6 +342,7 @@ cdef class S12Pmt(S12):
 
         S12.__init__(self, s12d)
         self.ipmtd = ipmtd
+        cdef int npmts
         try                 : self.npmts = len(ipmtd[next(iter(ipmtd))])
         except StopIteration: self.npmts = 0
 
@@ -398,6 +408,8 @@ cdef class S12Pmt(S12):
 
 cdef class S1Pmt(S12Pmt):
     def __init__(self, s1d, ipmtd):
+
+        if len(ipmtd) == 0 or len(s1d) == 0: raise InitializedEmptyPmapObject
         self.s1d = s1d
         S12Pmt.__init__(self, s1d, ipmtd)
 
@@ -411,6 +423,8 @@ cdef class S1Pmt(S12Pmt):
 
 cdef class S2Pmt(S12Pmt):
     def __init__(self, s2d, ipmtd):
+
+        if len(ipmtd) == 0 or len(s2d) == 0: raise InitializedEmptyPmapObject
         self.s2d = s2d
         S12Pmt.__init__(self, s2d, ipmtd)
 

--- a/invisible_cities/evm/pmaps_test.py
+++ b/invisible_cities/evm/pmaps_test.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from numpy.testing import assert_equal
 from pytest        import mark
+from pytest        import raises
 
 from hypothesis             import given
 from hypothesis.strategies  import floats
@@ -12,13 +13,17 @@ from hypothesis.extra.numpy import arrays
 from .. types.ic_types_c    import xy
 from .. types.ic_types_c    import minmax
 from .. core.exceptions     import InconsistentS12dIpmtd
+from .. core.exceptions     import InitializedEmptyPmapObject
 
 from .. reco.pmaps_functions_c import integrate_sipm_charges_in_peak
 from .. reco  import pmaps_functions as pmapf
 from .  pmaps import S1
 from .  pmaps import S2
+from .  pmaps import S12
 from .  pmaps import S2Si
 from .  pmaps import S12Pmt
+from .  pmaps import S1Pmt
+from .  pmaps import S2Pmt
 from .  pmaps import Peak
 from .  pmaps import check_s2d_and_s2sid_share_peaks
 from .. core.core_functions    import loc_elem_1d
@@ -293,3 +298,16 @@ def test_pmt_total_energy():
         s = 0
         for pn in s12pmt.peaks: s += s12pmt.pmt_total_energy_in_peak(pn, pmt)
         assert s12pmt.pmt_total_energy(pmt) == s
+
+@mark.parametrize("constructor, args",
+    ((Peak  , (np.array([],dtype=np.float64), np.array([], np.float64))),
+     (S1    , ({},   )),
+     (S2    , ({},   )),
+     (S12   , ({},   )),
+     (S2Si  , ({}, {})),
+     (S1Pmt , ({}, {})),
+     (S2Pmt , ({}, {})),
+     (S12Pmt, ({}, {}))))
+def test_pmap_constructors_raise_exception_when_initialized_with_empty_dicts(constructor, args):
+    with raises(InitializedEmptyPmapObject):
+        constructor(*args)

--- a/invisible_cities/io/pmap_io_test.py
+++ b/invisible_cities/io/pmap_io_test.py
@@ -238,15 +238,15 @@ def test_check_that_pmap_writer_and_ipmt_writer_does_not_modify_pmaps(config_tmp
         write_all_pmaps = pmap_writer_and_ipmt_writer(h5out)
         for ev in list(range(5)):
             if ev in    s1_dict:    s1 =    s1_dict[ev]  # Create empty si if there was no
-            else:    s1 = S1   ({}    )                  # peak of that kind found for that ev
+            else:    s1 = None                           # peak of that kind found for that ev
             if ev in    s2_dict:    s2 =    s2_dict[ev]
-            else:    s2 = S2   ({}    )
+            else:    s2 = None
             if ev in  s2si_dict:  s2si =  s2si_dict[ev]
-            else:  s2si = S2Si ({}, {})
+            else:  s2si = None
             if ev in s1pmt_dict: s1pmt = s1pmt_dict[ev]
-            else: s1pmt = S1Pmt({}, {})
+            else: s1pmt = None
             if ev in s2pmt_dict: s2pmt = s2pmt_dict[ev]
-            else: s2pmt = S2Pmt({}, {})
+            else: s2pmt = None
             write_all_pmaps(ev, s1, s2, s2si, s1pmt, s2pmt)
         h5out.flush() # Flush cannot go inside writers since writers do not know
                       # how much they have written or how much they will write

--- a/invisible_cities/reco/peak_functions.py
+++ b/invisible_cities/reco/peak_functions.py
@@ -353,8 +353,9 @@ def _compute_csum_and_pmaps(event, pmtrwf, sipmrwf,
                                             thr_MAU     = thr.thr_MAU)
 
     # zs sum
-    s2_ene, s2_indx = cpf.wfzs(csum, threshold=thr.thr_s2)
     s1_ene, s1_indx = cpf.wfzs(csum_mau, threshold=thr.thr_s1)
+    s2_ene, s2_indx = cpf.wfzs(csum    , threshold=thr.thr_s2)
+
 
     s1 = cpf.find_s1(csum,
                       s1_indx,
@@ -364,15 +365,20 @@ def _compute_csum_and_pmaps(event, pmtrwf, sipmrwf,
                       s2_indx,
                       **s2_params._asdict())
 
-    s1 = cpf.correct_s1_ene(s1.s1d, csum)
     sipmzs = cpf.signal_sipm(sipmrwf[event], adc_to_pes_sipm,
                            thr=thr.thr_sipm, n_MAU=100)
 
     s2si = cpf.find_s2si(sipmzs, s2.s2d, thr = thr.thr_SIPM)
 
+    if s1   is None:   s1d = None
+    else:    s1d = s1.s1d
+    if s2   is None:   s2d = None
+    else:   s2d = s2.s2d
+    if s2si is None: s2sid = None
+    else: s2sid = s2si.s2sid
 
     return (CSum(csum=csum, csum_mau=csum_mau),
-            PMaps(S1=s1.s1d, S2=s2.s2d, S2Si=s2si.s2sid))
+            PMaps(S1=s1d, S2=s2d, S2Si=s2sid))
 
 
 def compute_pmaps_from_rwf(event, pmtrwf, sipmrwf,

--- a/invisible_cities/reco/peak_functions_c.pyx
+++ b/invisible_cities/reco/peak_functions_c.pyx
@@ -14,6 +14,7 @@ from .. evm.pmaps import S1
 from .. evm.pmaps import S2
 from .. evm.pmaps import S2Si
 
+from .. core.exceptions        import InitializedEmptyPmapObject
 from .. core.system_of_units_c import units
 
 cpdef calibrated_pmt_sum(double [:, :]  CWF,
@@ -231,26 +232,34 @@ cpdef find_s1(double [:] csum,  int [:] index,
               time, length,
               int stride=4, rebin_stride=1):
     """
-    find s1 peaks and returns S1 objects
+    find s1 peaks and returns S1 objects. Will raise InitializedEmptyPmapObject if there is no S1
     """
-    return S1(find_s12(csum, index, time, length, stride, rebin_stride))
-
+    try:
+        return S1(find_s12(csum, index, time, length, stride, rebin_stride))
+    except InitializedEmptyPmapObject:
+        return None
 
 cpdef find_s2(double [:] csum,  int [:] index,
               time, length,
               int stride=40, rebin_stride=40):
     """
-    find s2 peaks and returns S2 objects
+    find s2 peaks and returns S2 objects.  Will raise InitializedEmptyPmapObject if there is no S2
     """
-    return S2(find_s12(csum, index, time, length, stride, rebin_stride))
+    try:
+        return S2(find_s12(csum, index, time, length, stride, rebin_stride))
+    except InitializedEmptyPmapObject:
+        return None
 
 
 cpdef find_s2si(double [:, :] sipmzs, dict s2d, double thr):
     """
-    find s2si and returns S2Si objects
+    find s2si and returns S2Si objects.  Will raise InitializedEmptyPmapObject if there is no S2Si
     """
     s2sid = sipm_s2sid(sipmzs, s2d, thr)
-    return S2Si(s2d, s2sid)
+    try:
+        return S2Si(s2d, s2sid)
+    except InitializedEmptyPmapObject:
+        return None
 
 
 cpdef find_s12(double [:] csum,  int [:] index,
@@ -271,13 +280,17 @@ cpdef find_s12(double [:] csum,  int [:] index,
 
 
 cpdef correct_s1_ene(dict s1d, np.ndarray csum):
+    """Will raise InitializedEmptyPmapObject if there is no S2Si"""
     cdef dict S1_corr = {}
     cdef int peak_no
     for peak_no, (t, _) in s1d.items():
         indices          = (t // 25).astype(int)
         S1_corr[peak_no] = t, csum[indices]
-    return S1(S1_corr)
 
+    try:
+        return S1(S1_corr)
+    except InitializedEmptyPmapObject:
+        return None
 
 cpdef rebin_waveform(int ts, int t_finish, double[:] wf, int stride=40):
     """

--- a/invisible_cities/reco/pmaps_functions_c.pyx
+++ b/invisible_cities/reco/pmaps_functions_c.pyx
@@ -20,7 +20,7 @@ from .. evm.pmaps import S2
 from .. evm.pmaps import S2Si
 from .. evm.pmaps import S1Pmt
 from .. evm.pmaps import S2Pmt
-
+from .. core.exceptions import InitializedEmptyPmapObject
 
 cpdef integrate_sipm_charges_in_peak(s2si, int peak_number):
     """Return arrays of nsipm and integrated charges from SiPM dictionary.
@@ -49,7 +49,8 @@ cpdef df_to_s1_dict(df, int max_events=-1):
     s12d_dict = df_to_pmaps_dict(df, max_events)  # {event:s12d}
 
     for event_no, s12d in s12d_dict.items():
-        s1_dict[event_no] = S1(s12d)
+        try: s1_dict[event_no] = S1(s12d)
+        except InitializedEmptyPmapObject: pass
 
     return s1_dict
 
@@ -66,7 +67,8 @@ cpdef df_to_s2_dict(df, int max_events=-1):
     s12d_dict = df_to_pmaps_dict(df, max_events)  # {event:s12d}
 
     for event_no, s12d in s12d_dict.items():
-        s2_dict[event_no] = S2(s12d)
+        try: s2_dict[event_no] = S2(s12d)
+        except InitializedEmptyPmapObject: pass
 
     return s2_dict
 
@@ -83,8 +85,8 @@ cpdef df_to_s1pmt_dict(dfs1, dfpmts, int max_events=-1):
     s1pmtd_dict = df_to_s12pmtd_dict(dfpmts, max_events)
     for event_no, ipmtd in s1pmtd_dict.items():
         s1d = s1_dict[event_no].s1d
-        s1pmt_dict[event_no] = S1Pmt(s1d, ipmtd)
-
+        try: s1pmt_dict[event_no] = S1Pmt(s1d, ipmtd)
+        except InitializedEmptyPmapObject: pass
     return s1pmt_dict
 
 
@@ -100,8 +102,8 @@ cpdef df_to_s2pmt_dict(dfs2, dfpmts, int max_events=-1):
     s2pmtd_dict = df_to_s12pmtd_dict(dfpmts, max_events)
     for event_no, ipmtd in s2pmtd_dict.items():
         s2d = s2_dict[event_no].s2d
-        s2pmt_dict[event_no] = S2Pmt(s2d, ipmtd)
-
+        try: s2pmt_dict[event_no] = S2Pmt(s2d, ipmtd)
+        except InitializedEmptyPmapObject: pass
     return s2pmt_dict
 
 
@@ -119,7 +121,8 @@ cpdef df_to_s2si_dict(dfs2, dfsi, int max_events=-1):
 
     for event_no, s2sid in s2sid_dict.items():
         s2d = s2_dict[event_no].s2d
-        s2si_dict[event_no] = S2Si(s2d, s2sid)
+        try: s2si_dict[event_no] = S2Si(s2d, s2sid)
+        except InitializedEmptyPmapObject: pass
 
     return s2si_dict
 
@@ -290,7 +293,8 @@ cpdef _delete_empty_s2si_peaks(dict s2si_dict):
                 del s2si_dict[ev].s2d  [pn]
                 # It is not sufficient to just delete the peaks because the S2Si class instance
                 # will still think it has peak pn even though its base dictionary does not
-                s2si_dict[ev] = S2Si(s2si_dict[ev].s2d, s2si_dict[ev].s2sid)
+                try: s2si_dict[ev] = S2Si(s2si_dict[ev].s2d, s2si_dict[ev].s2sid)
+                except InitializedEmptyPmapObject: del s2si_dict[ev]
     return s2si_dict
 
 


### PR DESCRIPTION
Pmap constructors: S1, S2, S2Si, S1Pmt, S2Pmt will now raise an exception when given empty dicts to initialize. Previously if we had an empty s2, we would call and initialize an empty S2Pmt --> S2 --> S12. This is now avoided. 

If the constructor is called to build a peaks out of empty dictionaries, the constructor now raises `InitializeEmptyPmapObject` which must be caught. 

The general flow of things has changed such that where previously if there were no s2 in an event, IC would pass around empty s2, s2si, and s2pmt, Now we just pass around `None`.

This PR merely creates this exception and catches it throughout the codebase where necessary. 