### PR TITLE
Voxel size

### DIFF
--- a/invisible_cities/evm/event_model.py
+++ b/invisible_cities/evm/event_model.py
@@ -115,7 +115,8 @@ class BHit:
     def E   (self): return self.energy
 
     def __str__(self):
-        return '<{} {}>'.format(self.pos.tolist(), self.E)
+        return '{}({.X}, {.Y}, {.Z}, E={.E})'.format(
+            self.__class__.__name__, self, self, self, self)
 
     __repr__ =     __str__
 

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -46,6 +46,12 @@ def voxelize_hits(hits             : Sequence[BHit],
     voxel_edges_lo = bounding_box_centre - number_of_voxels * voxel_dimensions / 2
     voxel_edges_hi = bounding_box_centre + number_of_voxels * voxel_dimensions / 2
 
+    # Expand the voxels a tiny bit, in order to include hits which
+    # fall within the margin of error of the voxel bounding box.
+    eps = 3e-12 # geometric mean of range that seems to work
+    voxel_edges_lo -= eps
+    voxel_edges_hi += eps
+
     hit_positions = np.array([h.pos for h in hits])
     hit_energies  =          [h.E   for h in hits]
     E, edges = np.histogramdd(hit_positions,

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -39,12 +39,19 @@ def voxelize_hits(hits             : Sequence[BHit],
     if not hits:
         raise NoHits
     hlo, hhi = bounding_box(hits)
-    hranges = hhi - hlo
-    bins = np.ceil(hranges / voxel_dimensions).astype(int)
-    nonzero_bins = np.clip(bins, a_min=1, a_max=None)
+    bounding_box_centre = (hhi + hlo) / 2
+    bounding_box_size   =  hhi - hlo
+    number_of_voxels = np.ceil(bounding_box_size / voxel_dimensions).astype(int)
+    number_of_voxels = np.clip(number_of_voxels, a_min=1, a_max=None)
+    voxel_edges_lo = bounding_box_centre - number_of_voxels * voxel_dimensions / 2
+    voxel_edges_hi = bounding_box_centre + number_of_voxels * voxel_dimensions / 2
+
     hit_positions = np.array([h.pos for h in hits])
     hit_energies  =          [h.E   for h in hits]
-    E, edges = np.histogramdd(hit_positions, bins=nonzero_bins, weights=hit_energies)
+    E, edges = np.histogramdd(hit_positions,
+                              bins    = number_of_voxels,
+                              range   = tuple(zip(voxel_edges_lo, voxel_edges_hi)),
+                              weights = hit_energies)
 
     def centres(a : np.ndarray) -> np.ndarray:
         return (a[1:] + a[:-1]) / 2

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -39,7 +39,7 @@ def big_enough(hits):
 
 posn = floats(min_value=10, max_value=100)
 ener = posn
-bunch_of_hits = lists(builds(Voxel, posn, posn, posn, ener),
+bunch_of_hits = lists(builds(BHit, posn, posn, posn, ener),
                       min_size =  1,
                       max_size = 30).filter(big_enough)
 

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -129,9 +129,6 @@ def test_voxelize_hits_respects_voxel_dimensions(hits, requested_voxel_dimension
                 np.isclose(off_by, unit)).all()
 
 
-
-
-
 @given(bunch_of_hits, box_sizes)
 def test_make_voxel_graph_keeps_all_voxels(hits, voxel_dimensions):
     voxels = voxelize_hits    (hits  , voxel_dimensions)

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -9,6 +9,7 @@ from numpy.testing import assert_almost_equal
 
 from pytest import fixture
 from pytest import mark
+from pytest import approx
 from pytest import raises
 parametrize = mark.parametrize
 
@@ -92,7 +93,7 @@ def test_voxelize_hits_does_not_lose_energy(hits, voxel_dimensions):
     def sum_energy(seq):
         return sum(e.E for e in seq)
 
-    assert_almost_equal(sum_energy(voxels), sum_energy(hits))
+    assert sum_energy(voxels) == approx(sum_energy(hits))
 
 
 random_graph = builds(partial(fast_gnp_random_graph, p=0.5),

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -55,6 +55,7 @@ def test_voxelize_hits_should_detect_no_hits():
     with raises(NoHits):
         voxelize_hits([], None)
 
+
 @given(bunch_of_hits)
 def test_bounding_box(hits):
     if not len(hits): # TODO: deal with empty sequences
@@ -100,6 +101,7 @@ random_graph = builds(partial(fast_gnp_random_graph, p=0.5),
 def test_voxels_from_track_return_node_voxels(graph):
     assert voxels_from_track_graph(graph) == graph.nodes()
 
+
 @given(bunch_of_hits, box_sizes)
 def test_voxelize_hits_keeps_bounding_box(hits, voxel_dimensions):
     voxels = voxelize_hits(hits, voxel_dimensions)
@@ -143,15 +145,18 @@ def test_find_extrema(spec, extrema):
     assert a in found
     assert b in found
 
+
 @given(builds(Voxel, posn, posn, posn, ener))
 def test_find_extrema_single_voxel(voxel):
     g = nx.Graph()
     g.add_node(voxel)
     assert find_extrema(shortest_paths(g)) == (voxel, voxel)
 
+
 def test_find_extrema_no_voxels():
     with raises(NoVoxels):
         find_extrema({})
+
 
 @fixture(scope='module')
 def track_extrema():
@@ -204,6 +209,7 @@ def test_blobs(track_extrema, radius, expected):
     Ea, Eb = expected
 
     assert blob_energies(track, radius) == (Ea, Eb)
+
 
 def test_voxelize_single_hit():
     hits = [BHit(1, 1, 1, 100)]

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -92,7 +92,7 @@ def test_voxelize_hits_does_not_lose_energy(hits, voxel_dimensions):
     def sum_energy(seq):
         return sum(e.E for e in seq)
 
-    assert_almost_equal(sum_energy(hits), sum_energy(voxels))
+    assert_almost_equal(sum_energy(voxels), sum_energy(hits))
 
 
 random_graph = builds(partial(fast_gnp_random_graph, p=0.5),

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -3,6 +3,8 @@ from functools import partial
 import numpy    as np
 import networkx as nx
 
+from itertools import combinations
+
 from numpy.testing import assert_almost_equal
 
 from pytest import fixture
@@ -114,6 +116,21 @@ def test_voxelize_hits_keeps_bounding_box(hits, voxel_dimensions):
 
     assert (vlo <= hlo).all()
     assert (vhi >= hhi).all()
+
+
+@given(bunch_of_hits, box_sizes)
+def test_voxelize_hits_respects_voxel_dimensions(hits, requested_voxel_dimensions):
+    voxels = voxelize_hits(hits, requested_voxel_dimensions)
+    unit   =                     requested_voxel_dimensions
+    for v1, v2 in combinations(voxels, 2):
+        distance_between_voxels = np.array(v2.XYZ) - np.array(v1.XYZ)
+        off_by = distance_between_voxels % requested_voxel_dimensions
+        assert (np.isclose(off_by, 0   ) |
+                np.isclose(off_by, unit)).all()
+
+
+
+
 
 @given(bunch_of_hits, box_sizes)
 def test_make_voxel_graph_keeps_all_voxels(hits, voxel_dimensions):


### PR DESCRIPTION
+ `voxelize_hits` was not respecting the requested `voxel_dimensions`.

+ There was no test of this behaviour.

This PR

+ adds a test demonstrating the problem
+ fixes `voxelize_hits` so that it passes the test
+ improves `__str__` in BHit and subclasses

This last point makes it much easer to understand and debug issues such as the main one in this PR.