### PR TITLE
Fix event number for MCTracks in irene

### DIFF
--- a/invisible_cities/cities/irene.py
+++ b/invisible_cities/cities/irene.py
@@ -87,7 +87,7 @@ class Irene(PmapCity):
             write.pmap         (event, *pmap)
             write.run_and_event(self.run_number, event, timestamp)
             if self.monte_carlo:
-                write.mc(mc_tracks, evt)
+                write.mc(mc_tracks, event)
 
     def check_s12(self, s12sum):
         """Checks for ocassional empty events, characterized by null s2_energy


### PR DESCRIPTION
Irene was passing its own event counter to mc_writer instead of using
the original event number. Due to this, the MC production is not
working as irene was not writing MCTracks. This commit fixes the problem.