### PR TITLE
Fix chi2 and errors in fit function

### DIFF
--- a/invisible_cities/core/fit_functions.py
+++ b/invisible_cities/core/fit_functions.py
@@ -28,6 +28,41 @@ def get_errors(cov):
     return np.sqrt(np.diag(cov))
 
 
+def get_chi2_and_pvalue(ydata, yfit, ndf, sigma=None):
+    """
+    Gets reduced chi2 and p-value
+
+    Parameters
+    ----------
+    ydata : np.ndarray
+        Data points.
+    yfit : np.ndarray
+        Fit values corresponding to ydata array.
+    sigma : np.ndarray
+        Data errors. If sigma is not given, it takes the poisson case:
+            sigma = sqrt(ydata)
+    ndf : int
+        Number of degrees of freedom
+        (number of data points - number of parameters).
+
+    Returns
+    -------
+    chi2 : float
+        Reduced chi2 computed as:
+            chi2 = [sum(ydata - yfit)**2 / sigma**2] / ndf
+    pvalue : float
+        Fit p-value.
+    """
+
+    if sigma is None:
+        sigma = ydata**0.5
+
+    chi2   = np.sum(((ydata - yfit) / sigma)**2)
+    pvalue = scipy.stats.chi2.sf(chi2, ndf)
+
+    return chi2 / ndf, pvalue
+
+
 # ###########################################################
 # Functions
 def gauss(x, amp, mu, sigma):

--- a/invisible_cities/core/fit_functions_test.py
+++ b/invisible_cities/core/fit_functions_test.py
@@ -4,6 +4,7 @@ Tests for fit_functions
 
 import numpy as np
 from pytest import mark
+from pytest import approx
 from flaky  import flaky
 
 from numpy.testing import assert_array_equal
@@ -26,6 +27,41 @@ def test_get_errors():
                      [-1,  4, -1],
                      [ 2, -4,  1]], dtype=float)
     assert_array_equal(fitf.get_errors(data), [3., 2., 1.])
+
+
+def test_get_chi2_and_pvalue_when_data_equals_error_and_fit_equals_zero():
+    Nevt  = int(1e6)
+    ydata = np.random.uniform(1, 100, Nevt)
+    yfit  = np.zeros_like(ydata)
+    errs  = ydata
+    chi2, pvalue = fitf.get_chi2_and_pvalue(ydata, yfit, Nevt, errs)
+
+    assert chi2   == approx(1  , rel=1e-3)
+    assert pvalue == approx(0.5, rel=1e-3)
+
+
+def test_get_chi2_and_pvalue_when_data_equals_fit():
+    Nevt  = int(1e6)
+    ydata = np.random.uniform(1, 100, Nevt)
+    yfit  = ydata
+    errs  = ydata**0.5 # Dummy value, not needed
+    chi2, pvalue = fitf.get_chi2_and_pvalue(ydata, yfit, Nevt, errs)
+
+    assert chi2   == approx(0., rel=1e-3)
+    assert pvalue == approx(1., rel=1e-3)
+
+
+@given(floats(min_value = -2500,
+              max_value = +2500),
+       floats(min_value = + 100,
+              max_value = + 300))
+def test_get_chi2_and_pvalue_gauss_errors(mean, sigma):
+    Nevt  = int(1e6)
+    ydata = np.random.normal(mean, sigma, Nevt)
+
+    chi2, pvalue = fitf.get_chi2_and_pvalue(ydata, mean, Nevt-1, sigma)
+
+    assert chi2 == approx(1, rel=1e-2)
 
 
 @given(float_arrays(min_value=-10,

--- a/invisible_cities/core/fit_functions_test.py
+++ b/invisible_cities/core/fit_functions_test.py
@@ -18,26 +18,26 @@ from .testing_utils import FLOAT_ARRAY
 from .testing_utils import random_length_float_arrays
 
 from . import core_functions as core
-from . import  fit_functions as fit
+from . import  fit_functions as fitf
 
 
 def test_get_errors():
     data = np.array([[ 9, -2,  1],
                      [-1,  4, -1],
                      [ 2, -4,  1]], dtype=float)
-    assert_array_equal(fit.get_errors(data), [3., 2., 1.])
+    assert_array_equal(fitf.get_errors(data), [3., 2., 1.])
 
 
 @given(float_arrays(min_value=-10,
                     max_value=10))
 def test_gauss_symmetry(data):
-    assert_allclose(fit.gauss( data, 1., 0., 1.),
-                    fit.gauss(-data, 1., 0., 1.))
+    assert_allclose(fitf.gauss( data, 1., 0., 1.),
+                    fitf.gauss(-data, 1., 0., 1.))
 
 
 #def test_gauss_breaks_when_sigma_is_negative():
 #    assert_raises(ValueError,
-#                  fit.get_from_name,
+#                  fitf.get_from_name,
 #                  funname)
 
 
@@ -51,14 +51,14 @@ def test_gauss_symmetry(data):
                 max_value = +100))
 def test_gauss_works_with_integers(x, a, b, c):
     args = [x, a , b, c]
-    assert_allclose(fit.gauss(*args),
-                    fit.gauss(*map(float, args)))
+    assert_allclose(fitf.gauss(*args),
+                    fitf.gauss(*map(float, args)))
 
 
 @given(random_length_float_arrays(min_length = 1,
                                   max_length = 10,))
 def test_polynom_at_zero(pars):
-    assert_allclose(fit.polynom(0., *pars),
+    assert_allclose(fitf.polynom(0., *pars),
                     pars[0])
 
 
@@ -66,7 +66,7 @@ def test_polynom_at_zero(pars):
                                   max_length = 10,
                                   min_value  = 1e-8))
 def test_polynom_at_one(pars):
-    assert_allclose(fit.polynom(1., *pars),
+    assert_allclose(fitf.polynom(1., *pars),
                     np.sum(pars), rtol=1e-5)
 
 
@@ -75,7 +75,7 @@ def test_polynom_at_one(pars):
        floats(min_value = -20.,
               max_value = -10.))
 def test_expo_double_negative_sign(x, mean):
-    assert fit.expo(x, 1., mean) > fit.expo(x+1., 1., mean)
+    assert fitf.expo(x, 1., mean) > fitf.expo(x+1., 1., mean)
 
 
 @given(floats(min_value = +10.,
@@ -83,7 +83,7 @@ def test_expo_double_negative_sign(x, mean):
        floats(min_value = +10.,
               max_value = +20.))
 def test_expo_double_positive_sign(x, mean):
-    assert fit.expo(x, 1., mean) < fit.expo(x+1., 1., mean)
+    assert fitf.expo(x, 1., mean) < fitf.expo(x+1., 1., mean)
 
 
 @given(floats(min_value = -20.,
@@ -91,7 +91,7 @@ def test_expo_double_positive_sign(x, mean):
        floats(min_value = +10.,
               max_value = +20.))
 def test_expo_flipped_signs(x, b):
-    assert fit.expo(x, 1., b) < fit.expo(x+1., 1., b)
+    assert fitf.expo(x, 1., b) < fitf.expo(x+1., 1., b)
 
 
 @given(integers(min_value = -10,
@@ -102,8 +102,8 @@ def test_expo_flipped_signs(x, b):
                 max_value = +10).filter(lambda x: x != 0))
 def test_expo_works_with_integers(x, a, b):
     args = [x, a, b]
-    assert_allclose(fit.expo(*args),
-                    fit.expo(*map(float, args)))
+    assert_allclose(fitf.expo(*args),
+                    fitf.expo(*map(float, args)))
 
 
 @given(floats(min_value = -10.,
@@ -111,7 +111,7 @@ def test_expo_works_with_integers(x, a, b):
        floats(min_value = -10.,
               max_value = +10.))
 def test_power_at_one(a, b):
-    assert_allclose(fit.power(1., a, b),
+    assert_allclose(fitf.power(1., a, b),
                     a)
 
 
@@ -120,30 +120,30 @@ def test_power_at_one(a, b):
        floats(min_value =   0.,
               max_value = +10.).filter(lambda x: x != 0.))
 def test_power_at_zero(a, b):
-    assert_allclose(fit.power(0., a, b),
+    assert_allclose(fitf.power(0., a, b),
                     0.)
 
 
 @mark.parametrize("        fn                 pars        ".split(),
-                  ((fit.gauss         , (3.0,  2.0, 0.50)),
-                   (fit.expo          , (6.0,  1.5)),
-                   (fit.polynom       , (8.0, -0.5, 0.01)),
-                   (fit.power         , (0.1,  0.8))))
+                  ((fitf.gauss         , (3.0,  2.0, 0.50)),
+                   (fitf.expo          , (6.0,  1.5)),
+                   (fitf.polynom       , (8.0, -0.5, 0.01)),
+                   (fitf.power         , (0.1,  0.8))))
 def test_fit(fn, pars):
     pars = np.array(pars)
     x = np.arange(10.)
     y = fn(x, *pars)
-    f = fit.fit(fn, x, y, pars * 1.5)
+    f = fitf.fit(fn, x, y, pars * 1.5)
     assert_allclose(f.values, pars)
 
 
 def test_fit_reduced_range():
     pars = np.array([1, 20, 5])
     x = np.linspace(0, 50, 100)
-    y = fit.gauss(x, *pars)
+    y = fitf.gauss(x, *pars)
 
-    f1 = fit.fit(fit.gauss, x, y, pars * 1.5)
-    f2 = fit.fit(fit.gauss, x, y, pars * 1.5, fit_range=(10, 30))
+    f1 = fitf.fit(fitf.gauss, x, y, pars * 1.5)
+    f2 = fitf.fit(fitf.gauss, x, y, pars * 1.5, fit_range=(10, 30))
     assert_allclose(f1.values, f2.values)
 
 
@@ -153,17 +153,17 @@ def test_fit_reduced_range():
 def test_fit_with_errors(reduced):
     pars = np.array([1e3, 1e2, 1e1])
     x = np.linspace(100, 300, 100)
-    y = fit.gauss(x, *pars)
+    y = fitf.gauss(x, *pars)
     e = 0.1 * y
 
     fit_range = (50, 150) if reduced else None
-    f = fit.fit(fit.gauss, x, y, pars * 1.2, fit_range=fit_range, sigma=e, maxfev=10000)
+    f = fitf.fit(fitf.gauss, x, y, pars * 1.2, fit_range=fit_range, sigma=e, maxfev=10000)
     assert_allclose(f.values, pars)
 
 
 @mark.parametrize(["func"],
-                  ((fit.profileX,),
-                   (fit.profileY,)))
+                  ((fitf.profileX,),
+                   (fitf.profileY,)))
 def test_profile1D_uniform_distribution(func):
     N    = 100000
     Nbin = 100
@@ -180,8 +180,8 @@ def test_profile1D_uniform_distribution(func):
 
 
 @mark.parametrize(["func"],
-                  ((fit.profileX,),
-                   (fit.profileY,)))
+                  ((fitf.profileX,),
+                   (fitf.profileY,)))
 @flaky(max_runs=3, min_passes=1)
 def test_profile1D_uniform_distribution_std(func):
     N    = 100000
@@ -196,8 +196,8 @@ def test_profile1D_uniform_distribution_std(func):
 
 
 @mark.parametrize("func xdata ydata".split(),
-                  ((fit.profileX, FLOAT_ARRAY(100), FLOAT_ARRAY(100)),
-                   (fit.profileY, FLOAT_ARRAY(100), FLOAT_ARRAY(100))))
+                  ((fitf.profileX, FLOAT_ARRAY(100), FLOAT_ARRAY(100)),
+                   (fitf.profileY, FLOAT_ARRAY(100), FLOAT_ARRAY(100))))
 def test_profile1D_custom_range(func, xdata, ydata):
     xrange     = (-100, 100)
     kw         = "yrange" if func.__name__.endswith("Y") else "xrange"
@@ -207,11 +207,11 @@ def test_profile1D_custom_range(func, xdata, ydata):
 
 
 @mark.parametrize("func xdata ydata xrange".split(),
-                  ((fit.profileX,
+                  ((fitf.profileX,
                     FLOAT_ARRAY(100, -100, 100),
                     FLOAT_ARRAY(100, -500,   0),
                     (-100, 100)),
-                   (fit.profileY,
+                   (fitf.profileY,
                     FLOAT_ARRAY(100, -100, 100),
                     FLOAT_ARRAY(100, -500,   0),
                     (-500, 0))))
@@ -221,10 +221,10 @@ def test_profile1D_full_range_x(func, xdata, ydata, xrange):
 
 @mark.skip(reason="Hypothesis can't handle sequences longer than 2**10")
 #@mark.parametrize("func xdata ydata".split(),
-#                  ((fit.profileX,
+#                  ((fitf.profileX,
 #                    FLOAT_ARRAY(10000, -100, 100),
 #                    FLOAT_ARRAY(10000, -500,   0)),
-#                   (fit.profileY,
+#                   (fitf.profileY,
 #                    FLOAT_ARRAY(10000, -100, 100),
 #                    FLOAT_ARRAY(10000, -500,   0))))
 def test_profile1D_one_bin_missing_x(func, xdata, ydata):
@@ -234,10 +234,10 @@ def test_profile1D_one_bin_missing_x(func, xdata, ydata):
 
 
 @mark.parametrize("func xdata ydata".split(),
-                  ((fit.profileX,
+                  ((fitf.profileX,
                     FLOAT_ARRAY(100, min_value=-1e10, max_value=+1e10),
                     FLOAT_ARRAY(100, min_value=-1e10, max_value=+1e10)),
-                   (fit.profileY,
+                   (fitf.profileY,
                     FLOAT_ARRAY(100, min_value=-1e10, max_value=+1e10),
                     FLOAT_ARRAY(100, min_value=-1e10, max_value=+1e10))))
 def test_number_of_bins_matches(func, xdata, ydata):
@@ -247,10 +247,10 @@ def test_number_of_bins_matches(func, xdata, ydata):
 
 
 @mark.parametrize("func xdata ydata".split(),
-                  ((fit.profileX,
+                  ((fitf.profileX,
                     FLOAT_ARRAY(100),
                     FLOAT_ARRAY(100)),
-                   (fit.profileY,
+                   (fitf.profileY,
                     FLOAT_ARRAY(100),
                     FLOAT_ARRAY(100))))
 def test_empty_dataset_yields_nans(func, xdata, ydata):
@@ -274,11 +274,11 @@ def test_profileXY_full_range():
     xdata = np.random.rand(N)
     ydata = np.random.rand(N)
     zdata = np.random.rand(N)
-    xp, yp, zp, ze = fit.profileXY(xdata,
-                                   ydata,
-                                   zdata,
-                                   Nbin,
-                                   Nbin)
+    xp, yp, zp, ze = fitf.profileXY(xdata,
+                                    ydata,
+                                    zdata,
+                                    Nbin,
+                                    Nbin)
 
     assert np.all(abs(zp - 0.5) < 3.00*rms)
     assert np.all(abs(ze - rms*(Nbin**2/N)**0.5) < eps)


### PR DESCRIPTION
- Chi2
Implemented chi2 computation, based on scipy.stat.chisquare is only valid when data smearing is Poisson distributed. So, a general chi2 function is added, with formula extracted from [1].

- Errors
Fit errors, given by scipy.optimize.curve_fit were not correct as flag absolute_sigma was set to false. When true, "[data] sigma describes one standard deviation errors of the input data points", so covariance matrix estimation is based on these values. Otherwise, data sigma is only taken as "relative weights of the data points" and covariance matrix is not affected by the overall magnitude of the values in sigma, just by relative magnitudes.

Both improvements are shown in https://github.com/bpalmeiro/ICARO/blob/Chi2_demostration/icaro/Chi2_demonstration/Chi2_demonstration.ipynb

[1]  Numerical Recipes. The Art of Scientific Computing, 3rd Edition, 2007, ISBN 0-521-88068-8. Pages 778-780
