### PR TITLE
Fix `test_noise_sampler_compute_thresholds`

### DIFF
--- a/invisible_cities/core/random_sampling.py
+++ b/invisible_cities/core/random_sampling.py
@@ -62,7 +62,7 @@ class NoiseSampler:
         """
         (self.probs,
          self.xbins,
-         self.baselines) = DB.SiPMNoise()
+         self.baselines) = DB.SiPMNoise(run_number)
         self.nsamples    = sample_size
         self.smear       = smear
         self.active      = DB.DataSiPM(run_number).Active.values[:, np.newaxis]

--- a/invisible_cities/core/random_sampling_test.py
+++ b/invisible_cities/core/random_sampling_test.py
@@ -231,7 +231,7 @@ def test_noise_sampler_compute_thresholds(datasipm, noise_sampler, pes_to_adc, a
     if as_array:
         pes_to_adc *= np.ones(len(datasipm))
 
-    thresholds       = noise_sampler.compute_thresholds(0.99, pes_to_adc)
+    thresholds       = noise_sampler.compute_thresholds(thr, pes_to_adc)
     threshold_counts = np.unique(thresholds, return_counts = True)
     threshold_counts = dict(zip(*threshold_counts))
 

--- a/invisible_cities/core/random_sampling_test.py
+++ b/invisible_cities/core/random_sampling_test.py
@@ -221,7 +221,7 @@ def test_noise_sampler_take_sample(datasipm, noise_sampler):
 
 
 @mark.parametrize("pes_to_adc",
-                  (1, 2.5, 10, 25.4))
+                  (0.25, 1, 2.5, 10))
 @mark.parametrize("as_array",
                   (False, True))
 def test_noise_sampler_compute_thresholds(datasipm, noise_sampler, pes_to_adc, as_array):

--- a/invisible_cities/core/random_sampling_test.py
+++ b/invisible_cities/core/random_sampling_test.py
@@ -150,7 +150,7 @@ def test_inverse_cdf_hypothesis_generated(distribution, percentile):
 
 @fixture(scope="module")
 def run_number():
-    return 4651
+    return 4714
 
 @fixture(scope="module")
 def datasipm(run_number):

--- a/invisible_cities/core/random_sampling_test.py
+++ b/invisible_cities/core/random_sampling_test.py
@@ -171,9 +171,7 @@ def noise_sampler(request, run_number):
     1.35  :   8,
     1.45  :   6,
     1.55  :   3,
-    2.05  :   1,
-    np.inf:   8}
-
+    np.inf:   9}
     return (NoiseSampler(run_number, nsamples, smear),
             nsamples, smear,
             thr, true_threshold_counts)
@@ -212,7 +210,7 @@ def test_noise_sampler_take_sample(datasipm, noise_sampler):
         sample = samples[i]
         if active:
             if smear:
-                # Find closest energy bin and ensure it is close enough.
+                # Find closest energy bin and ensure it is close enough.
                 diffs      = noise_sampler.xbins - sample[:, np.newaxis]
                 closest    = np.min(np.abs(diffs), axis=1)
                 assert np.all(closest <= noise_sampler.dx)
@@ -221,7 +219,7 @@ def test_noise_sampler_take_sample(datasipm, noise_sampler):
         else:
             assert not np.any(sample)
 
-@mark.skip
+
 @mark.parametrize("pes_to_adc",
                   (1, 2.5, 10, 25.4))
 @mark.parametrize("as_array",
@@ -236,6 +234,7 @@ def test_noise_sampler_compute_thresholds(datasipm, noise_sampler, pes_to_adc, a
     thresholds       = noise_sampler.compute_thresholds(0.99, pes_to_adc)
     threshold_counts = np.unique(thresholds, return_counts = True)
     threshold_counts = dict(zip(*threshold_counts))
+
     assert sorted(true_threshold_counts) == sorted(threshold_counts)
     for i, truth in true_threshold_counts.items():
         assert truth == threshold_counts[i]


### PR DESCRIPTION
This test was failing because of an unexpected change in the
database. The test relies ultimately on the data provided by the
database, which was, in a way, hard-coded in a fixture.