### PR TITLE
Fix conda version to one known to work

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -47,15 +47,14 @@ function install_conda {
     else
         echo Installing conda for $CONDA_OS
         if which wget; then
-            wget https://repo.continuum.io/miniconda/Miniconda3-latest-${CONDA_OS}-x86_64.sh -O miniconda.sh
+            wget https://repo.continuum.io/miniconda/Miniconda3-4.3.21-${CONDA_OS}-x86_64.sh -O miniconda.sh
         else
-            curl https://repo.continuum.io/miniconda/Miniconda3-latest-${CONDA_OS}-x86_64.sh -o miniconda.sh
+            curl https://repo.continuum.io/miniconda/Miniconda3-4.3.21-${CONDA_OS}-x86_64.sh -o miniconda.sh
         fi
         bash miniconda.sh -b -p $HOME/miniconda
         export PATH="$HOME/miniconda/bin:$PATH"
         echo Prepended $HOME/miniconda/bin to your PATH. Please add it to your shell profile for future sessions.
         conda config --set always_yes yes --set changeps1 no
-        conda update conda
         echo Prepended $HOME/miniconda/bin to your PATH. Please add it to your shell profile for future sessions.
     fi
 }


### PR DESCRIPTION
Anaconda introduced a bug in version 4.3.27 and in general we should keep our software versions under control, this is a first step towards that. The previous version 4.3.21 works well.

In the future we will need to decide when to upgrade our dependencies, but we need control over them or errors like #343, will keep appearing both in Travis, Canfranc, users, etc.