### PR TITLE
Kr city init counter

### DIFF
--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -743,6 +743,7 @@ class KrCity(PCity):
 
     def __init__(self, **kwds):
         super().__init__(**kwds)
+        self.cnt.init(n_events_more_than_1_cluster = 0)
         #self.reco_algorithm = find_algorithm(self.conf.reco_algorithm)
 
 

--- a/invisible_cities/cities/dorothea_test.py
+++ b/invisible_cities/cities/dorothea_test.py
@@ -140,3 +140,17 @@ def test_dorothea_filter_events(config_tmpdir, Kr_pmaps_run4628):
 
     assert np.all(dst.event.values == events_pass)
     assert np.all(dst.peak.values  ==   peak_pass)
+
+def test_dorothea_issue_347(KrMC_pmaps, config_tmpdir):
+    PATH_IN =  KrMC_pmaps[0]
+    PATH_OUT = os.path.join(config_tmpdir, 'KrDST.h5')
+    conf = configure('dummy invisible_cities/config/dorothea_with_corona.conf'.split())
+    # with this parameters Corona will find several clusters
+    conf.update(dict(files_in   = PATH_IN,
+                     file_out   = PATH_OUT,
+                     lm_radius     = 0.1,
+                     new_lm_radius = 0.2,
+                     msipm         = 1))
+    dorothea = Dorothea(**conf)
+    dorothea.run()
+    dorothea.end()

--- a/invisible_cities/cities/dorothea_test.py
+++ b/invisible_cities/cities/dorothea_test.py
@@ -141,16 +141,17 @@ def test_dorothea_filter_events(config_tmpdir, Kr_pmaps_run4628):
     assert np.all(dst.event.values == events_pass)
     assert np.all(dst.peak.values  ==   peak_pass)
 
-def test_dorothea_issue_347(KrMC_pmaps, config_tmpdir):
-    PATH_IN =  KrMC_pmaps[0]
+def test_dorothea_issue_347(Kr_pmaps_run4628, config_tmpdir):
+    PATH_IN =  Kr_pmaps_run4628
     PATH_OUT = os.path.join(config_tmpdir, 'KrDST.h5')
     conf = configure('dummy invisible_cities/config/dorothea_with_corona.conf'.split())
     # with this parameters Corona will find several clusters
     conf.update(dict(files_in   = PATH_IN,
                      file_out   = PATH_OUT,
-                     lm_radius     = 0.1,
-                     new_lm_radius = 0.2,
+                     lm_radius     = 10.0,
+                     new_lm_radius = 13.0,
                      msipm         = 1))
     dorothea = Dorothea(**conf)
     dorothea.run()
-    dorothea.end()
+    cnts = dorothea.end()
+    assert cnts.n_events_more_than_1_cluster == 3

--- a/invisible_cities/config/dorothea_with_corona.conf
+++ b/invisible_cities/config/dorothea_with_corona.conf
@@ -1,0 +1,14 @@
+#!/usr/bin/python
+# dorothea_with_corona.conf
+
+# Dorothea computes a KDST after selecting PMAPS according to an S12 selector.
+
+include('$ICDIR/config/dorothea.conf')
+
+# use corona
+
+qthr           =    5 * pes
+qlm            =   40 * pes
+lm_radius      =   15 * mm
+new_lm_radius  =   25 * mm
+msipm          =    1


### PR DESCRIPTION
Solve issue 347:  Dorothea configured with corona crashed due to a non initialized counter that counts the number of events with multiple clusters. This pull request inits the counter in KrCity and adds a test. 
Closes #347 