### PR TITLE
Refactor Penthesilea and Dorothea

### DIFF
--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -210,7 +210,7 @@ class City:
 
         with tb.open_file(self.output_file, "w",
                           filters = tbl.filters(self.compression)) as h5out:
-            self.write_parameters(h5out)
+            #self.write_parameters(h5out)
             self.writers = self.get_writers(h5out)
             self.file_loop()
 
@@ -257,9 +257,9 @@ class City:
         """Must be implemented by cities"""
         raise NotImplementedError("Concrete City must implement `event_loop`")
 
-    def write_parameters(self, h5out):
-        """Must be implemented by cities"""
-        raise NotImplementedError("Concrete City must implement `write_parameters`")
+    # def write_parameters(self, h5out):
+    #     """Must be implemented by cities"""
+    #     raise NotImplementedError("Concrete City must implement `write_parameters`")
 
     def get_writers(self, h5out):
         """Must be implemented by cities"""

--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -637,6 +637,13 @@ class PCity(City):
                       n_events_not_s2si_filter     = 0,
                       n_events_selected            = 0)
 
+    def create_dst_event(self, pmapVectors):
+        """Must be implemented by any city derived from PCity"""
+        raise NotImplementedError("Concrete City must implement `create_dst_event`")
+
+    def s12_selector(self):
+        """Must be implemented by any city derived from PCity"""
+        raise NotImplementedError("Concrete City must implement `s12_selector`")
 
     def event_loop(self, pmapVectors):
         """actions:

--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -253,19 +253,19 @@ class City:
 
     def file_loop(self):
         """Must be implemented by cities"""
-        raise FileLoopMethodNotSet
+        raise NotImplementedError("Concrete City must implement `file_loop`")
 
     def event_loop(self):
         """Must be implemented by cities"""
-        raise EventLoopMethodNotSet
+        raise NotImplementedError("Concrete City must implement `event_loop`")
 
     def write_parameters(self, h5out):
         """Must be implemented by cities"""
-        pass
+        raise NotImplementedError("Concrete City must implement `write_parameters`")
 
     def get_writers(self, h5out):
         """Must be implemented by cities"""
-        pass
+        raise NotImplementedError("Concrete City must implement `get_writers`")
 
     def set_up_database(self):
         DataPMT       = load_db.DataPMT (self.run_number)

--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -23,8 +23,6 @@ from .. core.configure          import configure
 from .. core.exceptions         import NoInputFiles
 from .. core.exceptions         import NoOutputFile
 from .. core.exceptions         import UnknownRWF
-from .. core.exceptions         import FileLoopMethodNotSet
-from .. core.exceptions         import EventLoopMethodNotSet
 from .. core.exceptions         import SipmEmptyList
 from .. core.exceptions         import SipmZeroCharge
 from .. core.exceptions         import ClusterEmptyList

--- a/invisible_cities/cities/dorothea.py
+++ b/invisible_cities/cities/dorothea.py
@@ -1,28 +1,16 @@
 """
 code: dorothea.py
-description: create a lightweight DST.
+description: create a KDST.
 credits: see ic_authors_and_legal.rst in /doc
 
-last revised: JJGC, July-2017
+last revised: JJGC, September-2017
 """
 
-import numpy  as np
-import tables as tb
-
-from .. core.configure         import configure
-from .. core.system_of_units_c import units
-
-from .. io.kdst_io              import kr_writer
+rom .. io.kdst_io               import kr_writer
 from .. evm.ic_containers       import PmapVectors
 
-from .. reco                   import tbl_functions   as tbl
-from .. reco                   import pmaps_functions_c as pmp
-
-from .. filters.s1s2_filter    import s1s2_filter
 from .. filters.s1s2_filter    import S12Selector
-
 from .  base_cities            import KrCity
-from .  base_cities            import EventLoop
 
 
 class Dorothea(KrCity):
@@ -30,71 +18,17 @@ class Dorothea(KrCity):
     def __init__(self, **kwds):
         super().__init__(**kwds)
 
-        self.cnt.init(n_events_tot                 = 0,
-                      nevt_out                     = 0,
-                      n_events_not_s1              = 0,
-                      n_events_not_s2              = 0,
-                      n_events_not_s2si            = 0,
-                      n_events_not_s1s2_filter     = 0,
-                      n_events_not_s2si_filter     = 0,
-                      n_events_selected            = 0)
-
-
         self.drift_v = self.conf.drift_v
         self._s1s2_selector = S12Selector(**kwds)
-
-
-    def event_loop(self, pmapVectors):
-        """actions:
-        1. loops over all PMAPS
-        2. filter pmaps
-        3. write kr_event
-        """
-
-        write_kr = self.writers
-        event_numbers= pmapVectors.events
-        timestamps = pmapVectors.timestamps
-        s1_dict = pmapVectors.s1
-        s2_dict = pmapVectors.s2
-        s2si_dict = pmapVectors.s2si
-
-        for evt_number, evt_time in zip(event_numbers, timestamps):
-            self.conditional_print(self.cnt.n_events_tot, self.cnt.nevt_out)
-
-            # Count events in and break if necessary before filtering
-            what_next = self.event_range_step()
-            if what_next is EventLoop.skip_this_event: continue
-            if what_next is EventLoop.terminate_loop : break
-            self.cnt.n_events_tot += 1
-            # get pmaps
-            s1, s2, s2si = self. get_pmaps_from_dicts(s1_dict,
-                                                      s2_dict,
-                                                      s2si_dict,
-                                                      evt_number)
-            # filtering
-            # loop event away if any signal (s1, s2 or s2si) not present
-            if s1 == None:
-                self.cnt.n_events_not_s1 += 1
-                continue
-            if s2 == None:
-                self.cnt.n_events_not_s2 += 1
-                continue
-            if s2si == None:
-                self.cnt.n_events_not_s2si += 1
-                continue
-            # loop event away if filter fails
-            if not s1s2_filter(self._s1s2_selector, s1, s2, s2si):
-                self.cnt.n_events_more_than_1_cluster += 1
-                continue
-            # event passed selection:
-            self.cnt.n_events_selected     += 1
-            # create Kr event & write to file
-            pmapVectors = PmapVectors(s1=s1, s2=s2, s2si=s2si,
-                                      events=evt_number,
-                                      timestamps=evt_time)
-            evt = self.create_kr_event(pmapVectors)
-            write_kr(evt)
 
     def get_writers(self, h5out):
         """Get the writers needed by dorothea"""
         return  kr_writer(h5out)
+
+    def create_dst_event(self, pmapVectors):
+        """Get the writers needed by dorothea"""
+        return  self.create_kr_event(pmapVectors)
+
+    def s12_selector(self):
+        """Return the selector defined for Dorothea"""
+        return self._s1s2_selector

--- a/invisible_cities/cities/dorothea.py
+++ b/invisible_cities/cities/dorothea.py
@@ -6,20 +6,14 @@ credits: see ic_authors_and_legal.rst in /doc
 last revised: JJGC, September-2017
 """
 
-rom .. io.kdst_io               import kr_writer
-from .. evm.ic_containers       import PmapVectors
-
-from .. filters.s1s2_filter    import S12Selector
-from .  base_cities            import KrCity
-
+from .. io.kdst_io               import kr_writer
+from .  base_cities              import KrCity
 
 class Dorothea(KrCity):
+    """Read PMAPS and produces a KDST"""
 
     def __init__(self, **kwds):
         super().__init__(**kwds)
-
-        self.drift_v = self.conf.drift_v
-        self._s1s2_selector = S12Selector(**kwds)
 
     def get_writers(self, h5out):
         """Get the writers needed by dorothea"""
@@ -29,6 +23,5 @@ class Dorothea(KrCity):
         """Get the writers needed by dorothea"""
         return  self.create_kr_event(pmapVectors)
 
-    def s12_selector(self):
-        """Return the selector defined for Dorothea"""
-        return self._s1s2_selector
+    def write_parameters(self, h5out):
+        pass

--- a/invisible_cities/cities/dorothea.py
+++ b/invisible_cities/cities/dorothea.py
@@ -35,8 +35,9 @@ class Dorothea(KrCity):
                       n_events_not_s1              = 0,
                       n_events_not_s2              = 0,
                       n_events_not_s2si            = 0,
-                      n_events_rejected_filter     = 0,
-                      n_events_more_than_1_cluster = 0)
+                      n_events_not_s1s2_filter     = 0,
+                      n_events_not_s2si_filter     = 0,
+                      n_events_selected            = 0)
 
 
         self.drift_v = self.conf.drift_v
@@ -86,7 +87,7 @@ class Dorothea(KrCity):
                 self.cnt.n_events_more_than_1_cluster += 1
                 continue
             # event passed selection:
-            self.cnt.nevt_out += 1
+            self.cnt.n_events_selected     += 1
             # create Kr event & write to file
             pmapVectors = PmapVectors(s1=s1, s2=s2, s2si=s2si,
                                       events=evt_number,

--- a/invisible_cities/cities/dorothea_test.py
+++ b/invisible_cities/cities/dorothea_test.py
@@ -52,7 +52,7 @@ def test_dorothea_KrMC(config_tmpdir, KrMC_pmaps):
     dorothea.run()
     cnt  = dorothea.end()
     nevt_in  = cnt.n_events_tot
-    nevt_out = cnt.nevt_out
+    nevt_out = cnt.n_events_selected
     if nrequired > 0:
         assert nrequired    == nevt_in
         assert nevt_out     <= nevt_in

--- a/invisible_cities/cities/isidora.py
+++ b/invisible_cities/cities/isidora.py
@@ -90,6 +90,9 @@ class Isidora(DeconvolutionCity):
 
         return writers
 
+    def write_parameters(self, h5out):
+        pass
+
     def display_IO_info(self):
         """display info"""
         super().display_IO_info()

--- a/invisible_cities/cities/penthesilea.py
+++ b/invisible_cities/cities/penthesilea.py
@@ -3,91 +3,25 @@ code: penthesila.py
 description: Read PMAPS and produces hits and beyond
 credits: see ic_authors_and_legal.rst in /doc
 
-last revised: JJGC, July-2017
+last revised: JJGC, September-2017
 """
 
-import numpy  as np
-import tables as tb
-
-from .. core.configure         import configure
-from .. core.system_of_units_c import units
-from .. types.ic_types         import xy
 from .. io.hits_io             import hits_writer
-from .. cities.base_cities     import City
 from .. cities.base_cities     import HitCity
-from .. cities.base_cities     import EventLoop
-from .. evm.event_model        import Cluster
-from .. evm.ic_containers      import PmapVectors
-from .. reco                   import tbl_functions as tbl
-
-from .. filters.s1s2_filter    import s1s2_filter
-from .. filters.s1s2_filter    import s2si_filter
-from .. filters.s1s2_filter    import S12Selector
 
 class Penthesilea(HitCity):
-    """Read PMAPS and produces hits and beyond"""
+    """Read PMAPS and produces a HDST"""
 
     def __init__(self, **kwds):
-        """actions:
-        1. inits base city
-        2. inits counters
-        3. inits s1s2 selector
-
-        """
         super().__init__(**kwds)
-        conf = self.conf
-
-        self.cnt.init(n_events_tot = 0,
-                      nevt_out     = 0)
-        self.drift_v        = conf.drift_v
-        self._s1s2_selector = S12Selector(**kwds)
-
-
-    def event_loop(self, pmapVectors):
-        """actions:
-        1. loops over all PMAPS
-        2. filter pmaps
-        3. write hit_event
-        """
-
-        write_hits = self.writers
-        event_numbers= pmapVectors.events
-        timestamps = pmapVectors.timestamps
-        s1_dict = pmapVectors.s1
-        s2_dict = pmapVectors.s2
-        s2si_dict = pmapVectors.s2si
-
-        for evt_number, evt_time in zip(event_numbers, timestamps):
-            self.conditional_print(self.cnt.n_events_tot, self.cnt.nevt_out)
-
-            # Count events in and break if necessary before filtering
-            what_next = self.event_range_step()
-            if what_next is EventLoop.skip_this_event: continue
-            if what_next is EventLoop.terminate_loop : break
-            self.cnt.n_events_tot += 1
-
-            # get pmaps
-            s1, s2, s2si = self. get_pmaps_from_dicts(s1_dict,
-                                                      s2_dict,
-                                                      s2si_dict,
-                                                      evt_number)
-            # filtering
-            # loop event away if any signal (s1, s2 or s2si) not present
-            if s1 == None or s2 == None or s2si == None:
-                continue
-            # filters in s12 and s2si
-            f1 = s1s2_filter(self._s1s2_selector, s1, s2, s2si)
-            f2 = s2si_filter(s2si)
-            if not f1 or not f2:
-                continue
-            # event passed selection: increment counter and write
-            self.cnt.nevt_out += 1
-            pmapVectors = PmapVectors(s1=s1, s2=s2, s2si=s2si,
-                                      events     = evt_number,
-                                      timestamps = evt_time)
-            evt = self.create_hits_event(pmapVectors)
-            write_hits(evt)
 
     def get_writers(self, h5out):
         """Get the writers needed by dorothea"""
         return  hits_writer(h5out)
+
+    def create_dst_event(self, pmapVectors):
+        """Get the writers needed by dorothea"""
+        return  self.create_hits_event(pmapVectors)
+
+    def write_parameters(self, h5out):
+        pass

--- a/invisible_cities/core/configure_test.py
+++ b/invisible_cities/core/configure_test.py
@@ -300,6 +300,8 @@ class DummyCity(City):
         self.cnt.n_events_tot = 10
 
     def file_loop(self): pass
+    def get_writers(self, h5out): pass
+    def write_parameters(self, h5out): pass
 
 
 def test_config_drive_fails_without_config_file():

--- a/invisible_cities/core/exceptions.py
+++ b/invisible_cities/core/exceptions.py
@@ -10,13 +10,6 @@ class NoInputFiles(ICException):
     """ Input files list is not defined """
     pass
 
-class FileLoopMethodNotSet(ICException):
-    """ File loop method no defined by cities"""
-    pass
-
-class EventLoopMethodNotSet(ICException):
-    """ Event loop method no defined by cities"""
-    pass
 
 class NoOutputFile(ICException):
     pass

--- a/invisible_cities/core/exceptions.py
+++ b/invisible_cities/core/exceptions.py
@@ -4,12 +4,9 @@ Define IC-specific exceptions
 
 class ICException(Exception):
     """ Base class for IC exceptions hierarchy """
-    pass
 
 class NoInputFiles(ICException):
     """ Input files list is not defined """
-    pass
-
 
 class NoOutputFile(ICException):
     pass

--- a/invisible_cities/io/indexation_test.py
+++ b/invisible_cities/io/indexation_test.py
@@ -20,6 +20,9 @@ class DummyCity(City):
     def file_loop(self):
         "Override so it is not executed"
 
+    def get_writers(self, h5out): pass
+    def write_parameters(self, h5out): pass
+
 
 @fixture(scope="session")
 def init_city(ICDIR, config_tmpdir):


### PR DESCRIPTION
This is an issue which will eventually turn into a PR. Given that GitHub has removed the ability of upgrading issues to PRs, I have started the issue as a PR, in order to save us the need of having both an issue and a PR covering the same topic.

The abstract methods `file_loop`, `event_loop`, `write_parameters` and `get_writers` are not consistent: Two of them raise very specific (and distinct) IC exceptions whose meaning is `NotImplementedError`; two of them `pass`.

This should be made consistent in one of two ways:

1. Remove the IC-specific exceptions, and make all 4 methods raise `NotImplementedError`.
2. Create two more IC-specific exceptions and make all 4 of them subclasses of `NotImplementedError` (as well as as `ICException`), and make each method raise its specific exception.

Once we agree on which option is preferred, anyone should feel free to effect the changes: I am unlikely to be around to do it myself.