### PR TITLE
Small fixes in fit functions

### DIFF
--- a/invisible_cities/core/fit_functions.py
+++ b/invisible_cities/core/fit_functions.py
@@ -128,6 +128,8 @@ def fit(func, x, y, seed=(), fit_range=None, **kwargs):
         if "sigma" in kwargs:
             kwargs["sigma"] = kwargs["sigma"][sel]
 
+    sigma_r = kwargs.get("sigma", np.ones_like(y))
+
     abs_sigma = "sigma" in kwargs
 
     vals, cov = scipy.optimize.curve_fit(func,
@@ -136,17 +138,13 @@ def fit(func, x, y, seed=(), fit_range=None, **kwargs):
                                          absolute_sigma = abs_sigma,
                                          **kwargs)
 
-    fitf    = lambda x: func(x, *vals)
-    fitx    = fitf(x)
-    nonzero = fitx != 0
+    fitf  = lambda x: func(x, *vals)
+    fitx  = fitf(x)
 
-    sigma_r = kwargs.get("sigma", np.ones_like(y))
-    sigma_r = sigma_r[nonzero]
-
-    chi2, pval = get_chi2_and_pvalue(y    [nonzero],
-                                     fitx [nonzero],
-                                     len(y[nonzero]) - len(vals),
-                                     sigma_r)
+    chi2, pval = get_chi2_and_pvalue(y                 ,
+                                     fitx              ,
+                                     len(y) - len(vals),
+                                     sigma_r           )
 
     return FitFunction(fitf,
                        vals,

--- a/invisible_cities/core/fit_functions.py
+++ b/invisible_cities/core/fit_functions.py
@@ -10,6 +10,7 @@ import scipy.stats
 
 from . import core_functions as coref
 from .. evm.ic_containers    import FitFunction
+from ..icaro.hst_functions   import poisson_sigma
 
 def get_errors(cov):
     """
@@ -55,7 +56,7 @@ def get_chi2_and_pvalue(ydata, yfit, ndf, sigma=None):
     """
 
     if sigma is None:
-        sigma = ydata**0.5
+        sigma = poisson_sigma(ydata)
 
     chi2   = np.sum(((ydata - yfit) / sigma)**2)
     pvalue = scipy.stats.chi2.sf(chi2, ndf)

--- a/invisible_cities/core/fit_functions_test.py
+++ b/invisible_cities/core/fit_functions_test.py
@@ -72,7 +72,7 @@ def test_fit_raises_ValueError_when_negative_or_zero_value_in_sigma(ey):
     def dummy(x, m):
         return m
 
-    x  = np.array([0  , 1])
+    x  = np.array([0  , 1  ])
     y  = np.array([4.1, 4.2])
     ey = np.full_like(y, ey)
 

--- a/invisible_cities/core/fit_functions_test.py
+++ b/invisible_cities/core/fit_functions_test.py
@@ -5,6 +5,7 @@ Tests for fit_functions
 import numpy as np
 from pytest import mark
 from pytest import approx
+from pytest import raises
 from flaky  import flaky
 
 from numpy.testing import assert_array_equal
@@ -64,6 +65,19 @@ def test_get_chi2_and_pvalue_gauss_errors(mean, sigma):
     chi2, pvalue = fitf.get_chi2_and_pvalue(ydata, mean, Nevt-1, sigma)
 
     assert chi2 == approx(1, rel=1e-2)
+
+
+@mark.parametrize("ey", (0, -1, -100))
+def test_fit_raises_ValueError_when_negative_or_zero_value_in_sigma(ey):
+    def dummy(x, m):
+        return m
+
+    x  = np.array([0  , 1])
+    y  = np.array([4.1, 4.2])
+    ey = np.full_like(y, ey)
+
+    with raises(ValueError):
+        fitf.fit(dummy, x, y, seed=(4,), sigma=ey)
 
 
 def test_chi2_str_line():


### PR DESCRIPTION
These are just small changes that remained from PR #359:
    - Some Cosmetics.
    - Removing a non-zero selection in fit function, no longer necessary.
    - Adding a test that demonstrates that invalid values for sigma were accepted.
    - Correcting correspondingly the code for checking invalid values in sigma.