### PR TITLE
Eliminate misleading dependence on voxel size from functions

### DIFF
--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -174,7 +174,8 @@ def make_tracks(evt_number       : float,
                 blob_radius      : float = 30 * units.mm) -> TrackCollection:
     """Make a track collection."""
     tc = TrackCollection(evt_number, evt_time) # type: TrackCollection
-    track_graphs = make_track_graphs(voxels, voxel_dimensions) # type: Sequence[Graph]
+    track_graphs = make_track_graphs(voxels) # type: Sequence[Graph]
+#    track_graphs = make_track_graphs(voxels, voxel_dimensions) # type: Sequence[Graph]
     for trk in track_graphs:
         a, b, voxels_a, voxels_b    = compute_blobs(trk, blob_radius)
         blob_a = Blob(a, voxels_a) # type: Blob

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -307,6 +307,7 @@ def test_length_cuts_corners(contiguity, expected_length):
     vox_size = np.array([1,1,1])
     voxels = [Voxel(x,y,z, 1, vox_size) for x,y,z in voxel_spec]
     tracks = make_track_graphs(voxels, contiguity=contiguity)
+
     assert len(tracks) == 1
     track_length = length(tracks[0])
     assert track_length == approx(expected_length)
@@ -346,5 +347,6 @@ def test_contiguity(proximity, contiguity, are_neighbours):
     expected_number_of_tracks = 1 if are_neighbours else 2
     voxels = [Voxel(x,y,z, 1, np.array([1,1,1])) for x,y,z in voxel_spec]
     tracks = make_track_graphs(voxels, contiguity=contiguity)
+
     assert len(tracks) == expected_number_of_tracks
     


### PR DESCRIPTION
I've realized that we kept the explicit dependence on voxel size in make_track_graph function, when we added the size property to Voxel. This PR fixes this.