### PR TITLE
Use event numbers from input files for MC

### DIFF
--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -365,12 +365,11 @@ class RawCity(City):
 
                     self.event_loop(NEVT, dataVectors)
                 elif self.raw_data_type == 'MCRD':
-                    first_event_no = self.event_number_from_input_file_name(filename)
                     NEVT, pmtrd, sipmrd     = self.get_rd_vectors(h5in)
                     dataVectors = DataVectors(pmt=pmtrd, sipm=sipmrd,
                                              mc=mc_tracks, events=events_info)
 
-                    self.event_loop(NEVT, first_event_no, dataVectors)
+                    self.event_loop(NEVT, dataVectors)
                 else:
                     raise UnknownRWF
 

--- a/invisible_cities/cities/diomira.py
+++ b/invisible_cities/cities/diomira.py
@@ -70,7 +70,7 @@ class Diomira(MonteCarloCity):
         self.trigger_filter   = TriggerFilter(self.trigger_params)
         self.trigger_type = conf.trigger_type
 
-    def event_loop(self, NEVT, first_event_no, dataVectors):
+    def event_loop(self, NEVT, dataVectors):
         """
         loop over events:
         1. simulate pmt and sipm response
@@ -113,12 +113,10 @@ class Diomira(MonteCarloCity):
 
             #write
             event_number, timestamp = self.event_and_timestamp(evt, events_info)
-            local_event_number = event_number + first_event_no
-
             if self.monte_carlo:
-                write.mc(mc_tracks, local_event_number)
+                write.mc(mc_tracks, event_number)
 
-            write.run_and_event(self.run_number, local_event_number, timestamp)
+            write.run_and_event(self.run_number, event_number, timestamp)
             write.rwf(RWF)
             write.cwf(BLR)
             write.sipm(dataSiPM)


### PR DESCRIPTION
We were computing a new event number in Diomira because in the
previous MC production, each file restarted the event counter to
zero. This is not the case anymore, each file has a unique event
number. Since this was a patch intended to use that old production, it
could be removed now.