### PR TITLE
Fix `test_weighted_mean_and_var_unbiased_frequentist`

### DIFF
--- a/invisible_cities/core/core_functions_test.py
+++ b/invisible_cities/core/core_functions_test.py
@@ -101,9 +101,8 @@ def test_weighted_mean_and_var_gaussian_function(mu, sigma, ndata):
 
 @flaky(max_runs   = 4,
        min_passes = 3)
-@given(integers(min_value=5, max_value=20))
-def test_weighted_mean_and_var_unbiased_frequentist(ndata):
-    mu, sigma = 100, 1
+def test_weighted_mean_and_var_unbiased_frequentist():
+    mu, sigma, ndata = 100, 1, np.random.randint(5, 20)
     data = np.random.normal(mu, sigma, size=ndata)
     values, freqs = np.unique(data, return_counts=True)
 


### PR DESCRIPTION
This test was failing frequently due to the lack of compatibility
between hypothesis and flaky modules. This has ben fixed by replacing
the hypothesis dependence with a random number.