### PR TITLE
Stop using dev version of the DB in travis (closes #367)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ branches:
 
 install:
   - source manage.sh install ${IC_PYTHON_VERSION}
-  - bash manage.sh download_test_db_dev
 
 script:
   - HYPOTHESIS_PROFILE=hard bash manage.sh run_tests_par 4


### PR DESCRIPTION
Use the production version of the DB for the tests in Travis as this is the one more updated and the one we should use in Canfranc. See discussion in #367.