### PR TITLE
Add stat functions module

### DIFF
--- a/invisible_cities/core/fit_functions.py
+++ b/invisible_cities/core/fit_functions.py
@@ -8,9 +8,10 @@ import numpy as np
 import scipy.optimize
 import scipy.stats
 
-from . import core_functions as coref
-from .. evm.ic_containers    import FitFunction
-from ..icaro.hst_functions   import poisson_sigma
+from .                    import core_functions as coref
+from .  stat_functions    import poisson_sigma
+from .. evm.ic_containers import FitFunction
+
 
 def get_errors(cov):
     """

--- a/invisible_cities/core/fit_functions_test.py
+++ b/invisible_cities/core/fit_functions_test.py
@@ -22,7 +22,7 @@ from .testing_utils import random_length_float_arrays
 from . import core_functions as core
 from . import  fit_functions as fitf
 
-from ..icaro.hst_functions import poisson_sigma
+from . stat_functions import poisson_sigma
 
 
 def test_get_errors():

--- a/invisible_cities/core/fit_functions_test.py
+++ b/invisible_cities/core/fit_functions_test.py
@@ -3,25 +3,23 @@ Tests for fit_functions
 """
 
 import numpy as np
-from pytest import mark
-from pytest import approx
-from pytest import raises
-from flaky  import flaky
 
+from pytest        import mark
+from pytest        import approx
+from pytest        import raises
+from flaky         import flaky
 from numpy.testing import assert_array_equal
 from numpy.testing import assert_allclose
 
 from hypothesis            import given
 from hypothesis.strategies import integers
 from hypothesis.strategies import floats
+from . testing_utils       import float_arrays
+from . testing_utils       import FLOAT_ARRAY
+from . testing_utils       import random_length_float_arrays
 
-from .testing_utils import float_arrays
-from .testing_utils import FLOAT_ARRAY
-from .testing_utils import random_length_float_arrays
-
-from . import core_functions as core
-from . import  fit_functions as fitf
-
+from .                import core_functions as core
+from .                import  fit_functions as fitf
 from . stat_functions import poisson_sigma
 
 

--- a/invisible_cities/core/stat_functions.py
+++ b/invisible_cities/core/stat_functions.py
@@ -1,0 +1,12 @@
+"""
+Contains statistics-related functions.
+"""
+
+def poisson_sigma(x, default=3):
+    """
+    Get the uncertainty of x (assuming it is poisson-distributed).
+    Set *default* when x is 0 to avoid null uncertainties.
+    """
+    u = x**0.5
+    u[x==0] = default
+    return u

--- a/invisible_cities/core/stat_functions_test.py
+++ b/invisible_cities/core/stat_functions_test.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+from pytest import mark
+from pytest import approx
+
+from hypothesis             import given
+from hypothesis.strategies  import composite
+from hypothesis.strategies  import integers
+from hypothesis.strategies  import floats
+from hypothesis.strategies  import sampled_from
+from hypothesis.extra.numpy import arrays
+
+from . stat_functions import poisson_sigma
+
+
+@composite
+def arrays_of_positive_numbers(draw):
+    _strategies     = {int: integers, float: floats}
+    _type, strategy = draw(sampled_from(list(_strategies.items())))
+    size            = draw(integers(1, 10))
+    return draw(arrays(_type, size, strategy(0, 100)))
+
+
+@mark.parametrize("default", (0, 1, 2))
+@given(array = arrays_of_positive_numbers())
+def test_poisson_sigma(array, default):
+    expected = np.where(array == 0, default, array**0.5)
+    assert poisson_sigma(array, default) == approx(expected)

--- a/invisible_cities/icaro/hst_functions.py
+++ b/invisible_cities/icaro/hst_functions.py
@@ -245,16 +245,6 @@ def plot_writer(outputfolder, format, dpi=100):
                              dpi    = dpi)
 
 
-def poisson_sigma(x, default=3):
-    """
-    Get the uncertainty of x (assuming it is poisson-distributed).
-    Set *default* when x is 0 to avoid null uncertainties.
-    """
-    u = x**0.5
-    u[x==0] = default
-    return u
-
-
 def measurement_string(x, u_x):
     """
     Display a value-uncertainty pair with the same precision.

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -12,7 +12,7 @@ from ..reco .corrections   import LifetimeXYCorrection
 from ..reco .corrections   import opt_nearest
 from ..reco .corrections   import opt_linear
 from ..reco .corrections   import opt_cubic
-from ..icaro.hst_functions import poisson_sigma
+from ..core.stat_functions import poisson_sigma
 from ..icaro.hst_functions import shift_to_bin_centers
 
 from numpy.testing import assert_allclose

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -2,18 +2,18 @@ from collections import namedtuple
 
 import numpy as np
 
-from ..core                import fit_functions as fitf
-from ..core .exceptions    import ParameterNotSet
-from ..reco .corrections   import Correction
-from ..reco .corrections   import Fcorrection
-from ..reco .corrections   import LifetimeCorrection
-from ..reco .corrections   import LifetimeRCorrection
-from ..reco .corrections   import LifetimeXYCorrection
-from ..reco .corrections   import opt_nearest
-from ..reco .corrections   import opt_linear
-from ..reco .corrections   import opt_cubic
-from ..core.stat_functions import poisson_sigma
-from ..icaro.hst_functions import shift_to_bin_centers
+from .. core                 import fit_functions as fitf
+from .. core .stat_functions import poisson_sigma
+from .. core .exceptions     import ParameterNotSet
+from .. icaro.hst_functions  import shift_to_bin_centers
+from .. reco .corrections    import Correction
+from .. reco .corrections    import Fcorrection
+from .. reco .corrections    import LifetimeCorrection
+from .. reco .corrections    import LifetimeRCorrection
+from .. reco .corrections    import LifetimeXYCorrection
+from .. reco .corrections    import opt_nearest
+from .. reco .corrections    import opt_linear
+from .. reco .corrections    import opt_cubic
 
 from numpy.testing import assert_allclose
 from pytest        import fixture


### PR DESCRIPTION
This PR solves an import loop introduced in #421.

The function `poisson_sigma` has been moved from `icaro/hst_functions.py` to its own module `core/stat_functions.py`. The function is now tested.