### PR TITLE
Fix normalization option "max" for N-dimensional corrections

### DIFF
--- a/invisible_cities/reco/corrections.py
+++ b/invisible_cities/reco/corrections.py
@@ -79,9 +79,10 @@ class Correction:
             u_ref = 0
 
         elif   strategy == "max"  :
-            index = np.argmax(self._fs)
-            f_ref = self._fs[index]
-            u_ref = self._us[index]
+            flat_index = np.argmax(self._fs)
+            mult_index = np.unravel_index(flat_index, self._fs.shape)
+            f_ref = self._fs[mult_index]
+            u_ref = self._us[mult_index]
 
         elif   strategy == "index":
             if "index" not in opts:

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -218,8 +218,10 @@ def test_correction_normalization_1d_to_max(toy_data_1d):
     X, E, Eu, *_, i_max = toy_data_1d
     correct  = Correction((X,), E, Eu,
                           norm_strategy = "max")
-    X_test  = X[i_max]
-    assert_allclose(correct(X_test).value, 1) # correct.xs is a list of axis
+
+    x_test = X
+    corrected_E = E * correct(x_test).value
+    assert_allclose(corrected_E, np.max(E))
 
 
 @given(uniform_energy_1d(),

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -262,6 +262,18 @@ def test_correction_attributes_2d_unnormalized(toy_data_2d):
 
 
 @given(uniform_energy_2d())
+def test_correction_normalization_2d_to_max(toy_data_2d):
+    X, Y, E, Eu, *_, i_max = toy_data_2d
+    correct  = Correction((X, Y), E, Eu,
+                          norm_strategy = "max")
+
+    x_test      = np.repeat(X, Y.size)
+    y_test      = np.tile  (Y, X.size)
+    corrected_E = E.flatten() * correct(x_test, y_test).value
+    assert_allclose(corrected_E, np.max(E))
+
+
+@given(uniform_energy_2d())
 def test_correction_call_2d(toy_data_2d):
     X, Y, E, Eu, F, Fu, i_max, j_max = toy_data_2d
     interp_strategy="nearest"

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -214,7 +214,7 @@ def test_correction_call_1d(toy_data_1d):
 
 
 @given(uniform_energy_1d())
-def test_correction_normalization(toy_data_1d):
+def test_correction_normalization_1d_to_max(toy_data_1d):
     X, E, Eu, *_, i_max = toy_data_1d
     correct  = Correction((X,), E, Eu,
                           norm_strategy = "max")
@@ -224,7 +224,7 @@ def test_correction_normalization(toy_data_1d):
 
 @given(uniform_energy_1d(),
        floats  (min_value=1e-8, max_value=1e8))
-def test_correction_normalization_to_const(toy_data_1d, norm_value):
+def test_correction_normalization_1d_to_const(toy_data_1d, norm_value):
     X, E, Eu, _, _, _ = toy_data_1d
     c = Correction((X,), E, Eu,
                    norm_strategy = "const",


### PR DESCRIPTION
The normalization option "max" was failing when used in corrections with more than 1 dimension. This was not detected before because we didn't have a test for that case (shame on me!). This PR adds that test, which also demonstrates the bug and fixes it.