### PR TITLE
Switchable voxel size strictness

### DIFF
--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -32,7 +32,8 @@ def bounding_box(seq : BHit) -> Sequence[np.ndarray]:
 
 
 def voxelize_hits(hits             : Sequence[BHit],
-                  voxel_dimensions : np.ndarray) -> List[Voxel]:
+                  voxel_dimensions : np.ndarray,
+                  strict_voxel_size: bool = True) -> List[Voxel]:
     """1. Hits are enclosed by a bounding box.
        2. Boundix box is discretized (via a hitogramdd).
        3. The energy of all the hits insidex each discreet "voxel" is added.
@@ -44,8 +45,10 @@ def voxelize_hits(hits             : Sequence[BHit],
     bounding_box_size   =  hhi - hlo
     number_of_voxels = np.ceil(bounding_box_size / voxel_dimensions).astype(int)
     number_of_voxels = np.clip(number_of_voxels, a_min=1, a_max=None)
-    voxel_edges_lo = bounding_box_centre - number_of_voxels * voxel_dimensions / 2
-    voxel_edges_hi = bounding_box_centre + number_of_voxels * voxel_dimensions / 2
+    if strict_voxel_size: half_range = number_of_voxels * voxel_dimensions / 2
+    else                : half_range =          bounding_box_size          / 2
+    voxel_edges_lo = bounding_box_centre - half_range
+    voxel_edges_hi = bounding_box_centre + half_range
 
     # Expand the voxels a tiny bit, in order to include hits which
     # fall within the margin of error of the voxel bounding box.

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -78,7 +78,6 @@ class Contiguity(Enum):
 
 
 def make_track_graphs(voxels           : Voxel,
-                      voxel_dimensions : np.ndarray,
                       contiguity       : Contiguity = Contiguity.CORNER) -> Sequence[Graph]:
     """Create a graph where the voxels are the nodes and the edges are any
     pair of neighbour voxel. Two voxels are considered to be
@@ -87,7 +86,7 @@ def make_track_graphs(voxels           : Voxel,
     """
 
     def neighbours(va : Voxel, vb : Voxel) -> bool:
-        return np.linalg.norm((va.pos - vb.pos) / voxel_dimensions) < contiguity.value
+        return np.linalg.norm((va.pos - vb.pos) / va.size) < contiguity.value
 
     voxel_graph = nx.Graph()
     voxel_graph.add_nodes_from(voxels)

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -33,7 +33,7 @@ def bounding_box(seq : BHit) -> Sequence[np.ndarray]:
 
 def voxelize_hits(hits             : Sequence[BHit],
                   voxel_dimensions : np.ndarray,
-                  strict_voxel_size: bool = True) -> List[Voxel]:
+                  strict_voxel_size: bool = False) -> List[Voxel]:
     """1. Hits are enclosed by a bounding box.
        2. Boundix box is discretized (via a hitogramdd).
        3. The energy of all the hits insidex each discreet "voxel" is added.

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -125,7 +125,7 @@ def test_voxelize_hits_keeps_bounding_box(hits, voxel_dimensions):
 
 @given(bunch_of_hits, box_sizes)
 def test_voxelize_hits_respects_voxel_dimensions(hits, requested_voxel_dimensions):
-    voxels = voxelize_hits(hits, requested_voxel_dimensions)
+    voxels = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=True)
     unit   =                     requested_voxel_dimensions
     for v1, v2 in combinations(voxels, 2):
         distance_between_voxels = np.array(v2.XYZ) - np.array(v1.XYZ)

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -133,11 +133,17 @@ def test_voxelize_hits_respects_voxel_dimensions(hits, requested_voxel_dimension
         assert (np.isclose(off_by, 0   ) |
                 np.isclose(off_by, unit)).all()
 
+@given(bunch_of_hits, box_sizes)
+def test_voxelize_hits_gives_voxels_correct_size(hits, requested_voxel_dimensions):
+    voxels = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False)
+    for v in voxels:
+        assert (v.size != requested_voxel_dimensions).all()
+
 
 @given(bunch_of_hits, box_sizes)
 def test_make_voxel_graph_keeps_all_voxels(hits, voxel_dimensions):
     voxels = voxelize_hits    (hits  , voxel_dimensions)
-    tracks = make_track_graphs(voxels, voxel_dimensions)
+    tracks = make_track_graphs(voxels)
     voxels_in_tracks = set().union(*(set(t.nodes_iter()) for t in tracks))
     assert set(voxels) == voxels_in_tracks
 
@@ -203,7 +209,7 @@ def track_extrema():
     )
     vox_size = np.array([1,1,1])
     voxels = [Voxel(x,y,z, E, vox_size) for (x,y,z,E) in voxel_spec]
-    tracks  = make_track_graphs(voxels, vox_size)
+    tracks  = make_track_graphs(voxels)
 
     assert len(tracks) == 1
     extrema = find_extrema(tracks[0])
@@ -250,7 +256,7 @@ def test_length():
                   (10,15,15,1)
     )
     voxels = [Voxel(x,y,z, E, np.array([1,1,1])) for (x,y,z,E) in voxel_spec]
-    tracks  = make_track_graphs(voxels, np.array([1,1,1]))
+    tracks  = make_track_graphs(voxels)
 
     assert len(tracks) == 1
     track_length = length(tracks[0])
@@ -273,7 +279,7 @@ def test_length_around_bend(contiguity, expected_length):
                   (0,2,0))
     vox_size = np.array([1,1,1])
     voxels = [Voxel(x,y,z, 1, vox_size) for x,y,z in voxel_spec]
-    tracks = make_track_graphs(voxels, vox_size, contiguity=contiguity)
+    tracks = make_track_graphs(voxels, contiguity=contiguity)
     assert len(tracks) == 1
     track_length = length(tracks[0])
     assert track_length == approx(expected_length)
@@ -294,7 +300,7 @@ def test_length_cuts_corners(contiguity, expected_length):
                   (1,1,1)) # Extremum 2
     vox_size = np.array([1,1,1])
     voxels = [Voxel(x,y,z, 1, vox_size) for x,y,z in voxel_spec]
-    tracks = make_track_graphs(voxels, vox_size, contiguity=contiguity)
+    tracks = make_track_graphs(voxels, contiguity=contiguity)
     assert len(tracks) == 1
     track_length = length(tracks[0])
     assert track_length == approx(expected_length)
@@ -333,5 +339,6 @@ def test_contiguity(proximity, contiguity, are_neighbours):
                                                (2,0,0)) )[proximity]
     expected_number_of_tracks = 1 if are_neighbours else 2
     voxels = [Voxel(x,y,z, 1, np.array([1,1,1])) for x,y,z in voxel_spec]
-    tracks = make_track_graphs(voxels, np.array([1,1,1]), contiguity=contiguity)
+    tracks = make_track_graphs(voxels, contiguity=contiguity)
     assert len(tracks) == expected_number_of_tracks
+    

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -89,7 +89,7 @@ def test_bounding_box(hits):
 
 @given(bunch_of_hits, box_sizes)
 def test_voxelize_hits_does_not_lose_energy(hits, voxel_dimensions):
-    voxels = voxelize_hits(hits, voxel_dimensions)
+    voxels = voxelize_hits(hits, voxel_dimensions, strict_voxel_size=False)
 
     if not hits:
         assert voxels == []

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -134,10 +134,16 @@ def test_voxelize_hits_respects_voxel_dimensions(hits, requested_voxel_dimension
                 np.isclose(off_by, unit)).all()
 
 @given(bunch_of_hits, box_sizes)
-def test_voxelize_hits_gives_voxels_correct_size(hits, requested_voxel_dimensions):
+def test_voxelize_hits_gives_maximum_voxels_size(hits, requested_voxel_dimensions):
     voxels = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False)
     for v in voxels:
-        assert (v.size != requested_voxel_dimensions).all()
+        assert (v.size <= requested_voxel_dimensions).all()
+
+@given(bunch_of_hits, box_sizes)
+def test_voxelize_hits_strict_gives_required_voxels_size(hits, requested_voxel_dimensions):
+    voxels = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=True)
+    for v in voxels:
+        assert v.size == approx(requested_voxel_dimensions)
 
 
 @given(bunch_of_hits, box_sizes)


### PR DESCRIPTION
Originally, `voxelize_hits` created voxels slightly smaller than the required voxel size.
We have added the option of using voxels of strict size. It seems that this worsen the results of 2-blob discrimination for the cases we have tried, but we want to keep the flexibility for future investigation.

Fixes #396.