### PR TITLE
Percentual sipm threshold

### DIFF
--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -516,7 +516,7 @@ class CalibratedCity(DeconvolutionCity):
         elif conf.thr_sipm_type.lower() == "individual":
             # In this case, the threshold is a percentual value
             noise_sampler = SiPMsNoiseSampler(self.run_number)
-            self.thr_sipm = noise_sampler.ComputeThresholds(conf.thr_sipm)
+            self.thr_sipm = noise_sampler.compute_thresholds(conf.thr_sipm)
         else:
             raise ValueError(("Wrong value in thr_sipm_type. It must"
                               "be either 'Common' or 'Individual'"))

--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -488,6 +488,12 @@ class CalibratedCity(DeconvolutionCity):
           a) equalize to pes;
           b) compute a MAU that follows baseline and keep samples above
              MAU + threshold.
+             The threshold can be used in two ways:
+             - A single value for all sipms (thr_sipm_type = "common"). In this
+               case, thr_sipm is the threshold value in pes.
+             - A value for each SiPM, based on a common the percentage
+               of noise reduction (thr_sipm_type = "individual"). In this case,
+               thr_sipm is the percentage.
        """
 
     parameters = tuple("""n_mau thr_mau thr_csum_s1 thr_csum_s2 n_mau_sipm thr_sipm thr_sipm_type""".split())

--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -490,7 +490,7 @@ class CalibratedCity(DeconvolutionCity):
              MAU + threshold.
        """
 
-    parameters = tuple("""n_mau thr_mau thr_csum_s1 thr_csum_s2 n_mau_sipm thr_sipm""".split())
+    parameters = tuple("""n_mau thr_mau thr_csum_s1 thr_csum_s2 n_mau_sipm thr_sipm thr_sipm_type""".split())
 
     def __init__(self, **kwds):
 
@@ -503,9 +503,17 @@ class CalibratedCity(DeconvolutionCity):
         self.thr_csum_s2 = conf.thr_csum_s2
 
         # Parameters of the SiPM signal
-        self.n_MAU_sipm = conf.n_mau_sipm
-        self.  thr_sipm = conf.  thr_sipm
-
+        self.n_MAU_sipm  = conf.n_mau_sipm
+        if   conf.thr_sipm_type.lower() == "common":
+            # In this case, the threshold is a value of threshold in pes
+            self.thr_sipm = conf.thr_sipm
+        elif conf.thr_sipm_type.lower() == "individual":
+            # In this case, the threshold is a percentual value
+            noise_sampler = SiPMsNoiseSampler(self.run_number)
+            self.thr_sipm = noise_sampler.ComputeThresholds(conf.thr_sipm)
+        else:
+            raise ValueError(("Wrong value in thr_sipm_type. It must"
+                              "be either 'Common' or 'Individual'"))
 
     def calibrated_pmt_mau(self, CWF):
         """Return the csum and csum_mau calibrated sums."""

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -75,7 +75,10 @@ def job_info_missing_pmts(config_tmpdir, ICDIR):
 
 
 @mark.slow
-def test_irene_electrons_40keV(config_tmpdir, ICDIR, s12params):
+@mark.parametrize("thr_sipm_type thr_sipm_value".split(),
+                  (("common"    , 3.5 ),
+                   ("individual", 0.99)))
+def test_irene_electrons_40keV(config_tmpdir, ICDIR, s12params, thr_sipm_type, thr_sipm_value):
     # NB: avoid taking defaults for PATH_IN and PATH_OUT
     # since they are in general test-specific
     # NB: avoid taking defaults for run number (test-specific)
@@ -86,10 +89,12 @@ def test_irene_electrons_40keV(config_tmpdir, ICDIR, s12params):
     nrequired  = 2
 
     conf = configure('dummy invisible_cities/config/irene.conf'.split())
-    conf.update(dict(run_number   = 0,
-                     files_in     = PATH_IN,
-                     file_out     = PATH_OUT,
-                     event_range  = (0, nrequired),
+    conf.update(dict(run_number    = 0,
+                     files_in      = PATH_IN,
+                     file_out      = PATH_OUT,
+                     event_range   = (0, nrequired),
+                     thr_sipm_type = thr_sipm_type,
+                     thr_sipm      = thr_sipm_value,
                      **unpack_s12params(s12params)))
 
     irene = Irene(**conf)

--- a/invisible_cities/config/calibrated_city.conf
+++ b/invisible_cities/config/calibrated_city.conf
@@ -16,5 +16,6 @@ thr_csum_s1 = 0.5 * pes
 thr_csum_s2 = 1.0 * pes
 
 # Set MAU thresholds for SiPM
-n_mau_sipm = 100
-thr_sipm   =   3.5 * pes
+n_mau_sipm    = 100
+thr_sipm      = 3.5 * pes
+thr_sipm_type = "common"

--- a/invisible_cities/core/random_sampling.py
+++ b/invisible_cities/core/random_sampling.py
@@ -86,4 +86,5 @@ class NoiseSampler:
             pes_to_adc = np.ones(self.probs.shape[0])
 
         cumprobs = np.apply_along_axis(np.cumsum, 1, self.probs)
-        return np.apply_along_axis(findcut, 1, cumprobs) * pes_to_adc
+        cuts_pes = np.apply_along_axis(findcut  , 1,   cumprobs)
+        return cuts_pes * pes_to_adc

--- a/invisible_cities/core/random_sampling.py
+++ b/invisible_cities/core/random_sampling.py
@@ -5,6 +5,33 @@ import numpy as np
 from .. database import load_db as DB
 
 
+def normalize_distribution(y):
+    ysum = np.sum(y)
+    return y / ysum if ysum else y
+
+
+def sample_discrete_distribution(x, y, size=1):
+    if not y.any():
+        return np.zeros(size)
+    return np.random.choice(x, p=y, size=size)
+
+
+def uniform_smearing(max_deviation, size=1):
+    return np.random.uniform(-max_deviation,
+                             +max_deviation,
+                             size = size)
+
+
+def inverse_cdf_index(y, percentile):
+    return np.argwhere(y >= percentile)[0,0]
+
+
+def inverse_cdf(x, y, percentile):
+    if not y.any():
+        return np.inf
+    return x[inverse_cdf_index(y, percentile)]
+
+
 class NoiseSampler:
     def __init__(self, run_number, sample_size=1, smear=True):
         """Sample a histogram as if it was a PDF.

--- a/invisible_cities/core/random_sampling.py
+++ b/invisible_cities/core/random_sampling.py
@@ -68,7 +68,7 @@ class NoiseSampler:
         noise_cut : float
             Fraction of the distribution to be left behind. Default is 0.99.
         pes_to_adc : float or array of floats, optional
-            Constant(s) for adc to pes conversion (default None).
+            Constant(s) for pes to adc conversion (default None).
             If not present, the thresholds are given in pes.
 
         Returns

--- a/invisible_cities/core/random_sampling.py
+++ b/invisible_cities/core/random_sampling.py
@@ -80,7 +80,7 @@ class NoiseSampler:
         def findcut(probs):
             if not probs.any():
                 return np.inf
-            return self.xbins[probs > noise_cut][0]
+            return self.xbins[probs >= noise_cut][0]
 
         if pes_to_adc is None:
             pes_to_adc = np.ones(self.probs.shape[0])

--- a/invisible_cities/core/random_sampling.py
+++ b/invisible_cities/core/random_sampling.py
@@ -84,7 +84,6 @@ class NoiseSampler:
 
         if pes_to_adc is None:
             pes_to_adc = np.ones(self.probs.shape[0])
-        pes_to_adc.reshape(self.probs.shape[0], 1)
 
         cumprobs = np.apply_along_axis(np.cumsum, 1, self.probs)
         return np.apply_along_axis(findcut, 1, cumprobs) * pes_to_adc

--- a/invisible_cities/core/random_sampling.py
+++ b/invisible_cities/core/random_sampling.py
@@ -62,9 +62,9 @@ class NoiseSampler:
         self.nsamples = sample_size
         self.probs, self.xbins, self.baselines = DB.SiPMNoise()
 
-        active         = DB.DataSiPM(run_number).Active.values[:, np.newaxis]
+        self.active    = DB.DataSiPM(run_number).Active.values[:, np.newaxis]
         # probs * active means that masked sensors are set to 0
-        self.probs     = np.apply_along_axis(norm, 1, self.probs * active)
+        self.probs     = np.apply_along_axis(norm, 1, self.probs * self.active)
         self.baselines = self.baselines.reshape(self.baselines.shape[0], 1)
         self.dx        = np.diff(self.xbins)[0] * 0.5
 
@@ -84,7 +84,7 @@ class NoiseSampler:
 
     def Sample(self):
         """Return a sample of each distribution."""
-        return self._sampler() + self.baselines
+        return (self._sampler() + self.baselines) * self.active
 
     def ComputeThresholds(self, noise_cut=0.99, pes_to_adc=None):
         """Find the number of pes at which each noise distribution leaves

--- a/invisible_cities/core/random_sampling_test.py
+++ b/invisible_cities/core/random_sampling_test.py
@@ -93,17 +93,17 @@ def test_uniform_smearing_range(max_deviation, nsamples):
                 max_value = 1e+2),
        integers(min_value = 200,
                 max_value = 1000))
-@flaky(max_runs=5, min_passes=2)
+@flaky(max_runs=10, min_passes=1)
 def test_uniform_smearing_stats(max_deviation, nsamples):
     expected_mean  = 0
     expected_std   = max_deviation / 3**0.5
-    tolerance_mean = 3    * expected_std / nsamples**0.5 # mean within 3 rms
-    tolerance_std  = 0.50                                # std  within 50%
+    tolerance_mean = 5 * expected_std / nsamples**0.5 # mean within 5 sigma
+    tolerance_std  = 0.20                             # std  within 20%
     samples        = uniform_smearing(max_deviation, nsamples)
     sample_mean    = np.mean(samples)
     sample_std     = np.std (samples)
-    assert np.isclose(sample_mean, expected_mean, atol=tolerance_mean)
-    assert np.isclose(sample_std , expected_std , rtol=tolerance_std )
+    assert np.isclose(sample_mean, expected_mean,    atol=tolerance_mean)
+    assert np.isclose(sample_std / expected_std , 1, rtol=tolerance_std )
 
 
 @mark.parametrize("frequencies percentile true_index".split(),

--- a/invisible_cities/core/random_sampling_test.py
+++ b/invisible_cities/core/random_sampling_test.py
@@ -11,6 +11,7 @@ from hypothesis.strategies import floats
 
 from . testing_utils    import float_arrays
 from . core_functions   import in_range
+from ..database.load_db import DataSiPM
 
 from . random_sampling  import normalize_distribution
 from . random_sampling  import sample_discrete_distribution
@@ -18,7 +19,6 @@ from . random_sampling  import uniform_smearing
 from . random_sampling  import inverse_cdf_index
 from . random_sampling  import inverse_cdf
 from . random_sampling  import NoiseSampler
-from ..database.load_db import DataSiPM
 
 sensible_sizes    =                  integers(min_value =    2,
                                               max_value =   20)
@@ -161,15 +161,15 @@ def noise_sampler_run0(request):
 
 
 def test_noise_sampler_output_shape(datasipm_run0, noise_sampler_run0):
-    nsipm                        = len(datasipm_run0)
-    noise_sampler, nsamples, _   = noise_sampler_run0
-    sample                       = noise_sampler.Sample()
+    nsipm                      = len(datasipm_run0)
+    noise_sampler, nsamples, _ = noise_sampler_run0
+    sample                     = noise_sampler.sample()
     assert sample.shape == (nsipm, nsamples)
 
 
 def test_noise_sampler_masked_sensors(datasipm_run0, noise_sampler_run0):
     noise_sampler, *_ = noise_sampler_run0
-    sample            = noise_sampler.Sample()
+    sample            = noise_sampler.sample()
 
     masked_sensors = datasipm_run0[datasipm_run0.Active==0].index.values
     assert not np.any(sample[masked_sensors])

--- a/invisible_cities/core/random_sampling_test.py
+++ b/invisible_cities/core/random_sampling_test.py
@@ -153,10 +153,10 @@ def datasipm_run0():
     return DataSiPM(0)
 
 
-@fixture(scope="module")
-def noise_sampler_run0():
+@fixture(scope="module", params=[False, True])
+def noise_sampler_run0(request):
     nsamples = 1000
-    smear    = False
+    smear    = request.param
     return NoiseSampler(0, nsamples, smear), nsamples, smear
 
 

--- a/invisible_cities/core/random_sampling_test.py
+++ b/invisible_cities/core/random_sampling_test.py
@@ -177,3 +177,14 @@ def test_noise_sampler_masked_sensors(datasipm, noise_sampler):
 
     masked_sensors = datasipm[datasipm.Active==0].index.values
     assert not np.any(sample[masked_sensors])
+
+
+def test_noise_sampler_attributes(datasipm, noise_sampler):
+    true_av_noise     = 0.00333333333333333
+    noise_sampler, *_ = noise_sampler
+
+    av_noise = noise_sampler.probs.mean(axis=1)
+    active   = datasipm.Active.values
+    masked   = active == 0; masked
+    assert np.allclose(av_noise[active == 0],             0, rtol = 1e-8)
+    assert np.allclose(av_noise[active == 1], true_av_noise, rtol = 1e-8)

--- a/invisible_cities/core/random_sampling_test.py
+++ b/invisible_cities/core/random_sampling_test.py
@@ -188,3 +188,20 @@ def test_noise_sampler_attributes(datasipm, noise_sampler):
     masked   = active == 0; masked
     assert np.allclose(av_noise[active == 0],             0, rtol = 1e-8)
     assert np.allclose(av_noise[active == 1], true_av_noise, rtol = 1e-8)
+
+
+def test_noise_sampler_take_sample(datasipm, noise_sampler):
+    noise_sampler, _, smear = noise_sampler
+    samples = noise_sampler.sample()
+    for i, active in enumerate(datasipm.Active):
+        sample = samples[i]
+        if active:
+            if smear:
+                # Find closest energy bin and ensure it is close enough.
+                diffs      = noise_sampler.xbins - sample[:, np.newaxis]
+                closest    = np.min(np.abs(diffs), axis=1)
+                assert np.all(closest <= noise_sampler.dx)
+            else:
+                assert np.all(np.in1d(sample, noise_sampler.xbins))
+        else:
+            assert not np.any(sample)

--- a/invisible_cities/core/random_sampling_test.py
+++ b/invisible_cities/core/random_sampling_test.py
@@ -147,6 +147,17 @@ def test_inverse_cdf_hypothesis_generated(distribution, percentile):
     assert true_value == icdf
 
 
+def test_noise_sampler_output_shape():
+    run_number = 0
+    nsipm      = len(DataSiPM(run_number))
+    nsamples   = 1000
+
+    sampler = NoiseSampler(run_number, nsamples, False)
+    sample  = sampler.Sample()
+
+    assert sample.shape == (nsipm, nsamples)
+
+
 def test_noise_sampler_masked_sensors():
     run_number = 0
 

--- a/invisible_cities/core/random_sampling_test.py
+++ b/invisible_cities/core/random_sampling_test.py
@@ -207,7 +207,11 @@ def test_noise_sampler_take_sample(datasipm, noise_sampler):
             assert not np.any(sample)
 
 
-def test_noise_sampler_compute_thresholds(datasipm, noise_sampler):
+@mark.parametrize("pes_to_adc",
+                  (1, 2.5, 10, 25.4))
+@mark.parametrize("as_array",
+                  (False, True))
+def test_noise_sampler_compute_thresholds(datasipm, noise_sampler, pes_to_adc, as_array):
     noise_sampler, *_ = noise_sampler
     true_threshold_counts = {
     0.85  :  19,
@@ -220,8 +224,11 @@ def test_noise_sampler_compute_thresholds(datasipm, noise_sampler):
     1.55  :   3,
     2.05  :   1,
     np.inf:   8}
+    true_threshold_counts = {pes_to_adc*k: v for k,v in true_threshold_counts.items()}
+    if as_array:
+        pes_to_adc *= np.ones(len(datasipm))
 
-    thresholds       = noise_sampler.compute_thresholds(0.99)
+    thresholds       = noise_sampler.compute_thresholds(0.99, pes_to_adc)
     threshold_counts = np.unique(thresholds, return_counts = True)
     threshold_counts = dict(zip(*threshold_counts))
     assert sorted(true_threshold_counts) == sorted(threshold_counts)

--- a/invisible_cities/core/random_sampling_test.py
+++ b/invisible_cities/core/random_sampling_test.py
@@ -149,27 +149,31 @@ def test_inverse_cdf_hypothesis_generated(distribution, percentile):
 
 
 @fixture(scope="module")
-def datasipm_run0():
-    return DataSiPM(0)
+def run_number():
+    return 0
+
+@fixture(scope="module")
+def datasipm(run_number):
+    return DataSiPM(run_number)
 
 
 @fixture(scope="module", params=[False, True])
-def noise_sampler_run0(request):
+def noise_sampler(request, run_number):
     nsamples = 1000
     smear    = request.param
-    return NoiseSampler(0, nsamples, smear), nsamples, smear
+    return NoiseSampler(run_number, nsamples, smear), nsamples, smear
 
 
-def test_noise_sampler_output_shape(datasipm_run0, noise_sampler_run0):
-    nsipm                      = len(datasipm_run0)
-    noise_sampler, nsamples, _ = noise_sampler_run0
+def test_noise_sampler_output_shape(datasipm, noise_sampler):
+    nsipm                      = len(datasipm)
+    noise_sampler, nsamples, _ = noise_sampler
     sample                     = noise_sampler.sample()
     assert sample.shape == (nsipm, nsamples)
 
 
-def test_noise_sampler_masked_sensors(datasipm_run0, noise_sampler_run0):
-    noise_sampler, *_ = noise_sampler_run0
+def test_noise_sampler_masked_sensors(datasipm, noise_sampler):
+    noise_sampler, *_ = noise_sampler
     sample            = noise_sampler.sample()
 
-    masked_sensors = datasipm_run0[datasipm_run0.Active==0].index.values
+    masked_sensors = datasipm[datasipm.Active==0].index.values
     assert not np.any(sample[masked_sensors])

--- a/invisible_cities/core/random_sampling_test.py
+++ b/invisible_cities/core/random_sampling_test.py
@@ -1,7 +1,151 @@
 import numpy as np
 
+from flaky  import flaky
+from pytest import mark
+
+from hypothesis            import given
+from hypothesis.strategies import composite
+from hypothesis.strategies import integers
+from hypothesis.strategies import floats
+
+from . testing_utils    import float_arrays
+from . core_functions   import in_range
+
+from . random_sampling  import normalize_distribution
+from . random_sampling  import sample_discrete_distribution
+from . random_sampling  import uniform_smearing
+from . random_sampling  import inverse_cdf_index
+from . random_sampling  import inverse_cdf
 from . random_sampling  import NoiseSampler
 from ..database.load_db import DataSiPM
+
+sensible_sizes    =                  integers(min_value =    2,
+                                              max_value =   20)
+valid_domains     = lambda size: float_arrays(min_value = -100,
+                                              max_value = +100,
+                                              size      = size).map(sorted)
+valid_frequencies = lambda size: float_arrays(min_value =    0,
+                                              max_value =  1e4,
+                                              size      = size).filter(lambda x: np.sum(x) != 0)
+zero_frequencies  = lambda size: float_arrays(min_value =    0,
+                                              max_value =    0,
+                                              size      = size)
+
+@composite
+def valid_distributions(draw):
+    size        = draw(sensible_sizes)
+    domain      = draw(valid_domains    (size))
+    frequencies = draw(valid_frequencies(size))
+    return domain, frequencies
+
+
+@composite
+def invalid_distributions(draw):
+    size        = draw(sensible_sizes)
+    domain      = draw(valid_domains   (size))
+    frequencies = draw(zero_frequencies(size))
+    return domain, frequencies
+
+
+cdf_from_freq = lambda x: np.cumsum(x/np.sum(x))
+
+@given(valid_distributions())
+def test_normalize_distribution_integral_is_one(distribution):
+    _, f         = distribution
+    f_normalized = normalize_distribution(f)
+    assert np.isclose(f_normalized.sum(), 1)
+
+
+@given(invalid_distributions())
+def test_normalize_distribution_invalid_input(distribution):
+    _, f         = distribution
+    f_normalized = normalize_distribution(f)
+    assert np.array_equal(f_normalized, f)
+
+
+@given(valid_distributions(),
+       integers(min_value = 1, max_value = 10))
+def test_sample_discrete_distribution_valid_input(distribution, nsamples):
+    domain, frequencies = distribution
+    frequencies = normalize_distribution(frequencies)
+    samples = sample_discrete_distribution(domain, frequencies, nsamples)
+    assert np.all(np.in1d(samples, domain))
+
+
+@given(invalid_distributions(),
+       integers(min_value = 1, max_value = 10))
+def test_sample_discrete_distribution_invalid_input(distribution, nsamples):
+    domain, frequencies = distribution
+    samples = sample_discrete_distribution(domain, frequencies, nsamples)
+    assert not np.any(samples)
+
+
+@given(floats(min_value = 1e-2,
+              max_value = 1e+2),
+       sensible_sizes)
+def test_uniform_smearing_range(max_deviation, nsamples):
+    samples = uniform_smearing(max_deviation, nsamples)
+    assert np.all(in_range(samples, -max_deviation, max_deviation))
+
+
+@given(floats  (min_value = 1e-2,
+                max_value = 1e+2),
+       integers(min_value = 200,
+                max_value = 1000))
+@flaky(max_runs=5, min_passes=2)
+def test_uniform_smearing_stats(max_deviation, nsamples):
+    expected_mean  = 0
+    expected_std   = max_deviation / 3**0.5
+    tolerance_mean = 3    * expected_std / nsamples**0.5 # mean within 3 rms
+    tolerance_std  = 0.50                                # std  within 50%
+    samples        = uniform_smearing(max_deviation, nsamples)
+    sample_mean    = np.mean(samples)
+    sample_std     = np.std (samples)
+    assert np.isclose(sample_mean, expected_mean, atol=tolerance_mean)
+    assert np.isclose(sample_std , expected_std , rtol=tolerance_std )
+
+
+@mark.parametrize("frequencies percentile true_index".split(),
+                  ((np.linspace(0, 1,  10), 0.6,  6),
+                   (np.linspace(0, 1, 101), 0.6, 60)))
+def test_inverse_cdf_index_ad_hoc(frequencies, percentile, true_index):
+    icdf_i = inverse_cdf_index(frequencies, percentile)
+    assert icdf_i == true_index
+
+
+@given(valid_distributions(),
+       floats(min_value = 0.1, max_value = 0.9))
+def test_inverse_cdf_index_hypothesis_generated(distribution, percentile):
+    _, freq = distribution
+    cdf = cdf_from_freq(freq)
+    for i, cp in enumerate(cdf):
+        if cp >= percentile:
+            true_index = i
+            break
+    icdf_i = inverse_cdf_index(cdf, percentile)
+    assert true_index == icdf_i
+
+
+@mark.parametrize("domain frequencies percentile true_value".split(),
+                  ((np.arange( 10), np.linspace(0, 1,  10), 0.6,  6),
+                   (np.arange(101), np.linspace(0, 1, 101), 0.6, 60)))
+def test_inverse_cdf_ad_hoc(domain, frequencies, percentile, true_value):
+    icdf = inverse_cdf(domain, frequencies, percentile)
+    assert true_value == icdf
+
+
+@given(valid_distributions(),
+       floats(min_value = 0.1, max_value = 0.9))
+def test_inverse_cdf_hypothesis_generated(distribution, percentile):
+    domain, freq = distribution
+    cdf = cdf_from_freq(freq)
+    for i, (d, cp) in enumerate(zip(domain, cdf)):
+        if cp >= percentile:
+            true_value = d
+            break
+    icdf = inverse_cdf(domain, cdf, percentile)
+    assert true_value == icdf
+
 
 def test_noise_sampler_masked_sensors():
     run_number = 0

--- a/invisible_cities/core/random_sampling_test.py
+++ b/invisible_cities/core/random_sampling_test.py
@@ -150,7 +150,7 @@ def test_inverse_cdf_hypothesis_generated(distribution, percentile):
 
 @fixture(scope="module")
 def run_number():
-    return 0
+    return 4651
 
 @fixture(scope="module")
 def datasipm(run_number):

--- a/invisible_cities/core/random_sampling_test.py
+++ b/invisible_cities/core/random_sampling_test.py
@@ -205,3 +205,25 @@ def test_noise_sampler_take_sample(datasipm, noise_sampler):
                 assert np.all(np.in1d(sample, noise_sampler.xbins))
         else:
             assert not np.any(sample)
+
+
+def test_noise_sampler_compute_thresholds(datasipm, noise_sampler):
+    noise_sampler, *_ = noise_sampler
+    true_threshold_counts = {
+    0.85  :  19,
+    0.95  : 687,
+    1.05  : 829,
+    1.15  : 199,
+    1.25  :  32,
+    1.35  :   8,
+    1.45  :   6,
+    1.55  :   3,
+    2.05  :   1,
+    np.inf:   8}
+
+    thresholds       = noise_sampler.compute_thresholds(0.99)
+    threshold_counts = np.unique(thresholds, return_counts = True)
+    threshold_counts = dict(zip(*threshold_counts))
+    assert sorted(true_threshold_counts) == sorted(threshold_counts)
+    for i, truth in true_threshold_counts.items():
+        assert truth == threshold_counts[i]

--- a/invisible_cities/reco/peak_functions_c.pxd
+++ b/invisible_cities/reco/peak_functions_c.pxd
@@ -132,7 +132,7 @@ Uses a MAU to set the signal threshold (thr, in PES)
 returns ZS waveforms for all SiPMs
 """
 cpdef signal_sipm(np.ndarray[np.int16_t, ndim=2] SIPM,
-                  double [:] adc_to_pes, double thr,
+                  double [:] adc_to_pes, thr,
                   int n_MAU=*)
 
 """

--- a/invisible_cities/reco/peak_functions_c.pyx
+++ b/invisible_cities/reco/peak_functions_c.pyx
@@ -405,7 +405,7 @@ cpdef rebin_waveform(int ts, int t_finish, double[:] wf, int stride=40):
 
 
 cpdef signal_sipm(np.ndarray[np.int16_t, ndim=2] SIPM,
-                  double [:] adc_to_pes, double thr,
+                  double [:] adc_to_pes, thr,
                   int n_MAU=100):
     """
     subtracts the baseline
@@ -423,6 +423,7 @@ cpdef signal_sipm(np.ndarray[np.int16_t, ndim=2] SIPM,
 
     cdef double [:, :] siwf = np.zeros((NSiPM, NSiWF), dtype=np.double)
     cdef double [:]    MAU_ = np.zeros(        NSiWF , dtype=np.double)
+    cdef double [:]    thrs = np.full ( NSiPM, thr)
     cdef double pmean
 
     # loop over all SiPMs. Skip any SiPM with adc_to_pes constant = 0
@@ -446,7 +447,7 @@ cpdef signal_sipm(np.ndarray[np.int16_t, ndim=2] SIPM,
 
         # threshold using the MAU
         for k in range(NSiWF):
-            if SiWF[j,k]  > MAU_[k] + thr * adc_to_pes[j]:
+            if SiWF[j,k]  > MAU_[k] + thrs[j] * adc_to_pes[j]:
                 siwf[j,k] = SiWF[j,k] / adc_to_pes[j]
 
     return np.asarray(siwf)

--- a/invisible_cities/reco/peak_functions_test.py
+++ b/invisible_cities/reco/peak_functions_test.py
@@ -6,6 +6,7 @@ credits: see ic_authors_and_legal.rst in /doc
 
 last revised: JJGC, 10-July-2017
 """
+
 from collections import namedtuple
 
 import tables        as tb
@@ -127,6 +128,7 @@ def csum_zs_blr_cwf(electron_RWF_file):
          wfzs_indx         = wfzs_indx,
          wfzs_indx_py      = wfzs_indx_py))
 
+
 @fixture(scope="module")
 def toy_S1_wf():
     s1      = {}
@@ -137,6 +139,7 @@ def toy_S1_wf():
     wf = np.random.rand(1000)
     return s1, wf, indices
 
+
 def test_csum_cwf_close_to_csum_of_calibrated_pmts(csum_zs_blr_cwf):
     p = csum_zs_blr_cwf
 
@@ -146,35 +149,43 @@ def test_csum_cwf_close_to_csum_of_calibrated_pmts(csum_zs_blr_cwf):
 
     assert np.isclose(np.sum(p.csum_cwf), np.sum(csum), rtol=0.0001)
 
+
 def test_csum_cwf_close_to_csum_blr(csum_zs_blr_cwf):
     p = csum_zs_blr_cwf
     assert np.isclose(np.sum(p.csum_cwf), np.sum(p.csum_blr), rtol=0.01)
+
 
 def test_csum_cwf_pmt_close_to_csum_blr_pmt(csum_zs_blr_cwf):
     p = csum_zs_blr_cwf
     assert np.isclose(np.sum(p.csum_cwf_pmt6), np.sum(p.csum_blr_pmt6),
                       rtol=0.01)
 
+
 def test_csum_cwf_close_to_wfzs_ene(csum_zs_blr_cwf):
     p = csum_zs_blr_cwf
     assert np.isclose(np.sum(p.csum_cwf), np.sum(p.wfzs_ene), rtol=0.1)
 
+
 def test_csum_blr_close_to_csum_blr_py(csum_zs_blr_cwf):
     p = csum_zs_blr_cwf
     assert np.isclose(np.sum(p.csum_blr), np.sum(p.csum_blr_py), rtol=1e-4)
+
 
 def test_csum_blr_pmt_close_to_csum_blr_py_pmt(csum_zs_blr_cwf):
     p = csum_zs_blr_cwf
     assert np.isclose(np.sum(p.csum_blr_pmt6), np.sum(p.csum_blr_py_pmt6),
                       rtol=1e-3)
 
+
 def test_wfzs_ene_close_to_wfzs_ene_py(csum_zs_blr_cwf):
     p = csum_zs_blr_cwf
     assert np.isclose(np.sum(p.wfzs_ene), np.sum(p.wfzs_ene_py), atol=1e-4)
 
+
 def test_wfzs_indx_close_to_wfzs_indx_py(csum_zs_blr_cwf):
     p = csum_zs_blr_cwf
     npt.assert_array_equal(p.wfzs_indx, p.wfzs_indx_py)
+
 
 @fixture(scope='module')
 def pmaps_electrons(electron_RWF_file):
@@ -239,6 +250,7 @@ def pmaps_electrons(electron_RWF_file):
 
     return pmp, pmp2, csum
 
+
 def test_rebin_waveform():
     """
     Uses a toy wf and and all possible combinations of S12 start and stop times to assure that
@@ -277,23 +289,28 @@ def test_rebin_waveform():
                     assert np.isclose(t, np.mean((np.ceil(T[i-1] / (rbs))*rbs, f)))
                     assert e == (f - np.ceil(T[i-1] / (rbs)) * rbs) / (bs)
 
+
 def test_rebinning_does_not_affect_the_sum_of_S2(pmaps_electrons):
     pmp, pmp2, _ = pmaps_electrons
     np.isclose(np.sum(pmp.S2[0][1]), np.sum(pmp2.S2[0][1]), rtol=1e-05)
 
+
 def test_sum_of_S2_and_sum_of_calibrated_sum_vector_must_be_close(pmaps_electrons):
     pmp, _, csum = pmaps_electrons
     np.isclose(np.sum(pmp.S2[0][1]), np.sum(csum.csum), rtol=1e-02)
+
 
 def test_length_of_S1_time_array_must_match_energy_array(pmaps_electrons):
     pmp, _, _ = pmaps_electrons
     if pmp.S1:
         assert len(pmp.S1[0][0]) == len(pmp.S1[0][1])
 
+
 def test_length_of_S2_time_array_must_match_energy_array(pmaps_electrons):
     pmp, _, _ = pmaps_electrons
     if pmp.S2:
         assert len(pmp.S2[0][0]) == len(pmp.S2[0][1])
+
 
 def test_length_of_S2_time_array_and_length_of_S2Si_energy_array_must_be_the_same(pmaps_electrons):
     pmp, _, _ = pmaps_electrons
@@ -301,6 +318,7 @@ def test_length_of_S2_time_array_and_length_of_S2Si_energy_array_must_be_the_sam
     if pmp.S2 and pmp.S2Si:
         for nsipm in pmp.S2Si[0]:
             assert len(pmp.S2Si[0][nsipm]) == len(pmp.S2[0][0])
+
 
 def toy_pmt_signal():
     """ Mimick a PMT waveform."""
@@ -313,15 +331,18 @@ def toy_pmt_signal():
     pmt = np.concatenate((v, v, v))
     return pmt
 
+
 def toy_cwf_and_adc(v, npmt=10):
     """Return CWF and adc_to_pes for toy example"""
     CWF = [v] * npmt
     adc_to_pes = np.ones(v.shape[0])
     return np.array(CWF), adc_to_pes
 
+
 def vsum_zsum(vsum, threshold=10):
     """Compute ZS over vsum"""
     return vsum[vsum > threshold]
+
 
 def test_csum_zs_s12():
     """Several sequencial tests:
@@ -405,6 +426,7 @@ def test_csum_zs_s12():
         e = S12L2[i][1]
         npt.assert_allclose(e, E)
 
+
 def test_find_s12_finds_first_correct_candidate_peak():
     """
     Checks that find_s12 initializes S12[0] (the array defining the boundaries of the
@@ -420,14 +442,17 @@ def test_find_s12_finds_first_correct_candidate_peak():
     assert np.allclose(S12L[0][0], np.array([2*25*units.ns + 25/2 *units.ns]))
     assert np.allclose(S12L[0][1], np.array([1]))
 
+
 def test_cwf_are_empty_for_masked_pmts(csum_zs_blr_cwf):
     assert np.all(csum_zs_blr_cwf.cwf6[6:] == 0.)
+
 
 def test_correct_S1_ene_returns_correct_energies(toy_S1_wf):
     S1, wf, indices = toy_S1_wf
     corrS1 = cpf.correct_s1_ene(S1, wf)
     for peak_no, (t, E) in corrS1.s1d.items():
         assert np.all(E == wf[indices[peak_no]])
+
 
 def test_select_peaks_of_allowed_length():
     pbounds = {}
@@ -451,6 +476,7 @@ def test_select_peaks_of_allowed_length():
         assert l >= length.min
         assert l <  length.max
 
+
 def test_find_peaks_finds_peaks_when_index_spaced_by_less_than_or_equal_to_stride():
     # explore a range of strides
     for stride in range(2,8):
@@ -468,6 +494,7 @@ def test_find_peaks_finds_peaks_when_index_spaced_by_less_than_or_equal_to_strid
             assert bounds[1][0] ==  600            # find correct start i for second p
             assert bounds[1][1] ==  605            # find correct end   i for second p
 
+
 def test_find_peaks_finds_no_peaks_when_index_spaced_by_more_than_stride():
     for stride in range(2,8):
         index  = np.concatenate((np.arange(  0, 500, stride + 1, dtype=np.int32),
@@ -479,6 +506,7 @@ def test_find_peaks_finds_no_peaks_when_index_spaced_by_more_than_stride():
         assert bounds[0][0] ==  600
         assert bounds[0][1] ==  605
 
+
 def test_find_peaks_when_no_index_after_tmin():
     stride = 2
     index = np.concatenate((np.arange(  0, 500, stride, dtype=np.int32),
@@ -489,6 +517,7 @@ def test_find_peaks_when_no_index_after_tmin():
     assert pf._find_peaks(index, time   = minmax(9e9, 9e10),
                                  length = minmax(2, 9999),
                                  stride = stride) == {}
+
 
 def test_extract_peaks_from_waveform():
     wf = np.random.uniform(size=52000)
@@ -506,6 +535,7 @@ def test_extract_peaks_from_waveform():
         assert np.allclose(S12L[k][1], wf[peak_bounds[k][0]: peak_bounds[k][1]])  # Check energies
     # Check that _extract... did not return extra peaks
     assert len(peak_bounds) == len(S12L)
+
 
 def test_get_ipmtd():
     npmts  = 4
@@ -531,9 +561,11 @@ def test_get_ipmtd():
             # check that the correct energy is in each pmt
             assert np.allclose(s12_pmts.sum(axis=1), cCWF[:, i_peak[0]: i_peak[1]].sum(axis=1))
 
+
 def test_sum_waveforms():
     wfs = np.random.random((12,1300*40))
     assert np.allclose(pf.sum_waveforms(wfs), np.sum(wfs, axis=0))
+
 
 @fixture(scope='module')
 def toy_ccwfs_and_csum():
@@ -544,6 +576,7 @@ def toy_ccwfs_and_csum():
     ccwf[:, indx[0]: indx[-1] + 1] += peak
     csum  = ccwf.sum(axis=0)
     return indx, ccwf, csum
+
 
 def test_find_s12_ipmt_find_same_s12_as_find_s12(toy_ccwfs_and_csum):
     indx, ccwf, csum = toy_ccwfs_and_csum
@@ -575,6 +608,7 @@ def test_find_s12_ipmt_find_same_s12_as_find_s12(toy_ccwfs_and_csum):
     assert s20.s2d.keys() == s21.s2d.keys()
     for peak0, peak1 in zip(s10.s1d.values(), s11.s1d.values()):
         assert np.allclose(peak0, peak1)
+
 
 def test_find_s12_ipmt_return_none_when_empty_index(toy_ccwfs_and_csum):
     indx, ccwf, csum = toy_ccwfs_and_csum

--- a/invisible_cities/reco/sensor_functions.py
+++ b/invisible_cities/reco/sensor_functions.py
@@ -52,6 +52,6 @@ def simulate_sipm_response(event, sipmrd, sipms_noise_sampler, sipm_adc_to_pes):
     """Add noise to the sipms with the NoiseSampler class and return
     the noisy waveform (in adc)."""
     # add noise (in PES) to true waveform
-    dataSiPM = sipmrd[event] + sipms_noise_sampler.Sample()
+    dataSiPM = sipmrd[event] + sipms_noise_sampler.sample()
     # return total signal in adc counts
     return wfm.to_adc(dataSiPM, sipm_adc_to_pes)

--- a/invisible_cities/reco/sensor_functions_test.py
+++ b/invisible_cities/reco/sensor_functions_test.py
@@ -79,7 +79,7 @@ def test_sipm_noise_sampler(electron_MCRD_file):
         noise_sampler = SiPMsNoiseSampler(run_number, SIPMWL, True)
 
         # signal in sipm with noise
-        sipmrwf = e40rd.root.sipmrd[event] + noise_sampler.Sample()
+        sipmrwf = e40rd.root.sipmrd[event] + noise_sampler.sample()
         # zs waveform
         sipmzs = wfm.noise_suppression(sipmrwf, sipms_thresholds)
         n_sipm = 0


### PR DESCRIPTION
This PR introduces the possibility of using two types of thresholds for the SiPMs:
- Common: a single value in pes for all the SiPMs.
- Individual: each SiPM has its own threshold based on a common percentage of noise reduction. Since each SiPM has a different PDF, they also have different thresholds.

The code to compute the thresholds based on the percentage was already in IC, but it has been cleaned up a bit. The cython function to extract the signal from the sipms has been adapted to take both types of thresholds and a flag has been introduced in the cities to switch between both modes. The tests included in this PR are, perhaps, still not very exhaustive. I have introduced three:
- A test for `irene` to check that can run in both modes (this is actually a parametrization of a previous test to run with the two values of the flag). However, it does not check the output, as this is more complicated, but it is somehow complemented with:
- Two tests for the function `signal_sipm` in `peak_functions`, one for each threshold mode. These tests ensure the output of the function is the one we expect.

The configuration files from now on must include a new option `thr_sipm_type` that must be equal to `"common"` or to `"individual"` (case insensitive).