### PR TITLE
Add tests for the BLR algorithm

### DIFF
--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -428,16 +428,16 @@ class DeconvolutionCity(RawCity):
        Since a Deconvolution city reads RWF, it is also a RawCity.
     """
 
-    parameters = tuple("""raw_data_type n_baseline thr_trigger acum_discharge_length""".split())
+    parameters = tuple("""raw_data_type n_baseline thr_trigger accum_discharge_length""".split())
 
     def __init__(self, **kwds):
         super().__init__(**kwds)
         conf = self.conf
 
         # BLR parameters
-        self.n_baseline            = conf.n_baseline
-        self.thr_trigger           = conf.thr_trigger
-        self.acum_discharge_length = conf.acum_discharge_length
+        self.n_baseline             = conf.n_baseline
+        self.thr_trigger            = conf.thr_trigger
+        self.accum_discharge_length = conf.accum_discharge_length
 
     def write_deconv_params(self, ofile):
         group = ofile.create_group(ofile.root, "DeconvParams")
@@ -449,9 +449,9 @@ class DeconvolutionCity(RawCity):
                                    tbl.filters(self.compression))
 
         row = table.row
-        row["N_BASELINE"]            = self.n_baseline
-        row["THR_TRIGGER"]           = self.thr_trigger
-        row["ACUM_DISCHARGE_LENGTH"] = self.acum_discharge_length
+        row["N_BASELINE"]             = self.n_baseline
+        row["THR_TRIGGER"]            = self.thr_trigger
+        row["ACCUM_DISCHARGE_LENGTH"] = self.accum_discharge_length
         table.flush()
 
     def deconv_pmt(self, RWF):
@@ -459,10 +459,10 @@ class DeconvolutionCity(RawCity):
         return blr.deconv_pmt(RWF,
                               self.coeff_c,
                               self.coeff_blr,
-                              pmt_active            = self.pmt_active,
-                              n_baseline            = self.n_baseline,
-                              thr_trigger           = self.thr_trigger,
-                              acum_discharge_length = self.acum_discharge_length)
+                              pmt_active             = self.pmt_active,
+                              n_baseline             = self.n_baseline,
+                              thr_trigger            = self.thr_trigger,
+                              accum_discharge_length = self.accum_discharge_length)
 
 
 class CalibratedCity(DeconvolutionCity):

--- a/invisible_cities/config/deconvolution_city.conf
+++ b/invisible_cities/config/deconvolution_city.conf
@@ -12,6 +12,6 @@
 include('$ICDIR/config/raw_city.conf')
 
 
-n_baseline            =   28000           # for a window of 800 mus
-thr_trigger           =       5 * adc     # threshold to start the blr algo
-acum_discharge_length =    5000           # accumulator goes to zero
+n_baseline             =   28000           # for a window of 800 mus
+thr_trigger            =       5 * adc     # threshold to start the blr algo
+accum_discharge_length =    5000           # accumulator goes to zero

--- a/invisible_cities/conftest.py
+++ b/invisible_cities/conftest.py
@@ -41,6 +41,11 @@ def config_tmpdir(tmpdir_factory):
     return tmpdir_factory.mktemp('configure_tests')
 
 
+@pytest.fixture(scope='session')
+def example_blr_wfs_filename(ICDIR):
+    return os.path.join(ICDIR, "database/test_data/", "blr_examples.h5")
+
+
 @pytest.fixture(scope  = 'session',
                 params = ['electrons_40keV_z250_RWF.h5',
                           'electrons_511keV_z250_RWF.h5',
@@ -321,7 +326,7 @@ def KrMC_hdst(ICDIR):
               1.47104004e+02,  1.50782271e+02,  1.35000000e+02,  1.47748654e+02,  1.48782929e+02,
               0.00000000e+00,  0.00000000e+00,  7.20626968e+01,  7.19827231e+01,  7.17844856e+01,
               7.35674548e+01,  0.00000000e+00,  0.00000000e+00, -7.83527723e+01, -7.78888272e+01,
-             -7.75947914e+01, -7.69924054e+01,  0.00000000e+0] 
+             -7.75947914e+01, -7.69924054e+01,  0.00000000e+0]
 
     Xrms  = [ 0.00000000e+00,  4.99964935e+00,  6.16285499e+00,  6.39776071e+00,  4.73166675e+00,
               0.00000000e+00,  0.00000000e+00,  0.00000000e+00,  4.99915988e+00,  4.99213896e+00,

--- a/invisible_cities/evm/nh5.py
+++ b/invisible_cities/evm/nh5.py
@@ -80,9 +80,9 @@ class FEE(tb.IsDescription):
 
 
 class DECONV_PARAM(tb.IsDescription):
-    N_BASELINE            = tb.Int32Col(pos=0)
-    THR_TRIGGER           = tb.Int16Col(pos=1)
-    ACUM_DISCHARGE_LENGTH = tb.Int16Col(pos=2)
+    N_BASELINE             = tb.Int32Col(pos=0)
+    THR_TRIGGER            = tb.Int16Col(pos=1)
+    ACCUM_DISCHARGE_LENGTH = tb.Int16Col(pos=2)
 
 
 class S12(tb.IsDescription):

--- a/invisible_cities/sierpe/blr.pxd
+++ b/invisible_cities/sierpe/blr.pxd
@@ -29,16 +29,16 @@ import numpy as np
 cimport numpy as np
 
 cpdef deconvolve_signal(double [:] signal_daq,
-                        int        n_baseline     = *,
-                        double     coef_clean     = *,
-                        double     coef_blr       = *,
-                        double     thr_trigger    = *,
-                        int acum_discharge_length = *)
+                        int        n_baseline      = *,
+                        double     coeff_clean     = *,
+                        double     coeff_blr       = *,
+                        double     thr_trigger     = *,
+                        int accum_discharge_length = *)
 
 cpdef deconv_pmt(np.ndarray[np.int16_t, ndim=2] pmtrwf,
                  double [:]                     coeff_c,
                  double [:]                     coeff_blr,
-                 list                           pmt_active            = *,
-                 int                            n_baseline            = *,
-                 double                         thr_trigger           = *,
-                 int                            acum_discharge_length = *)
+                 list                           pmt_active             = *,
+                 int                            n_baseline             = *,
+                 double                         thr_trigger            = *,
+                 int                            accum_discharge_length = *)

--- a/invisible_cities/sierpe/blr.pyx
+++ b/invisible_cities/sierpe/blr.pyx
@@ -3,11 +3,11 @@ cimport numpy as np
 from scipy import signal as SGN
 
 cpdef deconvolve_signal(double [:] signal_daq,
-                        int    n_baseline            = 28000,
-                        double coef_clean            = 2.905447E-06,
-                        double coef_blr              = 1.632411E-03,
-                        double thr_trigger           =     5,
-                        int    acum_discharge_length =  5000):
+                        int    n_baseline             = 28000,
+                        double coeff_clean            = 2.905447E-06,
+                        double coeff_blr              = 1.632411E-03,
+                        double thr_trigger            =     5,
+                        int    accum_discharge_length =  5000):
 
     """
     The accumulator approach by Master VHB
@@ -21,7 +21,7 @@ cpdef deconvolve_signal(double [:] signal_daq,
     which should be good for Na and Kr
     """
 
-    cdef double coef = coef_blr
+    cdef double coef = coeff_blr
     cdef int nm = n_baseline
     cdef double thr_acum = thr_trigger / coef
     cdef int len_signal_daq = len(signal_daq)
@@ -56,7 +56,7 @@ cpdef deconvolve_signal(double [:] signal_daq,
     cdef double [:]  b_cf
     cdef double [:]  a_cf
 
-    b_cf, a_cf = SGN.butter(1, coef_clean, 'high', analog=False);
+    b_cf, a_cf = SGN.butter(1, coeff_clean, 'high', analog=False);
     signal_daq = SGN.lfilter(b_cf, a_cf, signal_daq)
 
     cdef int k
@@ -75,10 +75,10 @@ cpdef deconvolve_signal(double [:] signal_daq,
 
             if acum[k-1] > 1:
                 acum[k] = acum[k-1] * (1 - coef)
-                if j < acum_discharge_length - 1:
+                if j < accum_discharge_length - 1:
                     j = j + 1
                 else:
-                    j = acum_discharge_length - 1
+                    j = accum_discharge_length - 1
             else:
                 acum[k] = 0
                 j = 0
@@ -89,10 +89,10 @@ cpdef deconvolve_signal(double [:] signal_daq,
 cpdef deconv_pmt(np.ndarray[np.int16_t, ndim=2] pmtrwf,
                  double [:]                     coeff_c,
                  double [:]                     coeff_blr,
-                 list                           pmt_active            =    [],
-                 int                            n_baseline            = 28000,
-                 double                         thr_trigger           =     5,
-                 int                            acum_discharge_length =  5000):
+                 list                           pmt_active             =    [],
+                 int                            n_baseline             = 28000,
+                 double                         thr_trigger            =     5,
+                 int                            accum_discharge_length =  5000):
     """
     Deconvolve all the PMTs in the event.
     :param pmtrwf: array of PMTs holding the raw waveform
@@ -120,11 +120,11 @@ cpdef deconv_pmt(np.ndarray[np.int16_t, ndim=2] pmtrwf,
     cdef int pmt
     for pmt in PMT:
         signal_r = deconvolve_signal(signal_i[pmt],
-                                     n_baseline            = n_baseline,
-                                     coef_clean            = coeff_c[pmt],
-                                     coef_blr              = coeff_blr[pmt],
-                                     thr_trigger           = thr_trigger,
-                                     acum_discharge_length = acum_discharge_length)
+                                     n_baseline             = n_baseline,
+                                     coeff_clean            = coeff_c[pmt],
+                                     coeff_blr              = coeff_blr[pmt],
+                                     thr_trigger            = thr_trigger,
+                                     accum_discharge_length = accum_discharge_length)
 
         CWF.append(signal_r)
 

--- a/invisible_cities/sierpe/blr_test.py
+++ b/invisible_cities/sierpe/blr_test.py
@@ -1,0 +1,147 @@
+import os
+
+from collections import namedtuple
+from itertools   import starmap
+
+import numpy  as np
+import tables as tb
+
+from pytest import fixture
+from pytest import approx
+from pytest import mark
+from flaky  import flaky
+
+from . import blr
+
+
+deconv_params = namedtuple("deconv_params",
+                           "n_baseline coeff_clean coeff_blr "
+                           "thr_trigger accum_discharge_length")
+
+
+@fixture(scope="session")
+def sin_wf_params():
+    n_baseline             = 500
+    coeff_clean            = 1e-6
+    coeff_blr              = 1e-3
+    thr_trigger            = 1e-3
+    accum_discharge_length = 10
+    return deconv_params(n_baseline, coeff_clean, coeff_blr,
+                         thr_trigger, accum_discharge_length)
+
+
+@fixture
+def sin_wf(sin_wf_params):
+    baseline        = np.random.uniform(0, 100)
+    wf              = np.full(sin_wf_params.n_baseline, baseline)
+    start           = np.random.choice (sin_wf_params.n_baseline // 2)
+    length          = np.random.randint(sin_wf_params.n_baseline // 50,
+                                        sin_wf_params.n_baseline // 2)
+    stop            = start + length
+
+    # minus sign to simulate inverted pmt response
+    wf[start:stop] -= np.sin(np.linspace(0, 2 * np.pi, length))
+    return wf
+
+
+@fixture(scope="session")
+def ad_hoc_blr_signals(example_blr_wfs_filename):
+    with tb.open_file(example_blr_wfs_filename) as file:
+        rwf    = file.root.RWF[:]
+        blrwf  = file.root.BLR[:]
+        attrs  = file.root.BLR.attrs
+        params = deconv_params(attrs.n_baseline            ,
+                               attrs.coeff_c               ,
+                               attrs.coeff_blr             ,
+                               attrs.thr_trigger           ,
+                               attrs.accum_discharge_length)
+        return rwf, blrwf, params
+
+
+def test_deconvolve_signal_positive_integral(sin_wf, sin_wf_params):
+    # The RWF should have null integral because contains roughly
+    # the same number of positive and negative samples.
+    # The CWF on the other hand should contain mostly positive
+    # samples, therefore the integral should be positive.
+    blr_wf = blr.deconvolve_signal(sin_wf, **sin_wf_params._asdict())
+    assert np.sum(blr_wf > 0)
+
+
+def test_deconvolve_signal_baseline_is_recovered(sin_wf, sin_wf_params):
+    # The RWF contains a baseline. The deconvolution process should
+    # remove it. We take the baseline as the most repeated value.
+    blr_wf      = blr.deconvolve_signal(sin_wf, **sin_wf_params._asdict())
+    (entries,
+     amplitude) = np.histogram(blr_wf, 200)
+    baseline    = amplitude[np.argmax(entries)]
+    assert np.abs(baseline) < 0.1
+
+
+@mark.slow
+@flaky(max_runs=3, min_passes=3)
+def test_deconvolve_signal_ad_hoc_signals(ad_hoc_blr_signals):
+    all_rwfs, all_true_blr_wfs, params = ad_hoc_blr_signals
+
+    # This test takes long, so we pick just one waveform.
+    # Its exhaustiveness relies on repeated test runs.
+    nevt, npmt, _ = all_rwfs.shape
+    evt_no = np.random.choice(nevt)
+    pmt_no = np.random.choice(npmt)
+
+    rwf         = all_rwfs        [evt_no, pmt_no]
+    true_blr_wf = all_true_blr_wfs[evt_no, pmt_no]
+    blr_wf = blr.deconvolve_signal(rwf.astype(np.double),
+                                   n_baseline             = params.n_baseline,
+                                   coeff_clean            = params.coeff_clean[pmt_no],
+                                   coeff_blr              = params.coeff_blr  [pmt_no],
+                                   thr_trigger            = params.thr_trigger,
+                                   accum_discharge_length = params.accum_discharge_length)
+    assert np.allclose(blr_wf, true_blr_wf)
+
+
+@mark.slow
+def test_deconv_pmt_ad_hoc_signals_all(ad_hoc_blr_signals):
+    all_rwfs, all_true_blr_wfs, params = ad_hoc_blr_signals
+    pmt_active                         = [] # Means all
+
+    # This test takes long, so we pick a random event.
+    # Its exhaustiveness relies on repeated test runs.
+    evt_no           = np.random.choice(all_rwfs.shape[0])
+    evt_rwfs         = all_rwfs        [evt_no]
+    evt_true_blr_wfs = all_true_blr_wfs[evt_no]
+
+    blr_wfs = blr.deconv_pmt(evt_rwfs,
+                             params.coeff_clean,
+                             params.coeff_blr  ,
+                             pmt_active,
+                             params.n_baseline ,
+                             params.thr_trigger,
+                             params.accum_discharge_length)
+
+    np.allclose(blr_wfs, evt_true_blr_wfs)
+
+
+@mark.slow
+def test_deconv_pmt_ad_hoc_signals_dead_sensors(ad_hoc_blr_signals):
+    all_rwfs, all_true_blr_wfs, params = ad_hoc_blr_signals
+
+    n_evts, n_pmts, _ = all_rwfs.shape
+    pmt_active        = np.arange(n_pmts)
+    n_alive           = np.random.randint(1, n_pmts - 1)
+    pmt_active        = np.random.choice(pmt_active, size=n_alive, replace=False)
+
+    # This test takes long, so we pick a random event.
+    # Its exhaustiveness relies on repeated test runs.
+    evt_no           = np.random.choice(n_evts)
+    evt_rwfs         = all_rwfs        [evt_no]
+    evt_true_blr_wfs = all_true_blr_wfs[evt_no]
+
+    blr_wfs = blr.deconv_pmt(evt_rwfs,
+                             params.coeff_clean,
+                             params.coeff_blr  ,
+                             pmt_active.tolist(),
+                             params.n_baseline ,
+                             params.thr_trigger,
+                             params.accum_discharge_length)
+
+    np.allclose(blr_wfs, evt_true_blr_wfs[pmt_active])


### PR DESCRIPTION
Somehow the module `sierpe/blr.pyx` has managed to escape the master's radar until now. This PR introduces some tests to this code, which belongs to the core of our processing chain. There are two types of tests:

- Property checking: by using a toy signal, we check that the integral is positive and that the baseline is recovered.

- Stability: by using some real waveforms we store the current value of the blr waveform in order to have something to compare with in the future. This assumes we trust the current algorithm.