### PR TITLE
Simplify counters

### DIFF
--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -75,7 +75,7 @@ from .. sierpe                  import blr
 from .. sierpe                  import fee as FE
 
 from .. types.ic_types          import minmax
-from .. types.ic_types          import Counter
+from .. types.ic_types          import Counters
 from .. types.ic_types          import NN
 from .. types.ic_types          import xy
 
@@ -111,8 +111,8 @@ class City:
         4. provides access to the data base.
         """
 
-        self.cnt = Counter()
-        self.cnt.init_counter('n_events_for_range')
+        self.cnt = Counters(n_events_for_range = 0)
+
         conf = Namespace(**kwds)
         self.conf = conf
 
@@ -177,7 +177,7 @@ class City:
         self.run()
         t1 = time()
         dt = t1 - t0
-        n_events = self.cnt.counter_value('n_events_tot')
+        n_events = self.cnt.n_events_tot
         print("run {} evts in {} s, time/event = {}".format(n_events,
                                                             dt,
                                                             dt / n_events))
@@ -276,8 +276,8 @@ class City:
                   .format(evt, n_events_tot))
 
     def event_range_step(self):
-        N = self.cnt.counter_value('n_events_for_range')
-        self.cnt.increment_counter('n_events_for_range')
+        N = self.cnt.n_events_for_range
+        self.cnt.n_events_for_range += 1
 
         if isinstance(self.last_event, int) and N >= self.last_event:
             # TODO: this side-effect should not be here
@@ -289,7 +289,7 @@ class City:
             return EventLoop.skip_this_event
 
     def event_range_finished(self):
-        N = self.cnt.counter_value('n_events_for_range')
+        N = self.cnt.n_events_for_range
         return isinstance(self.last_event, int) and N >= self.last_event
 
 
@@ -708,7 +708,7 @@ class KrCity(PCity):
                     c = clusters[0]
                 else:
                     cQ = [c.Q for c in clusters]
-                    self.cnt.increment_counter('n_events_more_than_1_cluster')
+                    self.cnt.n_events_more_than_1_cluster += 1
                     print('found case with more than one cluster')
                     print('clusters charge = {}'.format(cQ))
 

--- a/invisible_cities/cities/diomira.py
+++ b/invisible_cities/cities/diomira.py
@@ -57,8 +57,8 @@ class Diomira(MonteCarloCity):
         super().__init__(**kwds)
         conf = self.conf
 
-        self.cnt.set_name('diomira')
-        self.cnt.init_counters(('n_events_tot', 'nevt_out'))
+        self.cnt.init(n_events_tot = 0,
+                      nevt_out     = 0)
 
         self.sipm_noise_cut   = conf.sipm_noise_cut
 
@@ -84,14 +84,13 @@ class Diomira(MonteCarloCity):
         events_info = dataVectors.events
 
         for evt in range(NEVT):
-            self.conditional_print(self.cnt.counter_value('n_events_tot'),
-                                   self.cnt.counter_value('nevt_out'))
+            self.conditional_print(self.cnt.n_events_tot, self.cnt.nevt_out)
 
             # Count events in and break if necessary before filtering
             what_next = self.event_range_step()
             if what_next is EventLoop.skip_this_event: continue
             if what_next is EventLoop.terminate_loop : break
-            self.cnt.increment_counter('n_events_tot')
+            self.cnt.n_events_tot += 1
 
             # Simulate detector response
             dataPMT, blrPMT = self.simulate_pmt_response(evt, pmtrd,
@@ -110,7 +109,7 @@ class Diomira(MonteCarloCity):
                 if not self.trigger_filter(peak_data):
                     continue
 
-            self.cnt.increment_counter('nevt_out')
+            self.cnt.nevt_out += 1
 
             #write
             event_number, timestamp = self.event_and_timestamp(evt, events_info)

--- a/invisible_cities/cities/diomira_test.py
+++ b/invisible_cities/cities/diomira_test.py
@@ -98,7 +98,7 @@ def test_diomira_copy_mc_and_offset(config_tmpdir):
     diomira = Diomira(**conf)
     diomira.run()
     cnt     = diomira.end()
-    nactual = cnt.counter_value('n_events_tot')
+    nactual = cnt.n_events_tot
     if nrequired > 0:
         assert nrequired == nactual
 

--- a/invisible_cities/cities/dorothea.py
+++ b/invisible_cities/cities/dorothea.py
@@ -26,17 +26,18 @@ from .  base_cities            import EventLoop
 
 
 class Dorothea(KrCity):
+
     def __init__(self, **kwds):
         super().__init__(**kwds)
-        self.cnt.set_name('dorothea')
-        self.cnt.init_counters(('n_events_tot',
-                                'nevt_out',
-                                'n_events_not_s1',
-                                'n_events_not_s2',
-                                'n_events_not_s2si',
-                                'n_events_rejected_filter',
-                                'n_events_more_than_1_cluster'
-                                ))
+
+        self.cnt.init(n_events_tot                 = 0,
+                      nevt_out                     = 0,
+                      n_events_not_s1              = 0,
+                      n_events_not_s2              = 0,
+                      n_events_not_s2si            = 0,
+                      n_events_rejected_filter     = 0,
+                      n_events_more_than_1_cluster = 0)
+
 
         self.drift_v = self.conf.drift_v
         self._s1s2_selector = S12Selector(**kwds)
@@ -57,14 +58,13 @@ class Dorothea(KrCity):
         s2si_dict = pmapVectors.s2si
 
         for evt_number, evt_time in zip(event_numbers, timestamps):
-            self.conditional_print(self.cnt.counter_value('n_events_tot'),
-                                   self.cnt.counter_value('nevt_out'))
+            self.conditional_print(self.cnt.n_events_tot, self.cnt.nevt_out)
 
             # Count events in and break if necessary before filtering
             what_next = self.event_range_step()
             if what_next is EventLoop.skip_this_event: continue
             if what_next is EventLoop.terminate_loop : break
-            self.cnt.increment_counter('n_events_tot')
+            self.cnt.n_events_tot += 1
             # get pmaps
             s1, s2, s2si = self. get_pmaps_from_dicts(s1_dict,
                                                       s2_dict,
@@ -73,27 +73,26 @@ class Dorothea(KrCity):
             # filtering
             # loop event away if any signal (s1, s2 or s2si) not present
             if s1 == None:
-                self.cnt.increment_counter('n_events_not_s1')
+                self.cnt.n_events_not_s1 += 1
                 continue
             if s2 == None:
-                self.cnt.increment_counter('n_events_not_s2')
+                self.cnt.n_events_not_s2 += 1
                 continue
             if s2si == None:
-                self.cnt.increment_counter('n_events_not_s2si')
+                self.cnt.n_events_not_s2si += 1
                 continue
             # loop event away if filter fails
             if not s1s2_filter(self._s1s2_selector, s1, s2, s2si):
-                self.cnt.increment_counter('n_events_more_than_1_cluster')
+                self.cnt.n_events_more_than_1_cluster += 1
                 continue
             # event passed selection:
-            self.cnt.increment_counter('nevt_out') # increment counter
+            self.cnt.nevt_out += 1
             # create Kr event & write to file
             pmapVectors = PmapVectors(s1=s1, s2=s2, s2si=s2si,
                                       events=evt_number,
                                       timestamps=evt_time)
             evt = self.create_kr_event(pmapVectors)
             write_kr(evt)
-
 
     def get_writers(self, h5out):
         """Get the writers needed by dorothea"""

--- a/invisible_cities/cities/dorothea_test.py
+++ b/invisible_cities/cities/dorothea_test.py
@@ -51,8 +51,8 @@ def test_dorothea_KrMC(config_tmpdir, KrMC_pmaps):
 
     dorothea.run()
     cnt  = dorothea.end()
-    nevt_in = cnt.counter_value('n_events_tot')
-    nevt_out = cnt.counter_value('nevt_out')
+    nevt_in  = cnt.n_events_tot
+    nevt_out = cnt.nevt_out
     if nrequired > 0:
         assert nrequired    == nevt_in
         assert nevt_out     <= nevt_in

--- a/invisible_cities/cities/irene.py
+++ b/invisible_cities/cities/irene.py
@@ -38,12 +38,12 @@ class Irene(PmapCity):
 
         """
         super().__init__(**kwds)
-        self.cnt.set_name('irene')
-        self.cnt.init_counters(('n_events_tot',
-                                'n_empty_events',
-                                'n_empty_events_s2_ene_eq_0',
-                                'n_empty_events_s1_indx_empty',
-                                'n_empty_events_s2_indx_empty'))
+
+        self.cnt.init(n_events_tot                 = 0,
+                      n_empty_events               = 0,
+                      n_empty_events_s2_ene_eq_0   = 0,
+                      n_empty_events_s1_indx_empty = 0,
+                      n_empty_events_s2_indx_empty = 0)
 
         self.sp = self.get_sensor_params(self.input_files[0])
 
@@ -62,18 +62,18 @@ class Irene(PmapCity):
         events_info = dataVectors.events
 
         for evt in range(NEVT):
-            self.conditional_print(evt, self.cnt.counter_value('n_events_tot'))
+            self.conditional_print(evt, self.cnt.n_events_tot)
 
             what_next = self.event_range_step()
             if what_next is EventLoop.skip_this_event: continue
             if what_next is EventLoop.terminate_loop : break
-            self.cnt.increment_counter('n_events_tot')
+            self.cnt.n_events_tot += 1
 
             # calibrated sum in PMTs
             s12sum, cal_cwf, calsum = self.pmt_transformation(pmtrwf[evt])
 
             if not self.check_s12(s12sum): # ocasional but rare empty events
-                self.cnt.increment_counter('n_empty_events')
+                self.cnt.n_empty_events += 1
                 continue
 
             # calibrated sum in SiPMs
@@ -95,13 +95,13 @@ class Irene(PmapCity):
 
         """
         if  np.sum(s12sum.s2_ene) == 0:
-            self.cnt.increment_counter('n_empty_events_s2_ene_eq_0')
+            self.cnt.n_empty_events_s2_ene_eq_0 += 1
             return False
         elif np.sum(s12sum.s1_indx) == 0:
-            self.cnt.increment_counter('n_empty_events_s1_indx_empty')
+            self.cnt.n_empty_events_s1_indx_empty += 1
             return False
         elif np.sum(s12sum.s2_indx) == 0:
-            self.cnt.increment_counter('n_empty_events_s2_indx_empty')
+            self.cnt.n_empty_events_s2_indx_empty += 1
             return False
         else:
             return True

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -99,7 +99,7 @@ def test_irene_electrons_40keV(config_tmpdir, ICDIR, s12params):
     irene.run()
     cnt = irene.end()
 
-    nactual = cnt.counter_value('n_events_tot')
+    nactual = cnt.n_events_tot
     if nrequired > 0:
         assert nrequired == nactual
 
@@ -145,7 +145,7 @@ def test_irene_run_2983(config_tmpdir, ICDIR, s12params):
     irene.run()
     cnt = irene.end()
     if nrequired > 0:
-        assert nrequired == cnt.counter_value('n_events_tot')
+        assert nrequired == cnt.n_events_tot
 
 
 
@@ -216,9 +216,9 @@ def test_empty_events_issue_81(config_tmpdir, ICDIR, s12params):
     irene.run()
     cnt = irene.end()
 
-    assert cnt.counter_value('n_events_tot'              ) == 1
-    assert cnt.counter_value('n_empty_events_s2_ene_eq_0') == 1
-    assert cnt.counter_value('n_empty_events'            ) == 1
+    assert cnt.n_events_tot               == 1
+    assert cnt.n_empty_events_s2_ene_eq_0 == 1
+    assert cnt.n_empty_events             == 1
 
 
 def test_irene_electrons_40keV_pmt_active_is_correctly_set(job_info_missing_pmts, config_tmpdir, ICDIR, s12params):

--- a/invisible_cities/cities/isidora.py
+++ b/invisible_cities/cities/isidora.py
@@ -40,12 +40,11 @@ class Isidora(DeconvolutionCity):
         1. inits base city
         2. inits counters
         3. gets sensor parameters
-
         """
 
         super().__init__(**kwds)
-        self.cnt.set_name('isidora')
-        self.cnt.init_counter('n_events_tot')
+
+        self.cnt.init(n_events_tot = 0)
         self.sp = self.get_sensor_params(self.input_files[0])
 
     def event_loop(self, NEVT, dataVectors):
@@ -61,12 +60,12 @@ class Isidora(DeconvolutionCity):
         events_info = dataVectors.events
 
         for evt in range(NEVT):
-            self.conditional_print(evt, self.cnt.counter_value('n_events_tot'))
+            self.conditional_print(evt, self.cnt.n_events_tot)
 
             what_next = self.event_range_step()
             if what_next is EventLoop.skip_this_event: continue
             if what_next is EventLoop.terminate_loop : break
-            self.cnt.increment_counter('n_events_tot')
+            self.cnt.n_events_tot += 1
 
             CWF = self.deconv_pmt(pmtrwf[evt])  # deconvolution
 
@@ -76,7 +75,7 @@ class Isidora(DeconvolutionCity):
             write.pmt (CWF)
             write.sipm(sipmrwf[evt])
             if self.monte_carlo:
-                write.mc(mc_tracks, self.cnt.counter_value('n_events_tot'))
+                write.mc(mc_tracks, self.cnt.n_events_tot)
 
     def get_writers(self, h5out):
         """Get the writers needed by Isidora"""

--- a/invisible_cities/cities/isidora_test.py
+++ b/invisible_cities/cities/isidora_test.py
@@ -43,7 +43,7 @@ def test_isidora_electrons_40keV(config_tmpdir, ICDIR):
     isidora.run()
     cnt = isidora.end()
 
-    nactual = cnt.counter_value('n_events_tot')
+    nactual = cnt.n_events_tot
     if nrequired > 0:
         assert nrequired == nactual
 

--- a/invisible_cities/cities/penthesilea.py
+++ b/invisible_cities/cities/penthesilea.py
@@ -35,8 +35,9 @@ class Penthesilea(HitCity):
         """
         super().__init__(**kwds)
         conf = self.conf
-        self.cnt.set_name('penthesilea')
-        self.cnt.init_counters(('n_events_tot', 'nevt_out'))
+
+        self.cnt.init(n_events_tot = 0,
+                      nevt_out     = 0)
         self.drift_v        = conf.drift_v
         self._s1s2_selector = S12Selector(**kwds)
 
@@ -56,14 +57,13 @@ class Penthesilea(HitCity):
         s2si_dict = pmapVectors.s2si
 
         for evt_number, evt_time in zip(event_numbers, timestamps):
-            self.conditional_print(self.cnt.counter_value('n_events_tot'),
-                                   self.cnt.counter_value('nevt_out'))
+            self.conditional_print(self.cnt.n_events_tot, self.cnt.nevt_out)
 
             # Count events in and break if necessary before filtering
             what_next = self.event_range_step()
             if what_next is EventLoop.skip_this_event: continue
             if what_next is EventLoop.terminate_loop : break
-            self.cnt.increment_counter('n_events_tot')
+            self.cnt.n_events_tot += 1
 
             # get pmaps
             s1, s2, s2si = self. get_pmaps_from_dicts(s1_dict,
@@ -80,7 +80,7 @@ class Penthesilea(HitCity):
             if not f1 or not f2:
                 continue
             # event passed selection: increment counter and write
-            self.cnt.increment_counter('nevt_out')
+            self.cnt.nevt_out += 1
             pmapVectors = PmapVectors(s1=s1, s2=s2, s2si=s2si,
                                       events     = evt_number,
                                       timestamps = evt_time)

--- a/invisible_cities/cities/zaira.py
+++ b/invisible_cities/cities/zaira.py
@@ -30,7 +30,6 @@ class Zaira(DstCity):
 
         """
         super().__init__(**kwds)
-        self.cnt.set_name('zaira')
         self.set_lifetime_correction()
         self.set_xybins_and_range()
         self.set_z_and_e_fiducial()
@@ -90,7 +89,7 @@ class Zaira(DstCity):
             write_xy = xy_writer(h5out)
             write_xy(*xycorr._xs, xycorr._fs, xycorr._us, nevt)
 
-        self.cnt.set_counter('n_events_tot', value=len(dst))
+        self.cnt.n_events_tot = len(dst)
         return self.cnt
 
 

--- a/invisible_cities/cities/zaira_test.py
+++ b/invisible_cities/cities/zaira_test.py
@@ -27,4 +27,4 @@ def test_zaira_KrMC(config_tmpdir, ICDIR):
 
     zaira = Zaira(**conf)
     cnt = zaira.run()
-    assert cnt.counter_value('n_events_tot') > 0
+    assert cnt.n_events_tot > 0

--- a/invisible_cities/core/configure_test.py
+++ b/invisible_cities/core/configure_test.py
@@ -301,7 +301,7 @@ class DummyCity(City):
 
     def __init__(self, **kwds):
         super().__init__(**kwds)
-        self.cnt.init_counter('n_events_tot', value=10)
+        self.cnt.n_events_tot = 10
 
     def file_loop(self): pass
 
@@ -360,4 +360,4 @@ def test_config_drive_penthesilea_counters(simple_conf_file_name, tmpdir_factory
         'dummy-output-file-penthesilea-counters'+flags.replace(' ','-'))
     argv = 'penthesilea {conf} -i {infile} -o {outfile} {flags}'.format(**locals()).split()
     conf_ns, counters = Penthesilea.drive(argv)
-    assert counters.counter_value(counter) == value
+    assert getattr(counters, counter) == value

--- a/invisible_cities/types/ic_types.py
+++ b/invisible_cities/types/ic_types.py
@@ -1,61 +1,19 @@
+from argparse import Namespace
 
 import numpy as np
 
 NN= -999999  # No Number, a trick to aovid nans in data structs
-class Counter:
 
-    def __init__(self, counter_name=''):
-        self.cd = {}
-        self.cn = counter_name
+class Counters(Namespace):
 
-    def set_name(self, counter_name):
-        self.cn = counter_name
+    def set(self, **kwds):
+        for name, value in kwds.items():
+            setattr(self, name, value)
 
-    def init_counter(self, name, value=0):
-        self.cd.setdefault(name, value)
-
-    def init_counters(self, name_list, value=None):
-        if value==None:
-            for name in name_list:
-                self.cd.setdefault(name, 0)
-        else:
-            for value_no, name in enumerate(name_list):
-                self.cd.setdefault(name, value[value_no])
-
-    def increment_counter(self, name, value=1):
-        self.cd[name] += value
-
-    def increment_counters(self, name_list, value=None):
-        if value==None:
-            for name in name_list:
-                self.cd[name] += 1
-        else:
-            for value_no, name in enumerate(name_list):
-                self.cd[name] += value[value_no]
-
-    def set_counter(self, name, value=0):
-        self.cd[name] = value
-
-    def set_counters(self, name_list, value=None):
-        if value==None:
-            for name in name_list:
-                self.cd[name] =0
-        else:
-            for value_no, name in enumerate(name_list):
-                self.cd[name] = value[value_no]
-
-    def counter_value(self, name):
-        return self.cd[name]
-
-    def counters(self):
-        return tuple(self.cd.keys())
-
-    def __str__(self):
-        s = self.cn+':'
-        s2 = [' (counter = {}, value = {}), '.format(counter, value) for counter, value in self.cd.items()]
-        return  s + ''.join(s2)
-
-    __repr__ = __str__
+    def init(self, **kwds):
+        for name, value in kwds.items():
+            assert name not in self
+            setattr(self, name, value)
 
 
 class xy:

--- a/invisible_cities/types/ic_types_test.py
+++ b/invisible_cities/types/ic_types_test.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from . ic_types          import minmax
 from . ic_types          import xy
-from . ic_types          import Counter
+from . ic_types          import Counters
 from . ic_types_c        import xy as cxy
 from . ic_types_c        import minmax as cmm
 
@@ -141,82 +141,3 @@ def test_cxy(xyc, a, b):
     np.isclose (xyc.R  ,   r, rtol=1e-4)
     np.isclose (xyc.Phi, phi, rtol=1e-4)
     np.allclose(xyc.pos, pos, rtol=1e-3, atol=1e-03)
-
-def test_counters():
-    cnt = Counter('CityName')
-    # init by default to zero
-    cnt.init_counter('c1')
-    assert cnt.cd['c1'] == 0
-
-    # cannot init again
-    cnt.init_counter('c1', value=10)
-    assert cnt.cd['c1'] == 0
-
-    # but one can set
-    cnt.set_counter('c1', 10)
-    assert cnt.cd['c1'] == 10
-
-    # init to a value different than cero
-    cnt.init_counter('c2', value=1)
-    assert cnt.cd['c2'] == 1
-
-    # init a sequence of counters to zero
-    cnt_list = ('a1', 'a2', 'a3')
-    cnt.init_counters(cnt_list)
-    for a in cnt_list:
-        assert cnt.cd[a] == 0
-
-    # set them to diferent values
-    cnt_values = (10, 20, 30)
-    cnt.set_counters(cnt_list, value=cnt_values)
-    for i, a in enumerate(cnt_list):
-        assert cnt.cd[a] == cnt_values[i]
-
-    # init to diferent values
-    cnt_list2 = ('b1', 'b2', 'b3')
-    cnt.set_counters(cnt_list2, value=cnt_values)
-    for i, a in enumerate(cnt_list2):
-        assert cnt.cd[a] == cnt_values[i]
-
-    # cannot re-init
-    cnt_list3 = ('d1', 'd2', 'd3')
-    cnt.init_counters(cnt_list3)
-    for a in (cnt_list3):
-        assert cnt.cd[a] == 0
-
-    cnt.init_counters(cnt_list3, value=cnt_values)
-    for a in (cnt_list3):
-        assert cnt.cd[a] == 0
-
-    #increment counter (1 by default)
-    cnt.increment_counter('c1')
-    assert cnt.cd['c1'] == 11
-
-    #increment counter by some value
-    cnt.increment_counter('c1',value=9)
-    assert cnt.cd['c1'] == 20
-
-    cnt.set_counters(cnt_list)
-    #print(cnt)
-
-    #increment a list of counters
-    cnt.increment_counters(cnt_list)
-    #print(cnt)
-    for a in cnt_list:
-        assert cnt.cd[a] == 1
-
-    cnt.increment_counters(cnt_list, value=(10,10,10))
-    for a in cnt_list:
-        assert cnt.cd[a] == 11
-
-
-    cc = cnt.counters()
-
-    cc2 = ('c1','c2') + cnt_list + cnt_list2 + cnt_list3
-
-    for c in cc:
-        assert c in cc2
-
-    #counter value
-    assert cnt.counter_value('c1') == 20
-    assert cnt.counter_value('c2') == 1


### PR DESCRIPTION
This is an issue which should eventually be upgraded to a PR. As GitHub has removed the ability to turn issues into PRs, I am starting it as a PR, even before any code has been written.

Elsewhere, @jjgomezcadenas says

> As for the counter class, the idea was to have a generic counter and that was the best I could come up with. I am sure that the master can come with much prettier implementations, but old dog does not learn new tricks... (or it takes it a long wile).

As far as I can tell, it's just a namespace, which carries around a bunch of things which happen to be counters.

It has one useful feature: the ability to increment a whole bunch of counters in one go.

It has a lot of demerits, mostly to do with unnecessarily complicating things and introducing a new syntax for doing stuff that is simply done in standard Python. Which of the following 2 lines do you prefer?


    self.cnt.increment_counter('name')  # Counter
    self.cnt.name += 1                  # Normal way

How about implementing it as a subclass of `Namespace`, whith an added method for incrementing multiple counters. Though I'm not sure that it's worth it, over a plain namespace.
