### PR TITLE
allow irene to find ipmt pmaps

### DIFF
--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -55,6 +55,7 @@ from .. reco.xy_algorithms      import corona
 from .. evm.ic_containers       import S12Params
 from .. evm.ic_containers       import S12Sum
 from .. evm.ic_containers       import CSum
+from .. evm.ic_containers       import CCWf
 from .. evm.ic_containers       import DataVectors
 from .. evm.ic_containers       import PmapVectors
 from .. evm.ic_containers       import TriggerParams
@@ -448,6 +449,15 @@ class CalibratedCity(DeconvolutionCity):
         self.n_MAU_sipm = conf.n_mau_sipm
         self.  thr_sipm = conf.  thr_sipm
 
+
+    def calibrated_pmt_mau(self, CWF):
+        """Return the csum and csum_mau calibrated sums."""
+        return cpf.calibrated_pmt_mau(CWF,
+                                      self.adc_to_pes,
+                                      pmt_active = self.pmt_active,
+                                           n_MAU = self.  n_MAU   ,
+                                         thr_MAU = self.thr_MAU   )
+
     def calibrated_pmt_sum(self, CWF):
         """Return the csum and csum_mau calibrated sums."""
         return cpf.calibrated_pmt_sum(CWF,
@@ -506,18 +516,17 @@ class PmapCity(CalibratedCity):
         # deconvolve
         CWF = self.deconv_pmt(RWF)
         # calibrated PMT sum
+        ccwf, ccwf_mau = self.calibrated_pmt_mau(CWF)
         csum, csum_mau = self.calibrated_pmt_sum(CWF)
         #ZS sum for S1 and S2
-        s1_ene, s1_indx = self.csum_zs(csum_mau, threshold =
-                                           self.thr_csum_s1)
-        s2_ene, s2_indx = self.csum_zs(csum,     threshold =
-                                           self.thr_csum_s2)
+        s1_ene, s1_indx = self.csum_zs(csum_mau, threshold=self.thr_csum_s1)
+        s2_ene, s2_indx = self.csum_zs(csum,     threshold=self.thr_csum_s2)
         return (S12Sum(s1_ene  = s1_ene,
-                          s1_indx = s1_indx,
-                          s2_ene  = s2_ene,
-                          s2_indx = s2_indx),
-                CSum(csum = csum, csum_mau = csum_mau)
-                    )
+                       s1_indx = s1_indx,
+                       s2_ene  = s2_ene,
+                       s2_indx = s2_indx),
+                CCWf(ccwf = ccwf, ccwf_mau = ccwf_mau),
+                CSum(csum = csum, csum_mau = csum_mau))
 
 
     def pmaps(self, s1_indx, s2_indx, csum, cCWF, sipmzs, compute_ipmt_pmaps=False):

--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -487,6 +487,7 @@ class PmapCity(CalibratedCity):
     def __init__(self, **kwds):
         super().__init__(**kwds)
         conf = self.conf
+        self.compute_ipmt_pmaps = conf.compute_ipmt_pmaps
         self.s1_params = S12Params(time = minmax(min   = conf.s1_tmin,
                                                  max   = conf.s1_tmax),
                                    stride              = conf.s1_stride,
@@ -529,13 +530,13 @@ class PmapCity(CalibratedCity):
                 CSum(csum = csum, csum_mau = csum_mau))
 
 
-    def pmaps(self, s1_indx, s2_indx, csum, cCWF, sipmzs, compute_ipmt_pmaps=False):
+    def pmaps(self, s1_indx, s2_indx, ccwf, csum, sipmzs):
         """Computes s1, s2 and s2si objects (PMAPS)"""
-        if compute_ipmt_pmaps:
-            return pmp.get_pmaps_with_ipmt(s1_indx, s2_indx, csum, sipmzs,
+        if self.compute_ipmt_pmaps:
+            return pmp.get_pmaps_with_ipmt(s1_indx, s2_indx, ccwf, csum, sipmzs,
                                            self.s1_params, self.s2_params, self.thr_sipm_s2)
         else:
-            return pmp.get_pmaps(s1_indx, s2_indx, csum, cCWF, sipmzs,
+            return pmp.get_pmaps(s1_indx, s2_indx, csum, sipmzs,
                                  self.s1_params, self.s2_params, self.thr_sipm_s2)
 
 

--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -520,23 +520,14 @@ class PmapCity(CalibratedCity):
                     )
 
 
-<<<<<<< HEAD
-    def pmaps(self, s1_indx, s2_indx, csum, sipmzs):
-        """Computes s1, s2 and s2si objects (PMAPS)"""
-        s1   = cpf.find_s1(csum, s1_indx, **self.s1_params._asdict())
-        s2   = cpf.find_s2(csum, s2_indx, **self.s2_params._asdict())
-        s2si = cpf.find_s2si(sipmzs, s2.s2d, thr = self.thr_sipm_s2)
-        return s1, s2, s2si
-=======
-    def pmaps(self, s1_indx, s2_indx, csum, sipmzs, compute_ipmt_pmaps=False):
+    def pmaps(self, s1_indx, s2_indx, csum, cCWF, sipmzs, compute_ipmt_pmaps=False):
         """Computes s1, s2 and s2si objects (PMAPS)"""
         if compute_ipmt_pmaps:
             return pmp.get_pmaps_with_ipmt(s1_indx, s2_indx, csum, sipmzs,
                                            self.s1_params, self.s2_params, self.thr_sipm_s2)
         else:
-            return pmp.get_pmaps(s1_indx, s2_indx, csum, sipmzs,
+            return pmp.get_pmaps(s1_indx, s2_indx, csum, cCWF, sipmzs,
                                  self.s1_params, self.s2_params, self.thr_sipm_s2)
->>>>>>> allow irene to compute ipmt pmaps
 
 
 class DstCity(City):

--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -458,6 +458,9 @@ class CalibratedCity(DeconvolutionCity):
                                            n_MAU = self.  n_MAU   ,
                                          thr_MAU = self.thr_MAU   )
 
+    def sum_calibrated_pmt_mau(self, ccwf, ccwf_mau):
+        return pf.sum_waveforms(ccwf), pf.sum_waveforms(ccwf_mau)
+
     def calibrated_pmt_sum(self, CWF):
         """Return the csum and csum_mau calibrated sums."""
         return cpf.calibrated_pmt_sum(CWF,
@@ -518,7 +521,7 @@ class PmapCity(CalibratedCity):
         CWF = self.deconv_pmt(RWF)
         # calibrated PMT sum
         ccwf, ccwf_mau = self.calibrated_pmt_mau(CWF)
-        csum, csum_mau = self.calibrated_pmt_sum(CWF)
+        csum, csum_mau = self.sum_calibrated_pmt_mau(ccwf, ccwf_mau)
         #ZS sum for S1 and S2
         s1_ene, s1_indx = self.csum_zs(csum_mau, threshold=self.thr_csum_s1)
         s2_ene, s2_indx = self.csum_zs(csum,     threshold=self.thr_csum_s2)

--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -520,12 +520,23 @@ class PmapCity(CalibratedCity):
                     )
 
 
+<<<<<<< HEAD
     def pmaps(self, s1_indx, s2_indx, csum, sipmzs):
         """Computes s1, s2 and s2si objects (PMAPS)"""
         s1   = cpf.find_s1(csum, s1_indx, **self.s1_params._asdict())
         s2   = cpf.find_s2(csum, s2_indx, **self.s2_params._asdict())
         s2si = cpf.find_s2si(sipmzs, s2.s2d, thr = self.thr_sipm_s2)
         return s1, s2, s2si
+=======
+    def pmaps(self, s1_indx, s2_indx, csum, sipmzs, compute_ipmt_pmaps=False):
+        """Computes s1, s2 and s2si objects (PMAPS)"""
+        if compute_ipmt_pmaps:
+            return pmp.get_pmaps_with_ipmt(s1_indx, s2_indx, csum, sipmzs,
+                                           self.s1_params, self.s2_params, self.thr_sipm_s2)
+        else:
+            return pmp.get_pmaps(s1_indx, s2_indx, csum, sipmzs,
+                                 self.s1_params, self.s2_params, self.thr_sipm_s2)
+>>>>>>> allow irene to compute ipmt pmaps
 
 
 class DstCity(City):

--- a/invisible_cities/cities/irene.py
+++ b/invisible_cities/cities/irene.py
@@ -17,6 +17,7 @@ from .. core.system_of_units_c import units
 
 from .. io.mc_io               import mc_track_writer
 from .. io.pmap_io             import pmap_writer
+from .. io.pmap_io             import pmap_writer_and_ipmt_writer
 from .. io.run_and_event_io    import run_and_event_writer
 from .. reco                   import tbl_functions as tbl
 from .. evm.ic_containers      import S12Params as S12P
@@ -72,7 +73,7 @@ class Irene(PmapCity):
             sipmzs = self.calibrated_signal_sipm(sipmrwf[evt])
 
             # pmaps
-            pmap = self.pmaps(s12sum.s1_indx, s12sum.s2_indx, calsum.csum, sipmzs)
+            pmap = self.pmaps(s12sum.s1_indx, s12sum.s2_indx, cal_cwf.ccwf, calsum.csum, sipmzs)
 
             # write stuff
             event, timestamp = self.event_and_timestamp(evt, events_info)
@@ -111,9 +112,10 @@ class Irene(PmapCity):
     def get_writers(self, h5out):
         """Get the writers needed by Irene"""
         writers = Namespace(
-        pmap          =          pmap_writer(h5out),
-        run_and_event = run_and_event_writer(h5out),
-        mc            =      mc_track_writer(h5out) if self.monte_carlo else None,
+        run_and_event =        run_and_event_writer(h5out),
+        mc            =             mc_track_writer(h5out) if self.monte_carlo else None,
+        pmap          = pmap_writer_and_ipmt_writer(h5out) if self.compute_ipmt_pmaps \
+                                   else pmap_writer(h5out),
         )
         return writers
 

--- a/invisible_cities/cities/irene.py
+++ b/invisible_cities/cities/irene.py
@@ -62,7 +62,7 @@ class Irene(PmapCity):
 
         for evt in range(NEVT):
             # calibrated sum in PMTs
-            s12sum, calsum = self.pmt_transformation(pmtrwf[evt])
+            s12sum, cal_cwf, calsum = self.pmt_transformation(pmtrwf[evt])
 
             if not self.check_s12(s12sum): # ocasional but rare empty events
                 self.cnt.increment_counter('n_empty_events')

--- a/invisible_cities/cities/irene.py
+++ b/invisible_cities/cities/irene.py
@@ -70,15 +70,13 @@ class Irene(PmapCity):
 
             # calibrated sum in SiPMs
             sipmzs = self.calibrated_signal_sipm(sipmrwf[evt])
+
             # pmaps
-            s1, s2, s2si = self.pmaps(s12sum.s1_indx,
-                                      s12sum.s2_indx,
-                                      calsum.csum,
-                                      sipmzs)
+            pmap = self.pmaps(s12sum.s1_indx, s12sum.s2_indx, calsum.csum, sipmzs)
 
             # write stuff
             event, timestamp = self.event_and_timestamp(evt, events_info)
-            write.pmap         (event, s1, s2, s2si)
+            write.pmap         (event, *pmap)
             write.run_and_event(self.run_number, event, timestamp)
             if self.monte_carlo:
                 write.mc(mc_tracks, self.cnt.counter_value('n_events_tot'))

--- a/invisible_cities/config/pmap_city.conf
+++ b/invisible_cities/config/pmap_city.conf
@@ -5,9 +5,10 @@
 
 include('$ICDIR/config/calibrated_city.conf')
 
+compute_ipmt_pmaps = True
+
 # Set parameters to search for S1
 # Notice that in MC file S1 is in t=100 mus
-
 s1_tmin    =  99 * mus # position of S1 in MC files at 100 mus
 s1_tmax    = 101 * mus # change tmin and tmax if S1 not at 100 mus
 s1_stride  =   4       # minimum number of 25 ns bins in S1 searches

--- a/invisible_cities/evm/ic_containers.py
+++ b/invisible_cities/evm/ic_containers.py
@@ -30,6 +30,7 @@ for name, attrs in (
         ('PmapParams'     , 's1_params s2_params s1p_params s1_PMT_params s1p_PMT_params'),
         ('ThresholdParams', 'thr_s1 thr_s2 thr_MAU thr_sipm thr_SIPM'),
         ('CSum'           , 'csum csum_mau'),
+        ('CCWf'           , 'ccwf, ccwf_mau'),
         ('S12Sum'         , 's1_ene, s1_indx, s2_ene, s2_indx'),
         ('CalibratedPMT'  , 'CPMT CPMT_mau'),
         ('S1PMaps'        , 'S1 S1_PMT S1p S1p_PMT'),

--- a/invisible_cities/evm/pmaps.pyx
+++ b/invisible_cities/evm/pmaps.pyx
@@ -337,7 +337,7 @@ cdef class S12Pmt(S12):
         if len(ipmtd) == 0 or len(s12d) == 0: raise InitializedEmptyPmapObject
         # Check that energies in s12d are sum of ipmtd across pmts for each peak
         for peak, s12_pmts in zip(s12d.values(), ipmtd.values()):
-            if not np.allclose(peak[1], s12_pmts.sum(axis=0)):
+            if not np.allclose(peak[1], s12_pmts.sum(axis=0), atol=.01):
                 raise InconsistentS12dIpmtd
 
         S12.__init__(self, s12d)

--- a/invisible_cities/evm/pmaps_test.py
+++ b/invisible_cities/evm/pmaps_test.py
@@ -252,12 +252,9 @@ def test_S12Pmt_raises_error_when_s2_peak_E_not_equal_to_sum_of_s12pmt_peak():
     npmts  = 12
     ipmtd = {0: np.random.random((npmts, timebins))}
     s12d    = {0: np.array([list(range(timebins)), ipmtd[0].sum(axis=0)])}
-    ipmtd[0][-1, -1] += .0001
-    try:
+    ipmtd[0][-1, -1] += .1
+    with raises(InconsistentS12dIpmtd):
         S12Pmt(s12d, ipmtd)
-        assert False
-    except InconsistentS12dIpmtd:
-        pass
 
 
 def test_S12Pmt_pmt_waveform():

--- a/invisible_cities/reco/peak_functions.py
+++ b/invisible_cities/reco/peak_functions.py
@@ -235,27 +235,6 @@ def _extract_peaks_from_waveform(wf, peak_bounds, rebin_stride=1):
     return S12L
 
 
-def get_s12pmtd(cCWF, peak_bounds, rebin_stride=1):
-    """
-    Given the calibrated corrected waveforms of all active pmts for one event, CWF, and the
-    boundaries of all of the s12 peaks found in the csum, peak_bounds, return the s12 peaks of the
-    individual pmts, s12pmtd.
-    """
-    # extract the peaks from the cwf of each pmt
-    S12Ls = [cpf.extract_peaks_from_waveform(ccwf, peak_bounds, rebin_stride=rebin_stride) \
-             for ccwf in cCWF]
-
-    s12pmtd = {}
-    npmts  = len(S12Ls)
-    for pn in peak_bounds:
-        # initialize an the array of pmt energies with shape npmts, len(peak.t)
-        s12pmtd[pn] = np.empty((npmts, len(S12Ls[0][pn][0])), dtype=np.float32)
-        # fill the array of pmt s2 energies one pmt at a time
-        for pmt in range(npmts): s12pmtd[pn][pmt] = S12Ls[pmt][pn][1]
-
-    return s12pmtd
-
-
 def _find_s12(csum, index,
               time   = minmax(0, 1e+6),
               length = minmax(8, 1000000),

--- a/invisible_cities/reco/peak_functions.py
+++ b/invisible_cities/reco/peak_functions.py
@@ -447,3 +447,8 @@ def compute_pmaps_from_rwf(event, pmtrwf, sipmrwf,
 
 
     return PMaps(S1=s1, S2=s2, S2Si=s2si)
+
+
+def sum_waveforms(waveforms):
+    """sum waveforms over the 0th axis"""
+    return np.sum(waveforms, axis=0)

--- a/invisible_cities/reco/peak_functions_c.pxd
+++ b/invisible_cities/reco/peak_functions_c.pxd
@@ -90,21 +90,24 @@ returns the times (in ns) corresponding to the indexes in indx
 cpdef _time_from_index(int [:] indx)
 
 
-cpdef find_s1(double [:] csum,  int [:] index,
-              time, length,
-              int stride=*, rebin_stride=*)
+cpdef find_s1(double [:] csum, int [:] index, time, length, int stride=*, int rebin_stride=*)
 
 
-cpdef find_s2(double [:] csum,  int [:] index,
-              time, length,
-              int stride=*, rebin_stride=*)
+"""find s1 peaks and return s1 and s1pmt objects"""
+cpdef find_s1_ipmt(double [:,:] ccwf, double [:] csum, int [:] index, time, length, int stride=*, int rebin_stride=*)
+
+
+cpdef find_s2(double [:] csum,  int [:] index, time, length, int stride=*, int rebin_stride=*)
+
+
+"""find s2 peaks and return s2 and s2pmt objects"""
+cpdef find_s2_ipmt(double [:,:] ccwf, double [:] csum, int [:] index, time, length, int stride=*, int rebin_stride=*)
 
 
 cpdef find_s2si(double [:, :] sipmzs, dict s2d, double thr)
 
 
-cpdef find_s12(double [:] csum,  int [:] index,
-               time, length, int stride, rebin_stride)
+cpdef find_s12(double [:] csum, int [:] index, time, length, int stride, int rebin_stride)
 
 
 cpdef correct_s1_ene(dict s1d, np.ndarray csum)

--- a/invisible_cities/reco/peak_functions_c.pxd
+++ b/invisible_cities/reco/peak_functions_c.pxd
@@ -94,14 +94,18 @@ cpdef find_s1(double [:] csum, int [:] index, time, length, int stride=*, int re
 
 
 """find s1 peaks and return s1 and s1pmt objects"""
-cpdef find_s1_ipmt(double [:,:] ccwf, double [:] csum, int [:] index, time, length, int stride=*, int rebin_stride=*)
+cpdef find_s1_ipmt(double [:,:] ccwf, double [:] csum, int [:] index, time, length,
+    int stride=*,
+    int rebin_stride=*)
 
 
 cpdef find_s2(double [:] csum,  int [:] index, time, length, int stride=*, int rebin_stride=*)
 
 
 """find s2 peaks and return s2 and s2pmt objects"""
-cpdef find_s2_ipmt(double [:,:] ccwf, double [:] csum, int [:] index, time, length, int stride=*, int rebin_stride=*)
+cpdef find_s2_ipmt(double [:,:] ccwf, double [:] csum, int [:] index, time, length,
+    int stride=*,
+    int rebin_stride=*)
 
 
 cpdef find_s2si(double [:, :] sipmzs, dict s2d, double thr)

--- a/invisible_cities/reco/peak_functions_c.pyx
+++ b/invisible_cities/reco/peak_functions_c.pyx
@@ -98,9 +98,9 @@ cpdef calibrated_pmt_mau(double [:, :]  CWF,
                                    dtype = np.double) * (1 / n_MAU)
 
     # CWF if above MAU threshold
-    cdef double [:, :] pmt_thr  = np.zeros((NPMT,NWF), dtype=np.double)
-    cdef double [:, :] pmt_thr_mau  = np.zeros((NPMT,NWF), dtype=np.double)
-    cdef double [:]    MAU_pmt  = np.zeros(      NWF , dtype=np.double)
+    cdef double [:, :] pmt_thr  = np.zeros((NPMT, NWF), dtype=np.double)
+    cdef double [:, :] pmt_thr_mau  = np.zeros((NPMT, NWF), dtype=np.double)
+    cdef double [:]    MAU_pmt  = np.zeros(      NWF, dtype=np.double)
 
     for j in PMT:
         # MAU for each of the PMTs, following the waveform
@@ -110,7 +110,6 @@ cpdef calibrated_pmt_mau(double [:, :]  CWF,
             pmt_thr[j,k] = CWF[j,k] * 1 / adc_to_pes[j]
             if CWF[j,k] >= MAU_pmt[k] + thr_MAU: # >= not >: found testing!
                 pmt_thr_mau[j,k] = CWF[j,k] * 1 / adc_to_pes[j]
-
 
     return np.asarray(pmt_thr), np.asarray(pmt_thr_mau)
 

--- a/invisible_cities/reco/peak_functions_c.pyx
+++ b/invisible_cities/reco/peak_functions_c.pyx
@@ -243,7 +243,9 @@ cpdef find_s1(double [:] csum,  int [:] index,
 
 cpdef find_s1_ipmt(double [:,:] ccwf, double [:] csum, int [:] index,
                    time, length, int stride=4, int rebin_stride=1):
-    """find s2 peaks and return s2 and s2pmt objects"""
+    """
+    find s1 peaks and return s1 and s1pmt objects. Will raise InitializedEmptyPmapObject if no S1
+    """
     # Find indices bounding s1-like peaks
     s1_bounds = find_peaks(index, time, length, stride)
     try:

--- a/invisible_cities/reco/peak_functions_c.pyx
+++ b/invisible_cities/reco/peak_functions_c.pyx
@@ -239,6 +239,32 @@ cpdef find_s1(double [:] csum,  int [:] index,
     except InitializedEmptyPmapObject:
         return None
 
+cpdef find_s1_ipmt(double [:] csum, double [:,:] cCWF, int [:] index,
+                   time, length, int stride=4, rebin_stride=1):
+    """find s2 peaks and return s2 and s2pmt objects"""
+    # Find indices bounding s1-like peaks
+    s1_bounds = cpf.find_peaks(s1_indx, time, length, stride)
+    try:
+        s1    = S1(cpf.extract_peaks_from_waveform(csum, s1_bounds, rebin_stride=rebin_stride))
+        s1pmt = S1Pmt(s1.s1d, get_s12pmtd(cCWF, s1_bounds, rebin_stride=rebin_stride))
+        return s1, s1pmt
+    except InitializedEmptyPmapObject:
+        return None, None
+
+
+cpdef find_s2_ipmt(double [:] csum, double [:,:] cCWF,  int [:] index,
+              time, length, int stride=4, rebin_stride=40):
+    """find s2 peaks and return s2 and s2pmt objects"""
+    # Find indices bounding s2-like peaks
+    s1_bounds = cpf.find_peaks(s2_indx, time, length, stride)
+    try:
+        s1    = S2(cpf.extract_peaks_from_waveform(csum, s2_bounds, rebin_stride=rebin_stride))
+        s1pmt = S2Pmt(s2.s2d, get_s12pmtd(cCWF, s2_bounds, rebin_stride=rebin_stride))
+        return s2, s2pmt
+    except InitializedEmptyPmapObject:
+        return None, None
+
+
 cpdef find_s2(double [:] csum,  int [:] index,
               time, length,
               int stride=40, rebin_stride=40):

--- a/invisible_cities/reco/peak_functions_test.py
+++ b/invisible_cities/reco/peak_functions_test.py
@@ -507,7 +507,7 @@ def test_extract_peaks_from_waveform():
     # Check that _extract... did not return extra peaks
     assert len(peak_bounds) == len(S12L)
 
-def test_get_s12pmtd():
+def test_get_ipmtd():
     npmts  = 4
     ntbins = 52000
     cCWF   = np.random.random(size=(npmts, ntbins)) # generate wfs for pmts
@@ -534,3 +534,61 @@ def test_get_s12pmtd():
 def test_sum_waveforms():
     wfs = np.random.random((12,1300*40))
     assert np.allclose(pf.sum_waveforms(wfs), np.sum(wfs, axis=0))
+
+@fixture(scope='module')
+def toy_ccwfs_and_csum():
+    ccwf  = np.zeros((3, 52000), dtype=np.float64)
+    psize = 200
+    peak  = np.random.normal(loc=10, size=(ccwf.shape[0], psize))
+    indx  = np.arange(650, 650+psize, dtype=np.int32)
+    ccwf[:, indx[0]: indx[-1] + 1] += peak
+    csum  = ccwf.sum(axis=0)
+    return indx, ccwf, csum
+
+def test_find_s12_ipmt_find_same_s12_as_find_s12(toy_ccwfs_and_csum):
+    indx, ccwf, csum = toy_ccwfs_and_csum
+    s10    = cpf.find_s1(csum, indx,
+                     time   = minmax(0, 1e+6),
+                     length = minmax(0, 1000000),
+                     stride = 4,
+                     rebin_stride = 1)
+    s11, _ = cpf.find_s1_ipmt(ccwf, csum, indx,
+                     time   = minmax(0, 1e+6),
+                     length = minmax(0, 1000000),
+                     stride = 4,
+                     rebin_stride = 1)
+    s20    = cpf.find_s2(csum, indx,
+                     time   = minmax(0, 1e+6),
+                     length = minmax(0, 1000000),
+                     stride = 4,
+                     rebin_stride = 40)
+    s21, _ = cpf.find_s2_ipmt(ccwf, csum, indx,
+                     time   = minmax(0, 1e+6),
+                     length = minmax(0, 1000000),
+                     stride = 4,
+                     rebin_stride = 0)
+    # Check same s1s found
+    assert s10.s1d.keys() == s11.s1d.keys()
+    for peak0, peak1 in zip(s10.s1d.values(), s11.s1d.values()):
+        assert np.allclose(peak0, peak1)
+    # Check same s2s found
+    assert s20.s2d.keys() == s21.s2d.keys()
+    for peak0, peak1 in zip(s10.s1d.values(), s11.s1d.values()):
+        assert np.allclose(peak0, peak1)
+
+def test_find_s12_ipmt_return_none_when_empty_index(toy_ccwfs_and_csum):
+    indx, ccwf, csum = toy_ccwfs_and_csum
+    # Check no s1 found
+    for pmap_class in cpf.find_s1_ipmt(ccwf, csum, np.array([], dtype=np.int32),
+                         time   = minmax(0, 1e+6),
+                         length = minmax(0, 1000000),
+                         stride = 4,
+                         rebin_stride = 1):
+        assert pmap_class is None
+    # Check no s2 found
+    for pmap_class in cpf.find_s2_ipmt(ccwf, csum, np.array([], dtype=np.int32),
+                         time   = minmax(0, 1e+6),
+                         length = minmax(0, 1000000),
+                         stride = 4,
+                         rebin_stride = 1):
+        assert pmap_class is None

--- a/invisible_cities/reco/peak_functions_test.py
+++ b/invisible_cities/reco/peak_functions_test.py
@@ -511,7 +511,7 @@ def test_extract_peaks_from_waveform():
 def test_get_s12pmtd():
     npmts  = 4
     ntbins = 52000
-    cCWF    = np.random.random(size=(npmts, ntbins)) # generate wfs for pmts
+    cCWF   = np.random.random(size=(npmts, ntbins)) # generate wfs for pmts
     csum   = cCWF.sum(axis=0)                 # and their sum
     npeaks = 20
     peak_bounds  = {}
@@ -531,3 +531,7 @@ def test_get_s12pmtd():
             assert np.allclose(s12l[1], s12_pmts.sum(axis=0))
             # check that the correct energy is in each pmt
             assert np.allclose(s12_pmts.sum(axis=1), cCWF[:, i_peak[0]: i_peak[1]].sum(axis=1))
+
+def test_sum_waveforms():
+    wfs = np.random.random((12,1300*40))
+    assert np.allclose(pf.sum_waveforms(wfs), np.sum(wfs, axis=0))

--- a/invisible_cities/reco/peak_functions_test.py
+++ b/invisible_cities/reco/peak_functions_test.py
@@ -490,7 +490,6 @@ def test_find_peaks_when_no_index_after_tmin():
                                  length = minmax(2, 9999),
                                  stride = stride) == {}
 
-
 def test_extract_peaks_from_waveform():
     wf = np.random.uniform(size=52000)
     # Generate peak_bounds
@@ -525,7 +524,7 @@ def test_get_s12pmtd():
     for rebin_stride in rebin_strides:
         # extract the peaks from the csum, and for each pmt extract the peaks from the cCWF
         S12L   = cpf.extract_peaks_from_waveform(csum, peak_bounds, rebin_stride=rebin_stride)
-        s12pmtd = pf.get_s12pmtd(cCWF, peak_bounds, rebin_stride=rebin_stride)
+        s12pmtd = cpf.get_ipmtd(cCWF, peak_bounds, rebin_stride=rebin_stride)
         for s12l, s12_pmts, i_peak in zip(S12L.values(), s12pmtd.values(), peak_bounds.values()):
             # check that the sum of the individual pmt s12s equals the total s12, at each time bin
             assert np.allclose(s12l[1], s12_pmts.sum(axis=0))

--- a/invisible_cities/reco/pmaps_functions.py
+++ b/invisible_cities/reco/pmaps_functions.py
@@ -9,13 +9,31 @@ Last revised, JJGC, July, 2017.
 """
 import copy
 import numpy  as     np
+from .. reco import peak_functions_c  as cpf
 from .. reco import pmaps_functions_c as pmpc
-from .. core import core_functions_c as ccf
+from .. core import core_functions_c  as ccf
 from .. core.system_of_units_c      import units
 from .. core.exceptions             import NegativeThresholdNotAllowed
 from .. evm.pmaps                   import S2, S2Si, Peak
 
 from typing import Dict
+
+
+def get_pmaps(s1_indx, s2_indx, csum, sipmzs, s1_params, s2_params, thr_sipm_s2):
+    """Computes s1, s2 and s2si objects (PMAPS)"""
+    s1 = cpf.find_s1(csum, s1_indx, **s1_params._asdict())
+    s2 = cpf.find_s2(csum, s2_indx, **s2_params._asdict())
+    s2si = cpf.find_s2si(sipmzs, s2.s2d, thr = thr_sipm_s2)
+    return s1, s2, s2si
+
+
+def get_pmaps_with_ipmt(s1_indx, s2_indx, csum, sipmzs, s1_params, s2_params, thr_sipm_s2):
+    """Computes s1, s2, s2si, s1pmt and s2pmt objects"""
+    s1, s1pmt = cpf.find_s1_ipmt(csum, s1_indx, **s1_params._asdict())
+    s2, s2pmt = cpf.find_s2_ipmt(csum, s2_indx, **s2_params._asdict())
+    s2si      = cpf.find_s2si(sipmzs, s2.s2d, thr=thr_sipm_s2)
+    return s1, s2, s2si, s1pmt, s2pmt
+
 
 def _integrate_sipm_charges_in_peak_as_dict(s2si):
     """Return dict of integrated charges from a SiPM dictionary.

--- a/invisible_cities/reco/pmaps_functions.py
+++ b/invisible_cities/reco/pmaps_functions.py
@@ -27,11 +27,11 @@ def get_pmaps(s1_indx, s2_indx, csum, sipmzs, s1_params, s2_params, thr_sipm_s2)
     return s1, s2, s2si
 
 
-def get_pmaps_with_ipmt(s1_indx, s2_indx, csum, sipmzs, s1_params, s2_params, thr_sipm_s2):
+def get_pmaps_with_ipmt(s1_indx, s2_indx, ccwf, csum, sipmzs, s1_params, s2_params, thr_sipm_s2):
     """Computes s1, s2, s2si, s1pmt and s2pmt objects"""
-    s1, s1pmt = cpf.find_s1_ipmt(csum, s1_indx, **s1_params._asdict())
-    s2, s2pmt = cpf.find_s2_ipmt(csum, s2_indx, **s2_params._asdict())
-    s2si      = cpf.find_s2si(sipmzs, s2.s2d, thr=thr_sipm_s2)
+    s1, s1pmt = cpf.find_s1_ipmt(ccwf, csum, s1_indx, **s1_params._asdict())
+    s2, s2pmt = cpf.find_s2_ipmt(ccwf, csum, s2_indx, **s2_params._asdict())
+    s2si      = cpf.find_s2si(sipmzs, s2.s2d, thr = thr_sipm_s2)
     return s1, s2, s2si, s1pmt, s2pmt
 
 
@@ -69,6 +69,7 @@ def _integrate_S2Si_charge(s2sid):
     """
     return { peak_no : _integrate_sipm_charges_in_peak_as_dict(peak)
              for (peak_no, peak) in s2sid.items() }
+
 
 def rebin_s2si(s2, s2si, rf):
     """given an s2 and a corresponding s2si, rebin them by a factor rf"""


### PR DESCRIPTION
This pr will allow irene to make use of the ipmt pmap finders and writers in order to save ipmt pmaps. I've run this irene in my notebook a few times and everything looks good so far.

1)  In order to tell irene to write ipmt pmaps (or not) I had to put a flag `compute_ipmt_pmaps` in pmap_city.conf. This means that previous irene config files will not work without first adding the flag. This may be kind of annoying for people running productions @jmbenlloch @jerenner @gonzaponte. If there is a better way of doing this, please let me know, and I will implement it. The only alternative I could think of would be to create another city, but that sounds potentially even more annoying for you guys.

2) I did some time/memory profiling for on Kr data. From run 4446 with `thr_sipm = 1pes` and 'thr_sipm_s2 = 2pes' and found after running 1k events:
speed
1.92 evt / sec with IPMT
2.06 evt / sec without 
file size
2.37 x larger than without IPMT
So, time does not appear to be an issue, but the file size does grow substantially...  

3) @jjgomezcadenas I don't remember if we decided we wanted to put the ipmt pmaps in a different group, called `IPMT` in the hdf5 file... did we?

