### PR TITLE
Let voxels know their size

### DIFF
--- a/invisible_cities/evm/event_model.py
+++ b/invisible_cities/evm/event_model.py
@@ -139,7 +139,6 @@ class MCHit(BHit):
     @property
     def T   (self): return self.time
 
-
     def __str__(self):
         return '<pos = {} E = {} time = {}>'.format(
                 self.pos.tolist(), self.E, self.time)
@@ -158,8 +157,12 @@ class MCHit(BHit):
 
 class Voxel(BHit):
     """Represents a Voxel"""
-    def __init__(self, x,y,z, E):
+    def __init__(self, x,y,z, E, size):
         super().__init__(x,y,z, E)
+        self._size = size
+
+    @property
+    def size(self): return self._size
 
 
 class Cluster(BHit):

--- a/invisible_cities/evm/event_model_test.py
+++ b/invisible_cities/evm/event_model_test.py
@@ -40,11 +40,12 @@ def event_input(draw):
 
 @composite
 def voxel_input(draw, min_value=0, max_value=100):
-    x     = draw(floats  (  1,   5))
-    y     = draw(floats  (-10,  10))
-    z     = draw(floats  (.01,  .5))
-    E     = draw(floats  ( 50, 100))
-    return x, y, z, E
+    x     = draw(floats(  1,   5))
+    y     = draw(floats(-10,  10))
+    z     = draw(floats(.01,  .5))
+    E     = draw(floats( 50, 100))
+    size  = np.array([draw(floats(1,2)), draw(floats(1,2)), draw(floats(1,2))])
+    return x, y, z, E, size
 
 @composite
 def cluster_input(draw, min_value=0, max_value=100):
@@ -137,9 +138,9 @@ def test_hit(ci, hi):
 
 @given(voxel_input(1))
 def test_voxel(vi):
-    x, y, z, E = vi
+    x, y, z, E, size = vi
     xyz = x, y, z
-    v = Voxel(x, y, z, E)
+    v = Voxel(x, y, z, E, size)
 
     np.allclose(v.XYZ  , xyz,                rtol=1e-4)
     np.allclose(v.pos , np.array(xyz),       rtol=1e-4)

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -65,7 +65,7 @@ def voxelize_hits(hits             : Sequence[BHit],
 
     cx, cy, cz = map(centres, edges)
     nz = np.nonzero(E)
-    return [Voxel(cx[x], cy[y], cz[z], E[x,y,z]) for (x,y,z) in np.stack(nz).T]
+    return [Voxel(cx[x], cy[y], cz[z], E[x,y,z], voxel_dimensions) for (x,y,z) in np.stack(nz).T]
 
 
 class Contiguity(Enum):


### PR DESCRIPTION
A number of situations are popping up where it would be useful to query a voxel for its size, rather than having to hund backwards in the code for the size that was requested, or having to infer the size from the spacing. The latter is not only tedious, but also nontrivial, error-prone and iiable to be done on the basis of unfounded assumptions.

There are essentially no commits in this PR yet: it looks otherwise, because it is based on #383 which has not been approved and merged yet.

The purpose of opening the PR now is to solicit input on the question of what the interface should be.

We should discourage changing a voxel's size after construction, so I propose a read-only interface. This essentially excludes returning an `np.array`. Options include

+ 3 separate properties, one for each dimension
+ 1 property, returning a tuple
+ 1 property returning an np.array (dangerous but convenient)

Any thoughts?