### PR TITLE
Refactor interpolation in `Correction` class

### DIFF
--- a/invisible_cities/reco/corrections.py
+++ b/invisible_cities/reco/corrections.py
@@ -37,6 +37,7 @@ class Correction:
                    norm_strategy = False,
                    norm_opts     = None,
                  interp_strategy = "nearest",
+                 interp_opts     = None,
                  default_f       = 0,
                  default_u       = 0):
 
@@ -47,11 +48,12 @@ class Correction:
         self.norm_strategy   =   norm_strategy
         self.norm_opts       =   norm_opts
         self.interp_strategy = interp_strategy
+        self.interp_opts     = interp_opts
         self.default_f       = default_f
         self.default_u       = default_u
 
-        self._normalize          (  norm_strategy, norm_opts)
-        self._define_interpolator(interp_strategy)
+        self._normalize          (  norm_strategy,   norm_opts)
+        self._define_interpolator(interp_strategy, interp_opts)
 
     def __call__(self, *x):
         """
@@ -65,10 +67,10 @@ class Correction:
         """
         return Measurement(*self._get_correction(*x))
 
-    def _define_interpolator(self, opt):
-        if   opt == "nearest"  : corr = self._nearest_neighbor
-        elif opt == "bivariate": corr = self._bivariate()
-        else: raise ValueError("Interpolation option not recognized: {}".format(opt))
+    def _define_interpolator(self, strategy, opts):
+        if   strategy == "nearest"  : corr = self._nearest_neighbor
+        elif strategy == "bivariate": corr = self._bivariate()
+        else: raise ValueError("Interpolation strategy not recognized: {}".format(stragegy))
 
         self._get_correction = corr
 

--- a/invisible_cities/reco/corrections.py
+++ b/invisible_cities/reco/corrections.py
@@ -9,6 +9,15 @@ from ..core.exceptions    import ParameterNotSet
 from .. evm.ic_containers import Measurement
 
 
+opt_nearest = {"interp_method": "nearest"}
+opt_linear  = {"interp_method": "linear" ,
+               "default_f"    :     1    ,
+               "default_u"    :     0    }
+opt_cubic   = {"interp_method":  "cubic" ,
+               "default_f"    :     1    ,
+               "default_u"    :     0    }
+
+
 class Correction:
     """
     Interface for accessing any kind of corrections.

--- a/invisible_cities/reco/corrections.py
+++ b/invisible_cities/reco/corrections.py
@@ -50,8 +50,8 @@ class Correction:
         self.default_f       = default_f
         self.default_u       = default_u
 
-        self._normalize(norm_strategy, norm_opts)
-        self._get_correction = self._define_interpolation(interp_strategy)
+        self._normalize          (  norm_strategy, norm_opts)
+        self._define_interpolator(interp_strategy)
 
     def __call__(self, *x):
         """
@@ -65,11 +65,12 @@ class Correction:
         """
         return Measurement(*self._get_correction(*x))
 
-    def _define_interpolation(self, opt):
+    def _define_interpolator(self, opt):
         if   opt == "nearest"  : corr = self._nearest_neighbor
         elif opt == "bivariate": corr = self._bivariate()
         else: raise ValueError("Interpolation option not recognized: {}".format(opt))
-        return corr
+
+        self._get_correction = corr
 
     def _normalize(self, strategy, opts):
         if not strategy            : return

--- a/invisible_cities/reco/corrections.py
+++ b/invisible_cities/reco/corrections.py
@@ -34,10 +34,10 @@ class Correction:
 
     def __init__(self,
                  xs, fs, us,
-                   norm_strategy = False,
-                   norm_opts     = None,
+                   norm_strategy = None,
+                   norm_opts     = {},
                  interp_strategy = "nearest",
-                 interp_opts     = None,
+                 interp_opts     = {},
                  default_f       = 0,
                  default_u       = 0):
 

--- a/invisible_cities/reco/corrections.py
+++ b/invisible_cities/reco/corrections.py
@@ -70,7 +70,7 @@ class Correction:
     def _define_interpolator(self, strategy, opts):
         if   strategy == "nearest"  : corr = self._nearest_neighbor
         elif strategy == "bivariate": corr = self._bivariate()
-        else: raise ValueError("Interpolation strategy not recognized: {}".format(stragegy))
+        else: raise ValueError("Interpolation strategy not recognized: {}".format(strategy))
 
         self._get_correction = corr
 
@@ -79,7 +79,7 @@ class Correction:
 
         elif   strategy == "const" :
             if "value" not in opts:
-                raise ParameterNotSet(("Normalization stratery 'const' requires"
+                raise ParameterNotSet(("Normalization strategy 'const' requires"
                                        "the normalization option 'value'"))
             f_ref = opts["value"]
             u_ref = 0
@@ -97,14 +97,14 @@ class Correction:
 
         elif   strategy == "index" :
             if "index" not in opts:
-                raise ParameterNotSet(("Normalization stratery 'index' requires"
+                raise ParameterNotSet(("Normalization strategy 'index' requires"
                                        "the normalization option 'index'"))
             index = opts["index"]
             f_ref = self._fs[index]
             u_ref = self._us[index]
 
         else:
-            raise ValueError("Normalization option not recognized: {}".format(strategy))
+            raise ValueError("Normalization strategy not recognized: {}".format(strategy))
 
         assert f_ref > 0, "Invalid reference value."
 

--- a/invisible_cities/reco/corrections.py
+++ b/invisible_cities/reco/corrections.py
@@ -44,10 +44,11 @@ class Correction:
         self._fs =  np.array(fs, dtype=float)
         self._us =  np.array(us, dtype=float)
 
-        self._interp_strategy = interp_strategy
-
-        self._default_f = default_f
-        self._default_u = default_u
+        self.norm_strategy   =   norm_strategy
+        self.norm_opts       =   norm_opts
+        self.interp_strategy = interp_strategy
+        self.default_f       = default_f
+        self.default_u       = default_u
 
         self._normalize(norm_strategy, norm_opts)
         self._get_correction = self._define_interpolation(interp_strategy)
@@ -116,8 +117,8 @@ class Correction:
         self._us[ valid] *= self._fs[valid]
 
         # Set invalid to defaults
-        self._fs[~valid]  = self._default_f
-        self._us[~valid]  = self._default_u
+        self._fs[~valid]  = self.default_f
+        self._us[~valid]  = self.default_u
 
     def _find_closest_indices(self, x, y):
         # Find the index of the closest value in y for each value in x.

--- a/invisible_cities/reco/corrections.py
+++ b/invisible_cities/reco/corrections.py
@@ -100,8 +100,8 @@ class Correction:
 
         elif   strategy == "const" :
             if "value" not in opts:
-                raise ParameterNotSet(("Normalization strategy 'const' requires"
-                                       "the normalization option 'value'"))
+                raise ParameterNotSet("Normalization strategy 'const' requires"
+                                      "the normalization option 'value'")
             f_ref = opts["value"]
             u_ref = 0
 
@@ -118,8 +118,8 @@ class Correction:
 
         elif   strategy == "index" :
             if "index" not in opts:
-                raise ParameterNotSet(("Normalization strategy 'index' requires"
-                                       "the normalization option 'index'"))
+                raise ParameterNotSet("Normalization strategy 'index' requires"
+                                      "the normalization option 'index'")
             index = opts["index"]
             f_ref = self._fs[index]
             u_ref = self._us[index]

--- a/invisible_cities/reco/corrections.py
+++ b/invisible_cities/reco/corrections.py
@@ -71,9 +71,15 @@ class Correction:
              Each array is one coordinate. The number of coordinates must match
              that of the `xs` array in the init method.
         """
-        x = np.array(xs, ndmin=2).T
-        return Measurement(self._get_value      (x).flatten(),
-                           self._get_uncertainty(x).flatten())
+        # In order for this to work well both for arrays and scalars
+        arrays = len(np.shape(xs)) > 1
+        if arrays:
+            xs = np.stack(xs, axis=1)
+
+        value  = self._get_value      (xs).flatten()
+        uncert = self._get_uncertainty(xs).flatten()
+        return (Measurement(value   , uncert   ) if arrays else
+                Measurement(value[0], uncert[0]))
 
     def _init_interpolator(self, method, default_f, default_u):
         coordinates           = np.array(list(product(*self._xs)))

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -20,6 +20,7 @@ from pytest        import raises
 from flaky         import flaky
 
 from hypothesis             import given
+from hypothesis             import settings
 from hypothesis.strategies  import floats
 from hypothesis.strategies  import integers
 from hypothesis.strategies  import composite
@@ -214,6 +215,18 @@ def test_correction_attributes_1d_unnormalized(toy_data_1d):
     assert_allclose(c._us, Fu)
 
 
+@settings(max_examples=1)
+@given(uniform_energy_1d())
+def test_correction_call_scalar_values_1d(toy_data_1d):
+    X, E, Eu, F, Fu, _ = toy_data_1d
+    correct  = Correction((X,), E, Eu,
+                          norm_strategy = "max",
+                          **opt_nearest)
+    F_corrected, U_corrected = correct(X[0])
+    assert F_corrected == F [0]
+    assert U_corrected == Fu[0]
+
+
 @given(uniform_energy_1d())
 def test_correction_call_1d(toy_data_1d):
     X, E, Eu, F, Fu, _ = toy_data_1d
@@ -307,6 +320,20 @@ def test_correction_attributes_2d_unnormalized(toy_data_2d):
 
     assert_allclose(c._fs, F )
     assert_allclose(c._us, Fu)
+
+
+@settings(max_examples=1)
+@given(uniform_energy_2d())
+def test_correction_call_scalar_values_2d(toy_data_2d):
+    X, Y, E, Eu, F, Fu, i_max, j_max = toy_data_2d
+    correct = Correction((X,Y), E, Eu,
+                         norm_strategy =  "index",
+                         norm_opts     = {"index": (i_max, j_max)},
+                         **opt_nearest)
+
+    F_corrected, U_corrected = correct(X[0], Y[0])
+    assert F_corrected == F [0]
+    assert U_corrected == Fu[0]
 
 
 @given(uniform_energy_2d())

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -9,6 +9,7 @@ from ..reco.corrections import Fcorrection
 from ..reco.corrections import LifetimeCorrection
 from ..reco.corrections import LifetimeRCorrection
 from ..reco.corrections import LifetimeXYCorrection
+from ..reco.corrections import opt_nearest
 
 from numpy.testing import assert_allclose
 from pytest        import fixture
@@ -128,7 +129,8 @@ def uniform_energy_fun_data_3d(draw):
                                                           max_value = 1e+3)))
     u_LTs   = LTs * 0.1
 
-    LTc     = Correction((X, Y), LTs, u_LTs)
+    LTc     = Correction((X, Y), LTs, u_LTs,
+                         **opt_nearest)
 
     def LT_corr(z, x, y):
         return np.exp(z / LTc(x, y).value)
@@ -173,7 +175,8 @@ def test_correction_raises_exception_when_input_is_incomplete(strategy, options)
     with raises(ParameterNotSet):
         Correction((data,), data, data,
                    norm_strategy = strategy,
-                   norm_opts     = options)
+                   norm_opts     = options,
+                   **opt_nearest)
 
 
 def test_correction_raises_exception_when_data_is_invalid():
@@ -184,14 +187,16 @@ def test_correction_raises_exception_when_data_is_invalid():
     with raises(AssertionError):
         Correction((x, y), z, u_z,
                    norm_strategy =  "index",
-                   norm_opts     = {"index": (0, 0)})
+                   norm_opts     = {"index": (0, 0)},
+                   **opt_nearest)
 
 
 @given(uniform_energy_1d())
 def test_correction_attributes_1d(toy_data_1d):
     X, E, Eu, F, Fu, _ = toy_data_1d
     correct  = Correction((X,), E, Eu,
-                          norm_strategy = "max")
+                          norm_strategy = "max",
+                          **opt_nearest)
     assert_allclose(correct._xs[0], X ) # correct.xs is a list of axis
     assert_allclose(correct._fs   , F )
     assert_allclose(correct._us   , Fu)
@@ -201,7 +206,8 @@ def test_correction_attributes_1d(toy_data_1d):
 def test_correction_attributes_1d_unnormalized(toy_data_1d):
     X, _, _, F, Fu, _ = toy_data_1d
     c = Correction((X,), F, Fu,
-                   norm_strategy = None)
+                   norm_strategy = None,
+                   **opt_nearest)
     assert_allclose(c._fs, F )
     assert_allclose(c._us, Fu)
 
@@ -210,7 +216,8 @@ def test_correction_attributes_1d_unnormalized(toy_data_1d):
 def test_correction_call_1d(toy_data_1d):
     X, E, Eu, F, Fu, _ = toy_data_1d
     correct  = Correction((X,), E, Eu,
-                          norm_strategy = "max")
+                          norm_strategy = "max",
+                          **opt_nearest)
     F_corrected, U_corrected = correct(X)
     assert_allclose(F_corrected, F )
     assert_allclose(U_corrected, Fu)
@@ -220,7 +227,8 @@ def test_correction_call_1d(toy_data_1d):
 def test_correction_normalization_1d_to_max(toy_data_1d):
     X, E, Eu, *_, i_max = toy_data_1d
     correct  = Correction((X,), E, Eu,
-                          norm_strategy = "max")
+                          norm_strategy = "max",
+                          **opt_nearest)
 
     x_test = X
     corrected_E = E * correct(x_test).value
@@ -233,7 +241,9 @@ def test_correction_normalization_1d_to_const(toy_data_1d, norm_value):
     X, E, Eu, _, _, _ = toy_data_1d
     c = Correction((X,), E, Eu,
                    norm_strategy = "const",
-                   norm_opts     = {"value": norm_value})
+                   norm_opts     = {"value": norm_value},
+                   **opt_nearest)
+
     assert_allclose(c._fs, norm_value / E)
     assert_allclose(c._us, norm_value / E**2 * Eu)
 
@@ -249,6 +259,7 @@ def test_correction_normalization_to_center_1d(toy_data_1d):
     norm_uncer = Eu[norm_index]
     prop_uncer = (Eu / E)**2 + (norm_uncer / norm_value)**2
     prop_uncer = prop_uncer**0.5 * norm_value / E
+
     assert_allclose(c._fs, norm_value / E)
     assert_allclose(c._us, prop_uncer    )
 
@@ -264,6 +275,7 @@ def test_correction_normalization_to_center_2d(toy_data_2d):
     norm_uncer = Eu[norm_index]
     prop_uncer = (Eu / E)**2 + (norm_uncer / norm_value)**2
     prop_uncer = prop_uncer**0.5 * norm_value / E
+
     assert_allclose(c._fs, norm_value / E)
     assert_allclose(c._us, prop_uncer    )
 
@@ -273,14 +285,10 @@ def test_correction_normalization_to_center_2d(toy_data_2d):
 @given(uniform_energy_2d())
 def test_correction_attributes_2d(toy_data_2d):
     X, Y, E, Eu, F, Fu, i_max, j_max = toy_data_2d
-<<<<<<< 571dddbf9cd59d7cca3a655b5e08fa4357a2d015
-    interp_strategy="nearest"
     correct = Correction((X, Y), E, Eu,
-=======
-    correct = Correction((X,Y), E, Eu,
->>>>>>> Adapt tests to new arguments
-                           norm_strategy =  "index",
-                           norm_opts     = {"index": (i_max, j_max)})
+                         norm_strategy =  "index",
+                         norm_opts     = {"index": (i_max, j_max)},
+                         **opt_nearest)
 
     # attributes of the Correction class are 2d arrays,
     # so they must be flatten for comparison
@@ -292,7 +300,9 @@ def test_correction_attributes_2d(toy_data_2d):
 def test_correction_attributes_2d_unnormalized(toy_data_2d):
     X, Y, _, _, F, Fu, _, _ = toy_data_2d
     c = Correction((X, Y), F, Fu,
-                   norm_strategy = None)
+                   norm_strategy = None,
+                   **opt_nearest)
+
     assert_allclose(c._fs, F )
     assert_allclose(c._us, Fu)
 
@@ -314,7 +324,8 @@ def test_correction_call_2d(toy_data_2d):
     X, Y, E, Eu, F, Fu, i_max, j_max = toy_data_2d
     correct = Correction((X, Y), E, Eu,
                          norm_strategy =  "index",
-                         norm_opts     = {"index": (i_max, j_max)})
+                         norm_opts     = {"index": (i_max, j_max)},
+                         **opt_nearest)
 
     # create a collection of (x,y) point such that the
     # x coordinates are stored in X_sample and the y coordinates in Y_sample
@@ -366,7 +377,7 @@ def test_lifetimeXYcorrection(toy_f_data):
     Y       = np.tile    (Ygrid, Xgrid.size)
     Z       = np.linspace(0, 50, X    .size)
     F, u_F  = LT_corr(Z, X, Y), u_LT_corr(Z, X, Y)
-    correct = LifetimeXYCorrection(LTs, u_LTs, Xgrid, Ygrid)
+    correct = LifetimeXYCorrection(LTs, u_LTs, Xgrid, Ygrid, **opt_nearest)
     f_corrected, u_corrected = correct(Z, X, Y)
 
     assert_allclose(  F, f_corrected)
@@ -377,7 +388,8 @@ def test_lifetimeXYcorrection(toy_f_data):
 def test_lifetimeXYcorrection_kwargs(toy_f_data):
     Xgrid, Ygrid, LTs, u_LTs, LTs, u_LTs, LT_corr, u_LT_corr = toy_f_data
     kwargs = {"norm_strategy" :  "const",
-              "norm_opts"     : {"value": 1}}
+              "norm_opts"     : {"value": 1},
+              **opt_nearest}
 
     X       = np.repeat  (Xgrid, Ygrid.size)
     Y       = np.tile    (Ygrid, Xgrid.size)
@@ -403,7 +415,8 @@ def test_corrections_1d(gauss_data_1d):
     Z, E, Eu, Zevt, Eevt = gauss_data_1d
 
     correct = Correction((Z,), E, Eu,
-                         norm_strategy = "max")
+                         norm_strategy = "max",
+                         **opt_nearest)
     Eevt   *= correct(Zevt).value
 
     mean = np.mean(Eevt)
@@ -423,7 +436,8 @@ def test_corrections_2d(gauss_data_2d):
     X, Y, E, Eu, Xevt, Yevt, Eevt = gauss_data_2d
     correct = Correction((X, Y), E, Eu,
                          norm_strategy =  "index",
-                         norm_opts     = {"index": (25, 25)})
+                         norm_opts     = {"index": (25, 25)},
+                         **opt_nearest)
     Eevt   *= correct(Xevt, Yevt)[0]
 
     mean = np.mean(Eevt)

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -11,6 +11,7 @@ from ..reco.corrections import LifetimeRCorrection
 from ..reco.corrections import LifetimeXYCorrection
 from ..reco.corrections import opt_nearest
 from ..reco.corrections import opt_linear
+from ..reco.corrections import opt_cubic
 
 from numpy.testing import assert_allclose
 from pytest        import fixture
@@ -471,6 +472,39 @@ def test_corrections_linear_interpolation():
                          grid_values,
                          grid_uncert,
                          **opt_linear)
+
+    x_test  = np.random.uniform(xmin, xmax, size=100)
+    y_test  = np.random.uniform(ymin, ymax, size=100)
+    xy_test = np.stack([x_test, y_test], axis=1)
+
+    correction      = correct(x_test, y_test)
+    expected_values = np.apply_along_axis(grid_fun, 1, xy_test)
+    expected_uncert = expected_values/10
+
+    assert np.allclose(correction.value      , expected_values)
+    assert np.allclose(correction.uncertainty, expected_uncert)
+
+
+def test_corrections_cubic_interpolation():
+    # This is the function f(x,y) = x + y on a square grid. Because the
+    # interpolation is cubic, any point with coordinates (x, y) should
+    # yield exactly f(x, y). This test should probably contain a more
+    # complicated function.
+    xmin, xmax  = 10, 20
+    ymin, ymax  = 20, 30
+    grid_x      = np.arange(xmin, xmax + 1)
+    grid_y      = np.arange(ymin, ymax + 1)
+    grid_points = np.array([(i, j) for i in grid_x\
+                                   for j in grid_y])
+
+    grid_fun    = np.sum
+    grid_values = np.apply_along_axis(grid_fun, 1, grid_points)
+    grid_uncert = np.apply_along_axis(grid_fun, 1, grid_points)/10
+
+    correct = Correction((grid_x, grid_y),
+                         grid_values,
+                         grid_uncert,
+                         **opt_cubic)
 
     x_test  = np.random.uniform(xmin, xmax, size=100)
     y_test  = np.random.uniform(ymin, ymax, size=100)

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -53,7 +53,7 @@ def uniform_energy_1d(draw):
 
 
 @composite
-def uniform_energy_2d(draw, interp_strategy="nearest"):
+def uniform_energy_2d(draw):
     x_size  = draw(integers(min_value=2   , max_value=10 ))
     y_size  = draw(integers(min_value=2   , max_value=10 ))
     X0      = draw(floats  (min_value=-100, max_value=100))
@@ -273,11 +273,14 @@ def test_correction_normalization_to_center_2d(toy_data_2d):
 @given(uniform_energy_2d())
 def test_correction_attributes_2d(toy_data_2d):
     X, Y, E, Eu, F, Fu, i_max, j_max = toy_data_2d
+<<<<<<< 571dddbf9cd59d7cca3a655b5e08fa4357a2d015
     interp_strategy="nearest"
     correct = Correction((X, Y), E, Eu,
+=======
+    correct = Correction((X,Y), E, Eu,
+>>>>>>> Adapt tests to new arguments
                            norm_strategy =  "index",
-                           norm_opts     = {"index": (i_max, j_max)},
-                         interp_strategy = interp_strategy)
+                           norm_opts     = {"index": (i_max, j_max)})
 
     # attributes of the Correction class are 2d arrays,
     # so they must be flatten for comparison
@@ -309,11 +312,9 @@ def test_correction_normalization_2d_to_max(toy_data_2d):
 @given(uniform_energy_2d())
 def test_correction_call_2d(toy_data_2d):
     X, Y, E, Eu, F, Fu, i_max, j_max = toy_data_2d
-    interp_strategy="nearest"
     correct = Correction((X, Y), E, Eu,
-                           norm_strategy =  "index",
-                           norm_opts     = {"index": (i_max, j_max)},
-                         interp_strategy = interp_strategy)
+                         norm_strategy =  "index",
+                         norm_opts     = {"index": (i_max, j_max)})
 
     # create a collection of (x,y) point such that the
     # x coordinates are stored in X_sample and the y coordinates in Y_sample


### PR DESCRIPTION
This PR revisits the interpolation section of the `Correction` class. The main changes are:
- Major refactoring: A chunk of code that performed interpolation has been replaced by a handy function from `scipy`
- As a result, the linear and cubic interpolations are directly available.
- The output of the `__call__` method is consistent with the types of the input. Namely, if the inputs are arrays (scalars), the output contains arrays (scalars).
- Tests for all of the above
- Cosmetics, as usual