### PR TITLE
Remove flaky report if tests succeed

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -109,7 +109,7 @@ function run_tests {
     fi
 
     # Run the test suite
-    pytest -v
+    pytest -v --no-success-flaky-report
 }
 
 function run_tests_par {
@@ -120,8 +120,8 @@ function run_tests_par {
 
     # Run the test suite
     EXIT=0
-    pytest -v -n ${N_PROC} -m "not serial" || EXIT=$?
-    pytest -v              -m      serial  || EXIT=$?
+    pytest -v -n ${N_PROC} -m "not serial" --no-success-flaky-report || EXIT=$?
+    pytest -v              -m      serial  --no-success-flaky-report || EXIT=$?
     exit $EXIT
 }
 


### PR DESCRIPTION
The number of flaky tests has recently been increased and the report introduces too much noise to `pytest`'s output. This commit introduces a flag that removes the report, but just if the tests pass.