### PR TITLE
Index pytables after populating them

### DIFF
--- a/invisible_cities/io/hits_io.py
+++ b/invisible_cities/io/hits_io.py
@@ -81,8 +81,8 @@ def hits_writer(hdf5_file, *, compression='ZLIB4'):
                              fformat     = HitsTable,
                              description = 'Hits',
                              compression = compression)
-
-    hits_table.cols.event.create_index()
+    # Mark column to index after populating table
+    hits_table.set_attr('columns_to_index', ['event'])
 
     def write_hits(hits_event):
         hits_event.store(hits_table)

--- a/invisible_cities/io/indexation_test.py
+++ b/invisible_cities/io/indexation_test.py
@@ -14,7 +14,7 @@ from .  pmap_io            import     pmap_writer
 
 
 
-@fixture
+@fixture(scope="session")
 def init_city(ICDIR, config_tmpdir):
         conf = configure(('city ' + ICDIR +  'config/city.conf').split())
         file_out = os.path.join(config_tmpdir, "empty_file.h5")

--- a/invisible_cities/io/indexation_test.py
+++ b/invisible_cities/io/indexation_test.py
@@ -32,7 +32,7 @@ def init_city(ICDIR, config_tmpdir):
                    (    pmap_writer, "PMAPS", "S1"      , "event"     ),
                    (    pmap_writer, "PMAPS", "S2"      , "event"     ),
                    (    pmap_writer, "PMAPS", "S2Si"    , "event"     )])
-def test_hits_table_is_indexed(init_city, writer, group, node, column):
+def test_table_is_indexed(init_city, writer, group, node, column):
     city, file_out = init_city
     city.get_writers = writer
     city.run()

--- a/invisible_cities/io/indexation_test.py
+++ b/invisible_cities/io/indexation_test.py
@@ -2,24 +2,40 @@ import os
 import tables as tb
 
 from pytest import mark
+from pytest import fixture
 
+from .. cities.base_cities import City
+from .. core.configure   import configure
 from . hits_io import     hits_writer
 from . kdst_io import       kr_writer
 from .   mc_io import mc_track_writer
 from . pmap_io import     pmap_writer
 
 
-@mark.parametrize("writer content group node column".split(),
-                  [(    hits_writer, "hits"   , "RECO" , "Events"  , "event"     ),
-                   (      kr_writer, "kr"     , "DST"  , "Events"  , "event"     ),
-                   (mc_track_writer, "mctrk"  , "MC"   , "MCTracks", "event_indx"),
-                   (    pmap_writer, "S1pmaps", "PMAPS", "S1"      , "event"     ),
-                   (    pmap_writer, "S2pmaps", "PMAPS", "S2"      , "event"     ),
-                   (    pmap_writer, "Sipmaps", "PMAPS", "S2Si"    , "event"     )])
-def test_hits_table_is_indexed(config_tmpdir, writer, content, group, node, column):
-    outputfilename = os.path.join(config_tmpdir, f"empty_{content}_file.h5")
 
-    with tb.open_file(outputfilename, 'w') as h5out:
-        writer(h5out)
+@fixture
+def init_city(ICDIR, config_tmpdir):
+        conf = configure(('city ' + ICDIR +  'config/city.conf').split())
+        file_out = os.path.join(config_tmpdir, f"empty_file.h5")
+        conf.update(dict(file_out = file_out))
+        city = City(**conf)
+        city.display_IO_info = lambda: None
+        city.file_loop       = lambda: None
+        return city, file_out
+
+
+@mark.parametrize("writer group node column".split(),
+                  [(    hits_writer, "RECO" , "Events"  , "event"     ),
+                   (      kr_writer, "DST"  , "Events"  , "event"     ),
+                   (mc_track_writer, "MC"   , "MCTracks", "event_indx"),
+                   (    pmap_writer, "PMAPS", "S1"      , "event"     ),
+                   (    pmap_writer, "PMAPS", "S2"      , "event"     ),
+                   (    pmap_writer, "PMAPS", "S2Si"    , "event"     )])
+def test_hits_table_is_indexed(init_city, writer, group, node, column):
+    city, file_out = init_city
+    city.get_writers = writer
+    city.run()
+    city.end() # or city.index_tables(), but this checks that city.end() calls city.index_tables()
+    with tb.open_file(file_out, 'r') as h5out:
         table = getattr(getattr(h5out.root, group), node)
         assert getattr(table.cols, column).is_indexed

--- a/invisible_cities/io/indexation_test.py
+++ b/invisible_cities/io/indexation_test.py
@@ -13,15 +13,20 @@ from .    mc_io            import mc_track_writer
 from .  pmap_io            import     pmap_writer
 
 
+class DummyCity(City):
+    def display_IO_info(self):
+        "Override so it is not executed"
+
+    def file_loop(self):
+        "Override so it is not executed"
+
 
 @fixture(scope="session")
 def init_city(ICDIR, config_tmpdir):
     conf = configure(('city ' + ICDIR +  'config/city.conf').split())
     file_out = os.path.join(config_tmpdir, "empty_file.h5")
     conf.update(dict(file_out = file_out))
-    city = City(**conf)
-    city.display_IO_info = lambda: None
-    city.file_loop       = lambda: None
+    city = DummyCity(**conf)
     return city, file_out
 
 

--- a/invisible_cities/io/indexation_test.py
+++ b/invisible_cities/io/indexation_test.py
@@ -16,13 +16,13 @@ from .  pmap_io            import     pmap_writer
 
 @fixture(scope="session")
 def init_city(ICDIR, config_tmpdir):
-        conf = configure(('city ' + ICDIR +  'config/city.conf').split())
-        file_out = os.path.join(config_tmpdir, "empty_file.h5")
-        conf.update(dict(file_out = file_out))
-        city = City(**conf)
-        city.display_IO_info = lambda: None
-        city.file_loop       = lambda: None
-        return city, file_out
+    conf = configure(('city ' + ICDIR +  'config/city.conf').split())
+    file_out = os.path.join(config_tmpdir, "empty_file.h5")
+    conf.update(dict(file_out = file_out))
+    city = City(**conf)
+    city.display_IO_info = lambda: None
+    city.file_loop       = lambda: None
+    return city, file_out
 
 
 @mark.parametrize("writer group node column".split(),

--- a/invisible_cities/io/indexation_test.py
+++ b/invisible_cities/io/indexation_test.py
@@ -5,18 +5,19 @@ from pytest import mark
 from pytest import fixture
 
 from .. cities.base_cities import City
-from .. core.configure   import configure
-from . hits_io import     hits_writer
-from . kdst_io import       kr_writer
-from .   mc_io import mc_track_writer
-from . pmap_io import     pmap_writer
+from .. core  .configure   import configure
+
+from .  hits_io            import     hits_writer
+from .  kdst_io            import       kr_writer
+from .    mc_io            import mc_track_writer
+from .  pmap_io            import     pmap_writer
 
 
 
 @fixture
 def init_city(ICDIR, config_tmpdir):
         conf = configure(('city ' + ICDIR +  'config/city.conf').split())
-        file_out = os.path.join(config_tmpdir, f"empty_file.h5")
+        file_out = os.path.join(config_tmpdir, "empty_file.h5")
         conf.update(dict(file_out = file_out))
         city = City(**conf)
         city.display_IO_info = lambda: None

--- a/invisible_cities/io/kdst_io.py
+++ b/invisible_cities/io/kdst_io.py
@@ -10,7 +10,8 @@ def kr_writer(hdf5_file, *, compression='ZLIB4'):
                           fformat     = KrTable,
                           description = 'KDST Events',
                           compression = compression)
-    kr_table.cols.event.create_index()
+    # Mark column to index after populating table
+    kr_table.set_attr('columns_to_index', ['event'])
 
     def write_kr(kr_event):
         kr_event.store(kr_table)
@@ -24,6 +25,8 @@ def xy_writer(hdf5_file, *, compression='ZLIB4'):
                           fformat     = XYfactors,
                           description = 'x,y corrections',
                           compression = compression)
+    # Mark column to index after populating table
+    xy_table.set_attr('columns_to_index', ['nevt'])
 
     def write_xy(xs, ys, fs, us, ns):
         row = xy_table.row

--- a/invisible_cities/io/kdst_io.py
+++ b/invisible_cities/io/kdst_io.py
@@ -25,8 +25,6 @@ def xy_writer(hdf5_file, *, compression='ZLIB4'):
                           fformat     = XYfactors,
                           description = 'x,y corrections',
                           compression = compression)
-    # Mark column to index after populating table
-    xy_table.set_attr('columns_to_index', ['nevt'])
 
     def write_xy(xs, ys, fs, us, ns):
         row = xy_table.row

--- a/invisible_cities/io/mc_io.py
+++ b/invisible_cities/io/mc_io.py
@@ -24,7 +24,8 @@ class mc_track_writer:
                         title       = "MCTracks",
                         filters     = tbl.filters(self.compression))
 
-        self.mc_table.cols.event_indx.create_index()
+        # Mark column to index after populating table
+        self.mc_table.set_attr('columns_to_index', ['event_indx'])
 
     def __call__(self, mctracks, evt_number):
         for r in mctracks.iterrows(start=self.last_row):

--- a/invisible_cities/io/pmap_io.py
+++ b/invisible_cities/io/pmap_io.py
@@ -128,7 +128,9 @@ def _make_pmp_tables(hdf5_file, compression):
     s2si       = MKT(pmaps_group, 'S2Si', table_formats.S2Si, "S2Si Table", c)
     pmp_tables = (s1, s2, s2si)
     for table in pmp_tables:
-        table.cols.event.create_index()
+        # Mark column to be indexed
+        table.set_attr('columns_to_index', ['event'])
+
 
     return pmp_tables
 
@@ -145,5 +147,6 @@ def _make_ipmt_pmp_tables(hdf5_file, compression):
     s2pmt = MKT(ipmt_pmaps_group, 'S2Pmt', table_formats.S12Pmt,   "S2Pmt Table", c)
     ipmt_tables = (s1pmt, s2pmt)
     for table in ipmt_tables:
-        table.cols.event.create_index()
+        # Mark column to be indexed
+        table.set_attr('columns_to_index', ['event'])
     return ipmt_tables


### PR DESCRIPTION
This PR addresses the `create_index` issue. The Pytables node manager is apparently buggy. Francesc Alted suggested we: 
1) Populate all our pytables and close the write file. 
2) reopen the file and create indices. 

This is a little strange since after we have closed the writefile we have to reopen the file and remember which columns in which tables to index. To do this: 

- I've modified the writers -- with the exception of `xy_writer` whose pytable @gonzaponte says does not need to be indexed -- so that the writers mark a column or columns in their various tables to be indexed, instead of actually indexing them.
- Then a new method `City.index_tables` walks through the nodes in the write file that are pytables tables,  and checks the tables for columns that need to be indexed and indexes them.

There is one question we need to answer:
Where do we call `City.index_tables` ? I think we should call it in `City.end()` **as long as all cities use the `City.end()` method**. The other option I can think of is to put it at the end of `City.run()`. For now it is implemented in `City.end`