### PR TITLE
Bump hypothesis to 3.32

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,10 +4,12 @@ from hypothesis import settings
 from hypothesis import Verbosity
 
 # In addition to the 'default' profile, we provide
-settings.register_profile("hard"     , settings(max_examples = 1000))
-settings.register_profile("dev"      , settings(max_examples =   10))
-settings.register_profile("noshrink" , settings(max_examples =   10,
-                                                max_shrinks  =    0))
-settings.register_profile("debug"    , settings(max_examples =   10,
+settings.register_profile("hard"      , settings(max_examples = 1000))
+settings.register_profile("dev"       , settings(max_examples =   10))
+settings.register_profile("hard_nocov", settings(max_examples = 1000, use_coverage=False))
+settings.register_profile("dev_nocov" , settings(max_examples =   10, use_coverage=False))
+settings.register_profile("noshrink"  , settings(max_examples =   10,
+                                                 max_shrinks  =    0))
+settings.register_profile("debug"     , settings(max_examples =   10,
                                                 verbosity=Verbosity.verbose))
 settings.load_profile(os.getenv(u'HYPOTHESIS_PROFILE', 'dev'))

--- a/manage.sh
+++ b/manage.sh
@@ -82,7 +82,7 @@ dependencies:
 - sphinx=1.6.3=py36_0
 - pip:
   - flaky==3.4.0
-  - hypothesis==3.28
+  - hypothesis==3.32.0
   - pytest-xdist==1.20.0
 EOF
 


### PR DESCRIPTION
The serious performance degradation that invaded Travis with the advent of hypothesis 3.29, has been mostly fixed in hypothesis 3.32. On the other hand, 3.32 makes `test_in_range_right_shape` run an order of magnitude faster.

This PR contains a commit, which advances our hypothesis version no 3.32.0

Additionally, two new hypothesis profiles are added: versions of your existing `dev` and `hard` which switch off `use_coverage`. I think that we want to keep `use_coverage` on, but these profiles will make it easier to investigate performance degradations in the future.