### PR TITLE
Temporary workaround for #357: use older hypothesis

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -82,7 +82,7 @@ dependencies:
 - sphinx=1.6.3=py36_0
 - pip:
   - flaky==3.4.0
-  - hypothesis==3.31.2
+  - hypothesis==3.28
   - pytest-xdist==1.20.0
 EOF
 


### PR DESCRIPTION
As discussed in #357, taking the hypothesis version back to 3.28 should speed up the Travis builds significantly.

This is not a long-term solution, but it should let us work much more efficiently in the short term.

#357 needs to remain open, until a detailed analysis of the situation is performed and a good long-term solution is found.