### PR TITLE
Fix `contiguity`

### DIFF
--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -77,7 +77,7 @@ def make_track_graphs(voxels           : Voxel,
     """
 
     def neighbours(va : Voxel, vb : Voxel, scale : float = 1.0) -> bool:
-        return ((abs(va.pos - vb.pos) / voxel_dimensions) < contiguity).all()
+        return np.linalg.norm((va.pos - vb.pos) / voxel_dimensions) < contiguity
 
     voxel_graph = nx.Graph()
     voxel_graph.add_nodes_from(voxels)

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -1,5 +1,6 @@
 from functools   import reduce
 from itertools   import combinations
+from enum        import Enum
 
 import numpy    as np
 import networkx as nx
@@ -67,9 +68,15 @@ def voxelize_hits(hits             : Sequence[BHit],
     return [Voxel(cx[x], cy[y], cz[z], E[x,y,z]) for (x,y,z) in np.stack(nz).T]
 
 
+class Contiguity(Enum):
+    FACE   = 1.2
+    EDGE   = 1.5
+    CORNER = 1.8
+
+
 def make_track_graphs(voxels           : Voxel,
                       voxel_dimensions : np.ndarray,
-                      contiguity       : float = 1) -> Sequence[Graph]:
+                      contiguity       : Contiguity = Contiguity.CORNER) -> Sequence[Graph]:
     """Create a graph where the voxels are the nodes and the edges are any
     pair of neighbour voxel. Two voxels are considered to be
     neighbours if their distance normalized to their size is smaller
@@ -77,7 +84,7 @@ def make_track_graphs(voxels           : Voxel,
     """
 
     def neighbours(va : Voxel, vb : Voxel) -> bool:
-        return np.linalg.norm((va.pos - vb.pos) / voxel_dimensions) < contiguity
+        return np.linalg.norm((va.pos - vb.pos) / voxel_dimensions) < contiguity.value
 
     voxel_graph = nx.Graph()
     voxel_graph.add_nodes_from(voxels)

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -76,7 +76,7 @@ def make_track_graphs(voxels           : Voxel,
     than a contiguity factor.
     """
 
-    def neighbours(va : Voxel, vb : Voxel, scale : float = 1.0) -> bool:
+    def neighbours(va : Voxel, vb : Voxel) -> bool:
         return np.linalg.norm((va.pos - vb.pos) / voxel_dimensions) < contiguity
 
     voxel_graph = nx.Graph()

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -261,7 +261,7 @@ def test_length():
 
 
 @parametrize('contiguity, expected_length',
-             (mark.xfail((Contiguity.FACE, 4), reason='contiguity is broken'),
+             ((Contiguity.FACE, 4),
               (Contiguity.CORNER, 2 * sqrt(2))))
 def test_length_around_bend(contiguity, expected_length):
     # Make sure that we calculate the length along the track rather

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -203,7 +203,7 @@ def track_extrema():
                   (20,20,20,  2000),
     )
     voxels = [Voxel(x,y,z, E) for (x,y,z,E) in voxel_spec]
-    tracks  = make_track_graphs(voxels, np.array([1,1,1]), contiguity=Contiguity.CORNER)
+    tracks  = make_track_graphs(voxels, np.array([1,1,1]))
 
     assert len(tracks) == 1
     extrema = find_extrema(tracks[0])
@@ -250,7 +250,7 @@ def test_length():
                   (10,15,15,1)
     )
     voxels = [Voxel(x,y,z, E) for (x,y,z,E) in voxel_spec]
-    tracks  = make_track_graphs(voxels, np.array([1,1,1]), contiguity=Contiguity.CORNER)
+    tracks  = make_track_graphs(voxels, np.array([1,1,1]))
 
     assert len(tracks) == 1
     track_length = length(tracks[0])

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -202,7 +202,7 @@ def track_extrema():
                   (20,20,20,  2000),
     )
     voxels = [Voxel(x,y,z, E) for (x,y,z,E) in voxel_spec]
-    tracks  = make_track_graphs(voxels, np.array([1,1,1]), contiguity=1.5)
+    tracks  = make_track_graphs(voxels, np.array([1,1,1]), contiguity=1.8)
 
     assert len(tracks) == 1
     extrema = find_extrema(tracks[0])

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -299,25 +299,26 @@ def test_length_cuts_corners(contiguity, expected_length):
 
 
 
-@parametrize('criterion,  proximity,     are_neighbours',
-             (('FACE',   'share_face',            True),
-              ('FACE',   'share_edge',            False),
-              ('FACE',   'share_corner',          False),
-              ('FACE',   'share_nothing',         False),
-              ('FACE',   'share_nothing_algined', False),
+FACE, EDGE, CORNER = Contiguity
+@parametrize('contiguity,  proximity,          are_neighbours',
+             ((FACE,      'share_face',            True),
+              (FACE,      'share_edge',            False),
+              (FACE,      'share_corner',          False),
+              (FACE,      'share_nothing',         False),
+              (FACE,      'share_nothing_algined', False),
 
-              ('EDGE',   'share_face',            True),
-              ('EDGE',   'share_edge',            True),
-              ('EDGE',   'share_corner',          False),
-              ('EDGE',   'share_nothing',         False),
-              ('EDGE',   'share_nothing_algined', False),
+              (EDGE,      'share_face',            True),
+              (EDGE,      'share_edge',            True),
+              (EDGE,      'share_corner',          False),
+              (EDGE,      'share_nothing',         False),
+              (EDGE,      'share_nothing_algined', False),
 
-              ('CORNER', 'share_face',            True),
-              ('CORNER', 'share_edge',            True),
-              ('CORNER', 'share_corner',          True),
-              ('CORNER', 'share_nothing',         False),
-              ('CORNER', 'share_nothing_algined', False),))
-def test_contiguity(proximity, criterion, are_neighbours):
+              (CORNER,    'share_face',            True),
+              (CORNER,    'share_edge',            True),
+              (CORNER,    'share_corner',          True),
+              (CORNER,    'share_nothing',         False),
+              (CORNER,    'share_nothing_algined', False),))
+def test_contiguity(proximity, contiguity, are_neighbours):
     voxel_spec = dict(share_face            = ((0,0,0, 1),
                                                (0,0,1, 1)),
                       share_edge            = ((0,0,0, 1),
@@ -330,5 +331,5 @@ def test_contiguity(proximity, criterion, are_neighbours):
                                                (2,0,0, 1)) )[proximity]
     expected_number_of_tracks = 1 if are_neighbours else 2
     voxels = list(starmap(Voxel, voxel_spec))
-    tracks = make_track_graphs(voxels, np.array([1,1,1]), contiguity=Contiguity[criterion])
+    tracks = make_track_graphs(voxels, np.array([1,1,1]), contiguity=contiguity)
     assert len(tracks) == expected_number_of_tracks

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -35,6 +35,7 @@ from . paolina_functions import shortest_paths
 from . paolina_functions import make_track_graphs
 from . paolina_functions import voxels_from_track_graph
 from . paolina_functions import length
+from . paolina_functions import Contiguity
 
 from .. core.exceptions import NoHits
 from .. core.exceptions import NoVoxels
@@ -279,23 +280,23 @@ def test_length_around_bend(contiguity, expected_length):
 
 
 @parametrize('criterion,  proximity,     are_neighbours',
-             (('face',   'share_face',            True),
-              ('face',   'share_edge',            False),
-              ('face',   'share_corner',          False),
-              ('face',   'share_nothing',         False),
-              ('face',   'share_nothing_algined', False),
+             (('FACE',   'share_face',            True),
+              ('FACE',   'share_edge',            False),
+              ('FACE',   'share_corner',          False),
+              ('FACE',   'share_nothing',         False),
+              ('FACE',   'share_nothing_algined', False),
 
-              ('edge',   'share_face',            True),
-              ('edge',   'share_edge',            True),
-              ('edge',   'share_corner',          False),
-              ('edge',   'share_nothing',         False),
-              ('edge',   'share_nothing_algined', False),
+              ('EDGE',   'share_face',            True),
+              ('EDGE',   'share_edge',            True),
+              ('EDGE',   'share_corner',          False),
+              ('EDGE',   'share_nothing',         False),
+              ('EDGE',   'share_nothing_algined', False),
 
-              ('corner', 'share_face',            True),
-              ('corner', 'share_edge',            True),
-              ('corner', 'share_corner',          True),
-              ('corner', 'share_nothing',         False),
-              ('corner', 'share_nothing_algined', False),))
+              ('CORNER', 'share_face',            True),
+              ('CORNER', 'share_edge',            True),
+              ('CORNER', 'share_corner',          True),
+              ('CORNER', 'share_nothing',         False),
+              ('CORNER', 'share_nothing_algined', False),))
 def test_contiguity(proximity, criterion, are_neighbours):
     voxel_spec = dict(share_face            = ((0,0,0, 1),
                                                (0,0,1, 1)),
@@ -307,8 +308,7 @@ def test_contiguity(proximity, criterion, are_neighbours):
                                                (2,2,2, 1)),
                       share_nothing_algined = ((0,0,0, 1),
                                                (2,0,0, 1)) )[proximity]
-    contiguity = dict(face=1.2, edge=1.5, corner=1.8)[criterion]
     expected_number_of_tracks = 1 if are_neighbours else 2
     voxels = list(starmap(Voxel, voxel_spec))
-    tracks = make_track_graphs(voxels, np.array([1,1,1]), contiguity=contiguity)
+    tracks = make_track_graphs(voxels, np.array([1,1,1]), contiguity=Contiguity[criterion])
     assert len(tracks) == expected_number_of_tracks

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -203,7 +203,7 @@ def track_extrema():
                   (20,20,20,  2000),
     )
     voxels = [Voxel(x,y,z, E) for (x,y,z,E) in voxel_spec]
-    tracks  = make_track_graphs(voxels, np.array([1,1,1]), contiguity=1.8)
+    tracks  = make_track_graphs(voxels, np.array([1,1,1]), contiguity=Contiguity.CORNER)
 
     assert len(tracks) == 1
     extrema = find_extrema(tracks[0])
@@ -250,7 +250,7 @@ def test_length():
                   (10,15,15,1)
     )
     voxels = [Voxel(x,y,z, E) for (x,y,z,E) in voxel_spec]
-    tracks  = make_track_graphs(voxels, np.array([1,1,1]), contiguity=1.85)
+    tracks  = make_track_graphs(voxels, np.array([1,1,1]), contiguity=Contiguity.CORNER)
 
     assert len(tracks) == 1
     track_length = length(tracks[0])
@@ -261,8 +261,8 @@ def test_length():
 
 
 @parametrize('contiguity, expected_length',
-             (mark.xfail((1.2, 4), reason='contiguity is broken'),
-              (1.5, 2 * sqrt(2))))
+             (mark.xfail((Contiguity.FACE, 4), reason='contiguity is broken'),
+              (Contiguity.CORNER, 2 * sqrt(2))))
 def test_length_around_bend(contiguity, expected_length):
     # Make sure that we calculate the length along the track rather
     # that the shortcut

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -278,6 +278,26 @@ def test_length_around_bend(contiguity, expected_length):
     assert track_length == approx(expected_length)
 
 
+@parametrize('contiguity, expected_length',
+             (# Face contiguity requires 3 steps, each parallel to an axis
+              (Contiguity.FACE,  1 + 1 + 1),
+              # Edge continuity allows to cut one corner
+              (Contiguity.EDGE,  1 + sqrt(2)),
+              # Corner contiguity makes it possible to do in a single step
+              (Contiguity.CORNER,    sqrt(3))))
+def test_length_cuts_corners(contiguity, expected_length):
+    "Make sure that we cut corners, if the contiguity allows"
+    voxel_spec = ((0,0,0,  1), # Extremum 1
+                  (1,0,0,  1),
+                  (1,1,0,  1),
+                  (1,1,1,  1)) # Extremum 2
+    voxels = list(starmap(Voxel, voxel_spec))
+    tracks = make_track_graphs(voxels, np.array([1,1,1]), contiguity=contiguity)
+    assert len(tracks) == 1
+    track_length = length(tracks[0])
+    assert track_length == approx(expected_length)
+
+
 
 @parametrize('criterion,  proximity,     are_neighbours',
              (('FACE',   'share_face',            True),

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -275,3 +275,40 @@ def test_length_around_bend(contiguity, expected_length):
     assert len(tracks) == 1
     track_length = length(tracks[0])
     assert track_length == approx(expected_length)
+
+
+
+@parametrize('criterion,  proximity,     are_neighbours',
+             (('face',   'share_face',            True),
+              ('face',   'share_edge',            False),
+              ('face',   'share_corner',          False),
+              ('face',   'share_nothing',         False),
+              ('face',   'share_nothing_algined', False),
+
+              ('edge',   'share_face',            True),
+              ('edge',   'share_edge',            True),
+              ('edge',   'share_corner',          False),
+              ('edge',   'share_nothing',         False),
+              ('edge',   'share_nothing_algined', False),
+
+              ('corner', 'share_face',            True),
+              ('corner', 'share_edge',            True),
+              ('corner', 'share_corner',          True),
+              ('corner', 'share_nothing',         False),
+              ('corner', 'share_nothing_algined', False),))
+def test_contiguity(proximity, criterion, are_neighbours):
+    voxel_spec = dict(share_face            = ((0,0,0, 1),
+                                               (0,0,1, 1)),
+                      share_edge            = ((0,0,0, 1),
+                                               (0,1,1, 1)),
+                      share_corner          = ((0,0,0, 1),
+                                               (1,1,1, 1)),
+                      share_nothing         = ((0,0,0, 1),
+                                               (2,2,2, 1)),
+                      share_nothing_algined = ((0,0,0, 1),
+                                               (2,0,0, 1)) )[proximity]
+    contiguity = dict(face=1.2, edge=1.5, corner=1.8)[criterion]
+    expected_number_of_tracks = 1 if are_neighbours else 2
+    voxels = list(starmap(Voxel, voxel_spec))
+    tracks = make_track_graphs(voxels, np.array([1,1,1]), contiguity=contiguity)
+    assert len(tracks) == expected_number_of_tracks


### PR DESCRIPTION
Once upon a time there was an IC contributor whose handle starts with **j** (and ends with **jgomezcadenas**) who decided to improve some existing IC code by adding extra functionality to it. The functionality in question consisted of a parameter called `contiguity` to `make_track_graphs` whose purpose was to allow some degree of control over the criterion by which two voxels are considered to be neighbours.

For some strange reason, the developer gave the parameter a default value of `1`, meaning that (by default) no voxels would ever be considered neighbours, unless floating point arithmetic error brought the centres of two adjacent voxels to *less than* the required voxel separation.

What is even stranger is that the developer did not write any tests for this functionality, thus committing one of the greater IC sins.

The deveoper probably thought that, in such a simple case, it is not worth wasting time on writing tests: the solution is obviously correct.

As it turns out, the strange choice of default value was not the only problem with the implementation. The implementation created by the original developer of the code, considered voxels that share *entire* faces to be neighbours, and the logic embedded in the code was devised for that specific case. Merely changing the length used in that logic, was not enough to implement the new feature. But, **without an automated test**, how was the poor developer supposed to know that he had failed to achieve what he wanted?

Many moons later, another IC developer (whose handle starts with **p**) kept getting confused by the behaviour of `make_track_graphs` and related functions. She kept asking the *original* developer (the one who did **not** add `contiguity`) to explain how it was supposed to work.

Unfortunately, she chose to raise these questions is private emails, rather than in GitHub issues, so the *actual* author of `contiguity` remained oblivious of the fact that his untested and buggy addition to the code was repeatedly wasting time of two IC contributors. 

The moral of the story is, **always wirte tests for new functionality that you add to IC**.

This PR kicks off by adding tests that prove that `contiguity` is broken.

Further commits that fix it will follow ...