### PR TITLE
Add "scale" option when loading lifetime map

### DIFF
--- a/invisible_cities/reco/dst_functions.py
+++ b/invisible_cities/reco/dst_functions.py
@@ -31,6 +31,22 @@ def load_lifetime_xy_corrections(filename, *,
                                  node  = "LifetimeXY",
                                  scale = 1,
                                  **kwargs):
+    """
+    Load the lifetime map from hdf5 file.
+
+    Parameters
+    ----------
+    filename: str
+        Path to the file containing the map.
+    group: str
+        Name of the group where the table is stored.
+    node: str
+        Name of the table containing the data.
+    scale: float
+        Scale factor for the lifetime values.
+
+    Other kwargs are passed to the contructor of LifetimeXYCorrection.
+    """
     dst  = load_dst(filename, group, node)
     x, y = np.unique(dst.x.values), np.unique(dst.y.values)
     f, u = dst.factor.values * scale, dst.uncertainty.values * scale

--- a/invisible_cities/reco/dst_functions.py
+++ b/invisible_cities/reco/dst_functions.py
@@ -29,10 +29,11 @@ def load_xy_corrections(filename, *,
 def load_lifetime_xy_corrections(filename, *,
                                  group = "Corrections",
                                  node  = "LifetimeXY",
+                                 scale = 1,
                                  **kwargs):
     dst  = load_dst(filename, group, node)
     x, y = np.unique(dst.x.values), np.unique(dst.y.values)
-    f, u = dst.factor.values, dst.uncertainty.values
+    f, u = dst.factor.values * scale, dst.uncertainty.values * scale
 
     return LifetimeXYCorrection(f.reshape(x.size, y.size),
                                 u.reshape(x.size, y.size),

--- a/invisible_cities/reco/dst_functions.py
+++ b/invisible_cities/reco/dst_functions.py
@@ -1,5 +1,3 @@
-import pandas as pd
-import tables as tb
 import numpy  as np
 
 from .  corrections import Correction


### PR DESCRIPTION
Add a scale factor to the function that loads the lifetime map. This allows the use of the lifetime map in runs that are not right after/before the one used to extract the map.