### PR TITLE
Add new normalization option "center"

### DIFF
--- a/invisible_cities/reco/corrections.py
+++ b/invisible_cities/reco/corrections.py
@@ -2,9 +2,9 @@ import numpy as np
 import scipy as sc
 
 
-from ..core                     import fit_functions as fitf
-from ..core.exceptions          import ParameterNotSet
-from .. evm.ic_containers       import Measurement
+from ..core               import fit_functions as fitf
+from ..core.exceptions    import ParameterNotSet
+from .. evm.ic_containers import Measurement
 
 
 class Correction:

--- a/invisible_cities/reco/corrections.py
+++ b/invisible_cities/reco/corrections.py
@@ -84,6 +84,11 @@ class Correction:
             f_ref = self._fs[mult_index]
             u_ref = self._us[mult_index]
 
+        elif   strategy == "center":
+            index = tuple(i//2 for i in self._fs.shape)
+            f_ref = self._fs[index]
+            u_ref = self._us[index]
+
         elif   strategy == "index":
             if "index" not in opts:
                 raise ParameterNotSet(("Normalization stratery 'index' requires"

--- a/invisible_cities/reco/corrections.py
+++ b/invisible_cities/reco/corrections.py
@@ -34,9 +34,11 @@ class Correction:
 
     def __init__(self,
                  xs, fs, us,
-                   norm_strategy = False, norm_opts = None,
+                   norm_strategy = False,
+                   norm_opts     = None,
                  interp_strategy = "nearest",
-                 default_f = 0, default_u = 0):
+                 default_f       = 0,
+                 default_u       = 0):
 
         self._xs = [np.array( x, dtype=float) for x in xs]
         self._fs =  np.array(fs, dtype=float)
@@ -69,27 +71,27 @@ class Correction:
         return corr
 
     def _normalize(self, strategy, opts):
-        if not strategy           : return
+        if not strategy            : return
 
-        elif   strategy == "const":
+        elif   strategy == "const" :
             if "value" not in opts:
                 raise ParameterNotSet(("Normalization stratery 'const' requires"
                                        "the normalization option 'value'"))
             f_ref = opts["value"]
             u_ref = 0
 
-        elif   strategy == "max"  :
+        elif   strategy == "max"   :
             flat_index = np.argmax(self._fs)
             mult_index = np.unravel_index(flat_index, self._fs.shape)
             f_ref = self._fs[mult_index]
             u_ref = self._us[mult_index]
 
         elif   strategy == "center":
-            index = tuple(i//2 for i in self._fs.shape)
+            index = tuple(i // 2 for i in self._fs.shape)
             f_ref = self._fs[index]
             u_ref = self._us[index]
 
-        elif   strategy == "index":
+        elif   strategy == "index" :
             if "index" not in opts:
                 raise ParameterNotSet(("Normalization stratery 'index' requires"
                                        "the normalization option 'index'"))
@@ -109,8 +111,8 @@ class Correction:
         # Redefine and propagate uncertainties as:
         # u(F) = F sqrt(u(F)**2/F**2 + u(Fref)**2/Fref**2)
         self._fs[ valid]  = f_ref / valid_fs
-        self._us[ valid]  = np.sqrt((valid_us/valid_fs)**2 +
-                                    (   u_ref/f_ref   )**2 )
+        self._us[ valid]  = np.sqrt((valid_us / valid_fs)**2 +
+                                    (   u_ref / f_ref   )**2 )
         self._us[ valid] *= self._fs[valid]
 
         # Set invalid to defaults
@@ -167,13 +169,13 @@ def LifetimeXYCorrection(pars, u_pars, xs, ys, **kwargs):
 
 def LifetimeRCorrection(pars, u_pars):
     def LTfun(z, r, a, b, c, u_a, u_b, u_c):
-        LT = a - b * r * np.exp(r/c)
+        LT = a - b * r * np.exp(r / c)
         return fitf.expo(z, 1, LT)
 
     def u_LTfun(z, r, a, b, c, u_a, u_b, u_c):
-        LT   = a - b * r * np.exp(r/c)
-        u_LT = (u_a**2 + u_b**2 * np.exp(2*r/c) +
-                u_c**2 * b**2 * r**2 * np.exp(2*r/c)/c**4)**0.5
+        LT   = a - b * r * np.exp(r / c)
+        u_LT = (u_a**2 + u_b**2 * np.exp(2 * r / c) +
+                u_c**2 *   b**2 * r**2 * np.exp(2 * r / c) / c**4)**0.5
         return z * u_LT / LT**2 * LTfun(z, r, a, b, c, u_a, u_b, u_c)
 
     return Fcorrection(LTfun, u_LTfun, np.concatenate([pars, u_pars]))

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -1,4 +1,5 @@
-from collections   import namedtuple
+from collections import namedtuple
+
 import numpy as np
 
 from ..core             import fit_functions as fitf
@@ -13,8 +14,7 @@ from numpy.testing import assert_allclose
 from pytest        import fixture
 from pytest        import mark
 from pytest        import raises
-
-from flaky import flaky
+from flaky         import flaky
 
 from hypothesis             import given
 from hypothesis.strategies  import floats
@@ -30,7 +30,6 @@ FField_1d = namedtuple("Ffield1d", "X   P Pu F Fu fun u_fun")
 FField_2d = namedtuple("Ffield2d", "X Y P Pu F Fu fun u_fun")
 EField_1d = namedtuple("Efield1d", "X   E Eu F Fu imax"     )
 EField_2d = namedtuple("Efield2d", "X Y E Eu F Fu imax jmax")
-
 
 
 @composite
@@ -63,17 +62,19 @@ def uniform_energy_2d(draw, interp_strategy="nearest"):
     dY      = draw(floats  (min_value= 0.1, max_value=100))
     X       = np.arange(x_size) * dX + X0
     Y       = np.arange(y_size) * dY + Y0
-    E       = draw(arrays(float, (x_size, y_size), floats(min_value = 1e3 , max_value = 2e3 )))
-    u_rel   = draw(arrays(float, (x_size, y_size), floats(min_value = 1e-2, max_value = 2e-1)))
+    E       = draw(arrays(float, (x_size, y_size), floats(min_value = 1e+3,
+                                                          max_value = 2e+3)))
+    u_rel   = draw(arrays(float, (x_size, y_size), floats(min_value = 1e-2,
+                                                          max_value = 2e-1)))
     Eu      = E * u_rel
 
-    i_max = draw(integers(min_value=0, max_value=x_size-1))
-    j_max = draw(integers(min_value=0, max_value=y_size-1))
+    i_max = draw(integers(min_value=0, max_value=x_size - 1))
+    j_max = draw(integers(min_value=0, max_value=y_size - 1))
     e_max = E [i_max, j_max]
     u_max = Eu[i_max, j_max]
 
-    F     = e_max/E
-    Fu    = F * (Eu**2/E**2 + u_max**2/e_max**2)**0.5
+    F     = e_max / E
+    Fu    = F * (Eu**2 / E**2 + u_max**2 / e_max**2)**0.5
 
     return EField_2d(X, Y, E, Eu, F.flatten(), Fu.flatten(), i_max, j_max)
 
@@ -93,18 +94,18 @@ def uniform_energy_fun_data_1d(draw):
 @composite
 def uniform_energy_fun_data_2d(draw):
     def fun(z, r, a, b, c, u_a, u_b, u_c):
-        LT = a - b * r * np.exp(r/c)
+        LT = a - b * r * np.exp(r / c)
         return fitf.expo(z, 1, LT)
 
     def u_fun(z, r, a, b, c, u_a, u_b, u_c):
-        LT   = a - b * r * np.exp(r/c)
-        u_LT = (u_a**2 + u_b**2 * np.exp(2*r/c) +
-                u_c**2 * b**2 * r**2 * np.exp(2*r/c)/c**4)**0.5
+        LT   = a - b * r * np.exp(r / c)
+        u_LT = (u_a**2 + u_b**2 * np.exp(2 * r / c) +
+                u_c**2 * b**2 * r**2 * np.exp(2 * r / c) / c**4)**0.5
         return z * u_LT / LT**2 * fun(z, r, a, b, c, u_a, u_b, u_c)
 
-    a     = draw(floats(min_value=1e+2, max_value=1e+3));u_a = 0.1*a
-    b     = draw(floats(min_value=1e-2, max_value=1e-1));u_b = 0.1*b
-    c     = draw(floats(min_value=1e+3, max_value=5e+3));u_c = 0.1*c
+    a     = draw(floats(min_value=1e+2, max_value=1e+3));u_a = 0.1 * a
+    b     = draw(floats(min_value=1e-2, max_value=1e-1));u_b = 0.1 * b
+    c     = draw(floats(min_value=1e+3, max_value=5e+3));u_c = 0.1 * c
     Z     = np.linspace(0, 600, 100)
     R     = np.linspace(0, 200, 100)
     F     =   fun(Z, R, a, b, c, u_a, u_b, u_c)
@@ -123,23 +124,25 @@ def uniform_energy_fun_data_3d(draw):
     X       = np.arange(x_size) * dX + X0
     Y       = np.arange(y_size) * dY + Y0
 
-    LTs     = draw(arrays(float, (x_size, y_size), floats(min_value = 1e+2, max_value = 1e+3)))
+    LTs     = draw(arrays(float, (x_size, y_size), floats(min_value = 1e+2,
+                                                          max_value = 1e+3)))
     u_LTs   = LTs * 0.1
 
-    LTc     = Correction((X,Y), LTs, u_LTs)
+    LTc     = Correction((X, Y), LTs, u_LTs)
 
     def LT_corr(z, x, y):
-        return np.exp(z/LTc(x,y).value)
+        return np.exp(z / LTc(x, y).value)
 
     def u_LT_corr(z, x, y):
-        ltc = LTc(x,y)
-        return z*ltc.uncertainty/ltc.value**2*np.exp(z/ltc.value)
+        ltc = LTc(x, y)
+        return z * ltc.uncertainty / ltc.value**2 * np.exp(z / ltc.value)
+
     return FField_2d(X, Y, LTs, u_LTs, LTs, u_LTs, LT_corr, u_LT_corr)
 
 
 @fixture
 def gauss_data_1d():
-    mean = lambda z: 1e4 * np.exp(-z/300)
+    mean = lambda z: 1e4 * np.exp(-z / 300)
     Nevt = 100000
     Zevt = np.random.uniform(0, 500, size=Nevt)
     Eevt = np.random.normal(mean(Zevt), mean(Zevt)**0.5)
@@ -149,7 +152,7 @@ def gauss_data_1d():
 
 @fixture
 def gauss_data_2d():
-    mean = lambda x, y: 1e4 * np.exp(-(x**2 + y**2)/400**2)
+    mean = lambda x, y: 1e4 * np.exp(-(x**2 + y**2) / 400**2)
     Nevt = 100000
     Xevt = np.random.uniform(-200, 200, size=Nevt)
     Yevt = np.random.uniform(-200, 200, size=Nevt)
@@ -231,8 +234,8 @@ def test_correction_normalization_1d_to_const(toy_data_1d, norm_value):
     c = Correction((X,), E, Eu,
                    norm_strategy = "const",
                    norm_opts     = {"value": norm_value})
-    assert_allclose(c._fs, norm_value/E)
-    assert_allclose(c._us, norm_value/E**2*Eu)
+    assert_allclose(c._fs, norm_value / E)
+    assert_allclose(c._us, norm_value / E**2 * Eu)
 
 
 @given(uniform_energy_1d())
@@ -241,26 +244,28 @@ def test_correction_normalization_to_center_1d(toy_data_1d):
     c = Correction((X,), E, Eu,
                    norm_strategy = "center")
 
-    norm_index = X.size//2
+    norm_index = X.size // 2
     norm_value = E [norm_index]
     norm_uncer = Eu[norm_index]
-    prop_uncer = ((Eu/E)**2 + (norm_uncer/norm_value)**2)**0.5 * norm_value/E
-    assert_allclose(c._fs, norm_value/E)
-    assert_allclose(c._us, prop_uncer  )
+    prop_uncer = (Eu / E)**2 + (norm_uncer / norm_value)**2
+    prop_uncer = prop_uncer**0.5 * norm_value / E
+    assert_allclose(c._fs, norm_value / E)
+    assert_allclose(c._us, prop_uncer    )
 
 
 @given(uniform_energy_2d())
 def test_correction_normalization_to_center_2d(toy_data_2d):
     X, Y, E, Eu, *_ = toy_data_2d
-    c = Correction((X,Y), E, Eu,
+    c = Correction((X, Y), E, Eu,
                    norm_strategy = "center")
 
-    norm_index = X.size//2, Y.size//2
+    norm_index = X.size // 2, Y.size // 2
     norm_value = E [norm_index]
     norm_uncer = Eu[norm_index]
-    prop_uncer = ((Eu/E)**2 + (norm_uncer/norm_value)**2)**0.5 * norm_value/E
-    assert_allclose(c._fs, norm_value/E)
-    assert_allclose(c._us, prop_uncer  )
+    prop_uncer = (Eu / E)**2 + (norm_uncer / norm_value)**2
+    prop_uncer = prop_uncer**0.5 * norm_value / E
+    assert_allclose(c._fs, norm_value / E)
+    assert_allclose(c._us, prop_uncer    )
 
 
 #--------------------------------------------------------
@@ -269,7 +274,7 @@ def test_correction_normalization_to_center_2d(toy_data_2d):
 def test_correction_attributes_2d(toy_data_2d):
     X, Y, E, Eu, F, Fu, i_max, j_max = toy_data_2d
     interp_strategy="nearest"
-    correct = Correction((X,Y), E, Eu,
+    correct = Correction((X, Y), E, Eu,
                            norm_strategy =  "index",
                            norm_opts     = {"index": (i_max, j_max)},
                          interp_strategy = interp_strategy)
@@ -283,7 +288,7 @@ def test_correction_attributes_2d(toy_data_2d):
 @given(uniform_energy_2d())
 def test_correction_attributes_2d_unnormalized(toy_data_2d):
     X, Y, _, _, F, Fu, _, _ = toy_data_2d
-    c = Correction((X,Y), F, Fu,
+    c = Correction((X, Y), F, Fu,
                    norm_strategy = None)
     assert_allclose(c._fs, F )
     assert_allclose(c._us, Fu)
@@ -305,7 +310,7 @@ def test_correction_normalization_2d_to_max(toy_data_2d):
 def test_correction_call_2d(toy_data_2d):
     X, Y, E, Eu, F, Fu, i_max, j_max = toy_data_2d
     interp_strategy="nearest"
-    correct = Correction((X,Y), E, Eu,
+    correct = Correction((X, Y), E, Eu,
                            norm_strategy =  "index",
                            norm_opts     = {"index": (i_max, j_max)},
                          interp_strategy = interp_strategy)
@@ -380,7 +385,8 @@ def test_lifetimeXYcorrection_kwargs(toy_f_data):
 
     # These input values are chosen because they
     # effectively cancel the normalization.
-    correct = LifetimeXYCorrection(1/LTs, u_LTs/LTs**2, Xgrid, Ygrid, **kwargs)
+    correct = LifetimeXYCorrection(1 / LTs, u_LTs / LTs**2,
+                                   Xgrid, Ygrid, **kwargs)
     f_corrected, u_corrected = correct(Z, X, Y)
 
     assert_allclose(  F, f_corrected)
@@ -402,7 +408,9 @@ def test_corrections_1d(gauss_data_1d):
     mean = np.mean(Eevt)
     std  = np.std (Eevt)
 
-    y, x = np.histogram(Eevt, np.linspace(mean - 3 * std, mean + 3 * std, 100))
+    y, x = np.histogram(Eevt, np.linspace(mean - 3 * std,
+                                          mean + 3 * std,
+                                          100))
     x    = x[:-1] + np.diff(x) * 0.5
     f    = fitf.fit(fitf.gauss, x, y, (1e5, mean, std))
     assert f.chi2 < 3
@@ -414,13 +422,15 @@ def test_corrections_2d(gauss_data_2d):
     X, Y, E, Eu, Xevt, Yevt, Eevt = gauss_data_2d
     correct = Correction((X, Y), E, Eu,
                          norm_strategy =  "index",
-                         norm_opts     = {"index": (25,25)})
+                         norm_opts     = {"index": (25, 25)})
     Eevt   *= correct(Xevt, Yevt)[0]
 
     mean = np.mean(Eevt)
     std  = np.std (Eevt)
 
-    y, x = np.histogram(Eevt, np.linspace(mean - 3 * std, mean + 3 * std, 100))
+    y, x = np.histogram(Eevt, np.linspace(mean - 3 * std,
+                                          mean + 3 * std,
+                                          100))
     x    = x[:-1] + np.diff(x) * 0.5
     f    = fitf.fit(fitf.gauss, x, y, (1e5, mean, std))
     assert f.chi2 < 3

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -235,6 +235,34 @@ def test_correction_normalization_1d_to_const(toy_data_1d, norm_value):
     assert_allclose(c._us, norm_value/E**2*Eu)
 
 
+@given(uniform_energy_1d())
+def test_correction_normalization_to_center_1d(toy_data_1d):
+    X, E, Eu, *_ = toy_data_1d
+    c = Correction((X,), E, Eu,
+                   norm_strategy = "center")
+
+    norm_index = E.size//2
+    norm_value = E [norm_index]
+    norm_uncer = Eu[norm_index]
+    prop_uncer = ((Eu/E)**2 + (norm_uncer/norm_value)**2)**0.5 * norm_value/E
+    assert_allclose(c._fs, norm_value/E)
+    assert_allclose(c._us, prop_uncer  )
+
+
+@given(uniform_energy_2d())
+def test_correction_normalization_to_center_2d(toy_data_2d):
+    X, Y, E, Eu, *_ = toy_data_2d
+    c = Correction((X,Y), E, Eu,
+                   norm_strategy = "center")
+
+    norm_index = X.size//2, Y.size//2
+    norm_value = E [norm_index]
+    norm_uncer = Eu[norm_index]
+    prop_uncer = ((Eu/E)**2 + (norm_uncer/norm_value)**2)**0.5 * norm_value/E
+    assert_allclose(c._fs, norm_value/E)
+    assert_allclose(c._us, prop_uncer  )
+
+
 #--------------------------------------------------------
 
 @given(uniform_energy_2d())

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -241,7 +241,7 @@ def test_correction_normalization_to_center_1d(toy_data_1d):
     c = Correction((X,), E, Eu,
                    norm_strategy = "center")
 
-    norm_index = E.size//2
+    norm_index = X.size//2
     norm_value = E [norm_index]
     norm_uncer = Eu[norm_index]
     prop_uncer = ((Eu/E)**2 + (norm_uncer/norm_value)**2)**0.5 * norm_value/E


### PR DESCRIPTION
It is a shortcut for
```
norm_strategy = "index"
norm_opts = {"value": central_bin}
```
where `central_bin` is the arrays' shape tuple halved.

The idea is that the user doesn't need to know the indices corresponding to the central bin.