### PR TITLE
Let voxels have variable size event by event.

### DIFF
--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -124,20 +124,9 @@ def test_voxelize_hits_keeps_bounding_box(hits, voxel_dimensions):
 
 
 @given(bunch_of_hits, box_sizes)
-def test_voxelize_hits_respects_voxel_dimensions(hits, requested_voxel_dimensions):
-    voxels = voxelize_hits(hits, requested_voxel_dimensions)
-    unit   =                     requested_voxel_dimensions
-    for v1, v2 in combinations(voxels, 2):
-        distance_between_voxels = np.array(v2.XYZ) - np.array(v1.XYZ)
-        off_by = distance_between_voxels % requested_voxel_dimensions
-        assert (np.isclose(off_by, 0   ) |
-                np.isclose(off_by, unit)).all()
-
-
-@given(bunch_of_hits, box_sizes)
 def test_make_voxel_graph_keeps_all_voxels(hits, voxel_dimensions):
     voxels = voxelize_hits    (hits  , voxel_dimensions)
-    tracks = make_track_graphs(voxels, voxel_dimensions)
+    tracks = make_track_graphs(voxels)
     voxels_in_tracks = set().union(*(set(t.nodes_iter()) for t in tracks))
     assert set(voxels) == voxels_in_tracks
 
@@ -203,7 +192,7 @@ def track_extrema():
     )
     vox_size = np.array([1,1,1])
     voxels = [Voxel(x,y,z, E, vox_size) for (x,y,z,E) in voxel_spec]
-    tracks  = make_track_graphs(voxels, vox_size)
+    tracks  = make_track_graphs(voxels)
 
     assert len(tracks) == 1
     extrema = find_extrema(tracks[0])
@@ -250,7 +239,7 @@ def test_length():
                   (10,15,15,1)
     )
     voxels = [Voxel(x,y,z, E, np.array([1,1,1])) for (x,y,z,E) in voxel_spec]
-    tracks  = make_track_graphs(voxels, np.array([1,1,1]))
+    tracks  = make_track_graphs(voxels)
 
     assert len(tracks) == 1
     track_length = length(tracks[0])
@@ -273,7 +262,7 @@ def test_length_around_bend(contiguity, expected_length):
                   (0,2,0))
     vox_size = np.array([1,1,1])
     voxels = [Voxel(x,y,z, 1, vox_size) for x,y,z in voxel_spec]
-    tracks = make_track_graphs(voxels, vox_size, contiguity=contiguity)
+    tracks = make_track_graphs(voxels, contiguity=contiguity)
     assert len(tracks) == 1
     track_length = length(tracks[0])
     assert track_length == approx(expected_length)
@@ -294,7 +283,7 @@ def test_length_cuts_corners(contiguity, expected_length):
                   (1,1,1)) # Extremum 2
     vox_size = np.array([1,1,1])
     voxels = [Voxel(x,y,z, 1, vox_size) for x,y,z in voxel_spec]
-    tracks = make_track_graphs(voxels, vox_size, contiguity=contiguity)
+    tracks = make_track_graphs(voxels, contiguity=contiguity)
     assert len(tracks) == 1
     track_length = length(tracks[0])
     assert track_length == approx(expected_length)
@@ -333,5 +322,5 @@ def test_contiguity(proximity, contiguity, are_neighbours):
                                                (2,0,0)) )[proximity]
     expected_number_of_tracks = 1 if are_neighbours else 2
     voxels = [Voxel(x,y,z, 1, np.array([1,1,1])) for x,y,z in voxel_spec]
-    tracks = make_track_graphs(voxels, np.array([1,1,1]), contiguity=contiguity)
+    tracks = make_track_graphs(voxels, contiguity=contiguity)
     assert len(tracks) == expected_number_of_tracks


### PR DESCRIPTION
This PR addresses issue #389. A fixed voxelization for all the events is not optimal and, in fact, it turns out to have a big impact in the blob definition. Therefore, in this PR the method voxelize_hits has been changed in order to allow voxels to have a variable size that is at most as large as the size used as an input. Contiguity is calculated according to this event-by-event variable voxel size. @jerenner, once this PR will be approved, we need to use this code for the analysis, since the one we were using until now didn't calculate contiguity correctly.