### PR TITLE
Fix overflow warning

### DIFF
--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -104,7 +104,7 @@ def uniform_energy_fun_data_2d(draw):
 
     a     = draw(floats(min_value=1e+2, max_value=1e+3));u_a = 0.1*a
     b     = draw(floats(min_value=1e-2, max_value=1e-1));u_b = 0.1*b
-    c     = draw(floats(min_value=1e+1, max_value=1e+2));u_c = 0.1*c
+    c     = draw(floats(min_value=1e+3, max_value=5e+3));u_c = 0.1*c
     Z     = np.linspace(0, 600, 100)
     R     = np.linspace(0, 200, 100)
     F     =   fun(Z, R, a, b, c, u_a, u_b, u_c)


### PR DESCRIPTION
A test was raising an overflow warning continuously due to the use of
a small value within an exponential function. This commit makes
that value a bit bigger so the warning is not raised, but the test
remains the same.