### PR TITLE
Fix diomira masked channels

### DIFF
--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -1056,16 +1056,16 @@ class MonteCarloCity(TriggerEmulationCity):
         self.sp               = self.get_sensor_rd_params(self.input_files[0])
         self.noise_sampler    = SiPMsNoiseSampler(self.run_number, self.sp.SIPMWL, True)
 
-    @staticmethod
-    def simulate_sipm_response(event, sipmrd,
-                               sipms_noise_sampler, sipm_adc_to_pes):
+
+    def simulate_sipm_response(self, event, sipmrd):
         """Add noise with the NoiseSampler class and return
         the noisy waveform (in adc counts)."""
-        return sf.simulate_sipm_response(event, sipmrd, sipms_noise_sampler,
-                                         sipm_adc_to_pes)
+        return sf.simulate_sipm_response(event, sipmrd,
+                                         self.noise_sampler,
+                                         self.sipm_adc_to_pes)
 
 
-    def simulate_pmt_response(self, event, pmtrd, pmt_adc_to_pes):
+    def simulate_pmt_response(self, event, pmtrd):
         """ Full simulation of the energy plane response
         Input:
          1) extensible array pmtrd
@@ -1077,7 +1077,7 @@ class MonteCarloCity(TriggerEmulationCity):
         array of BLR waveforms (only decimation)
         """
         return sf.simulate_pmt_response(event, pmtrd,
-                                        pmt_adc_to_pes,
+                                        self.all_pmt_adc_to_pes,
                                         self.run_number)
 
     @property

--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -1001,6 +1001,12 @@ class TriggerEmulationCity(PmapCity):
         super().__init__(**kwds)
         self.trigger_params   = self.trigger_parameters()
 
+        self.IC_ids_selection = convert_channel_id_to_IC_id(self.DataPMT,
+                                                            self.trigger_params.trigger_channels)
+
+        if not np.all(np.in1d(self.IC_ids_selection, self.pmt_active)):
+            raise ValueError("Attempt to trigger in masked PMT")
+
     def trigger_parameters(self):
         """Simulate trigger parameters."""
         conf = self.conf
@@ -1020,15 +1026,9 @@ class TriggerEmulationCity(PmapCity):
         """
 
         CWF = self.deconv_pmt(RWF)
-        IC_ids_selection = convert_channel_id_to_IC_id(self.DataPMT,
-                                                       self.trigger_params.trigger_channels)
-
-        if not np.all(np.in1d(IC_ids_selection, self.pmt_active)):
-            raise ValueError("Attempt to trigger in masked PMT")
-
 
         peak_data = {}
-        for pmt_id in IC_ids_selection:
+        for pmt_id in self.IC_ids_selection:
             # Emulate zero suppression in the FPGA
             wfm_index, _ = \
             pkf.indices_and_wf_above_threshold(CWF[pmt_id],

--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -259,16 +259,16 @@ class City:
         self.DataPMT  = DataPMT
         self.DataSiPM = DataSiPM
 
-        self.xs              = DataSiPM.X.values
-        self.ys              = DataSiPM.Y.values
-        self.pmt_active      = np.nonzero(pmt_active)[0].tolist()
-        self.active_pmt_ids  = DataPMT.SensorID[DataPMT.Active == 1].values
-        self.pmt_adc_to_pes  = abs(DataPMT.adc_to_pes.values).astype(np.double)
-        self.pmt_adc_to_pes  = self.pmt_adc_to_pes[pmt_active]
-        self.sipm_adc_to_pes = DataSiPM.adc_to_pes.values    .astype(np.double)
-        self.coeff_c         = DataPMT.coeff_c.values        .astype(np.double)
-        self.coeff_blr       = DataPMT.coeff_blr.values      .astype(np.double)
-        self.noise_rms       = DataPMT.noise_rms.values      .astype(np.double)
+        self.xs                 = DataSiPM.X.values
+        self.ys                 = DataSiPM.Y.values
+        self.pmt_active         = np.nonzero(pmt_active)[0].tolist()
+        self.active_pmt_ids     = DataPMT.SensorID[DataPMT.Active == 1].values
+        self.all_pmt_adc_to_pes = abs(DataPMT.adc_to_pes.values).astype(np.double)
+        self.    pmt_adc_to_pes = self.all_pmt_adc_to_pes[pmt_active]
+        self.   sipm_adc_to_pes = DataSiPM.adc_to_pes.values    .astype(np.double)
+        self.coeff_c            = DataPMT.coeff_c.values        .astype(np.double)
+        self.coeff_blr          = DataPMT.coeff_blr.values      .astype(np.double)
+        self.noise_rms          = DataPMT.noise_rms.values      .astype(np.double)
 
         sipm_x_masked = DataSiPM[DataSiPM.Active == 0].X.values
         sipm_y_masked = DataSiPM[DataSiPM.Active == 0].Y.values

--- a/invisible_cities/cities/base_cities.py
+++ b/invisible_cities/cities/base_cities.py
@@ -1023,6 +1023,10 @@ class TriggerEmulationCity(PmapCity):
         IC_ids_selection = convert_channel_id_to_IC_id(self.DataPMT,
                                                        self.trigger_params.trigger_channels)
 
+        if not np.all(np.in1d(IC_ids_selection, self.pmt_active)):
+            raise ValueError("Attempt to trigger in masked PMT")
+
+
         peak_data = {}
         for pmt_id in IC_ids_selection:
             # Emulate zero suppression in the FPGA

--- a/invisible_cities/cities/diomira.py
+++ b/invisible_cities/cities/diomira.py
@@ -79,7 +79,7 @@ class Diomira(MonteCarloCity):
 
             # Simulate detector response
             dataPMT, blrPMT = self.simulate_pmt_response(evt, pmtrd,
-                                                         self.pmt_adc_to_pes)
+                                                         self.all_pmt_adc_to_pes)
             dataSiPM_noisy = self.simulate_sipm_response(evt, sipmrd,
                                                          self.noise_sampler,
                                                          self.sipm_adc_to_pes)

--- a/invisible_cities/cities/diomira.py
+++ b/invisible_cities/cities/diomira.py
@@ -78,12 +78,10 @@ class Diomira(MonteCarloCity):
             self.cnt.n_events_tot += 1
 
             # Simulate detector response
-            dataPMT, blrPMT = self.simulate_pmt_response(evt, pmtrd,
-                                                         self.all_pmt_adc_to_pes)
-            dataSiPM_noisy = self.simulate_sipm_response(evt, sipmrd,
-                                                         self.noise_sampler,
-                                                         self.sipm_adc_to_pes)
-            dataSiPM = wfm.noise_suppression(dataSiPM_noisy, self.sipms_thresholds)
+            dataPMT, blrPMT = self.simulate_pmt_response(evt, pmtrd)
+            dataSiPM_noisy  = self.simulate_sipm_response(evt, sipmrd)
+            dataSiPM        = wfm.noise_suppression(dataSiPM_noisy, self.sipms_thresholds)
+
             RWF = dataPMT.astype(np.int16)
             BLR = blrPMT.astype(np.int16)
 

--- a/invisible_cities/cities/diomira_test.py
+++ b/invisible_cities/cities/diomira_test.py
@@ -130,3 +130,23 @@ def test_diomira_copy_mc_and_offset(config_tmpdir):
                0)))
 def test_event_number_from_input_file_name(filename, first_evt):
     assert Diomira.event_number_from_input_file_name(filename) == first_evt
+
+
+@mark.slow
+def test_diomira_mismatch_between_input_and_database(ICDATADIR, output_tmpdir):
+    file_in  = os.path.join(ICDATADIR    , 'electrons_40keV_z250_MCRD.h5')
+    file_out = os.path.join(output_tmpdir, 'electrons_40keV_z250_RWF_test_mismatch.h5')
+
+    conf = configure('diomira invisible_cities/config/diomira.conf'.split())
+    conf.update(dict(run_number  = -4500, # Must be a run number with dead pmts
+                     files_in    = file_in,
+                     file_out    = file_out,
+                     tr_channels = (18, 19),
+                     event_range = (0, 1)))
+
+    diomira = Diomira(**conf)
+    diomira.run()
+    cnt     = diomira.end()
+
+    # we are just interested in checking whether the code runs or not
+    assert cnt.n_events_tot == 1

--- a/invisible_cities/cities/diomira_test.py
+++ b/invisible_cities/cities/diomira_test.py
@@ -21,9 +21,9 @@ from .. sierpe   import fee as FEE
 from .  diomira  import Diomira
 
 
-def test_diomira_fee_table(ICDIR):
+def test_diomira_fee_table(ICDATADIR):
     "Test that FEE table reads back correctly with expected values."
-    RWF_file = os.path.join(ICDIR, 'database/test_data/electrons_40keV_z250_RWF.h5')
+    RWF_file = os.path.join(ICDATADIR, 'electrons_40keV_z250_RWF.h5')
 
     with tb.open_file(RWF_file, 'r') as e40rwf:
         fee = tbl.read_FEE_table(e40rwf.root.MC.FEE)
@@ -52,7 +52,7 @@ def test_diomira_fee_table(ICDIR):
         assert abs(feep.CEILING - FEE.CEILING)             < eps
 
 
-def test_diomira_identify_bug(ICDIR):
+def test_diomira_identify_bug(ICDATADIR):
     """Read a one-event file in which the energy of PMTs is equal to zero and
     asset it must be son. This test would fail for a normal file where there
     is always some energy in the PMTs. It's purpose is to provide an automaic
@@ -65,7 +65,7 @@ def test_diomira_identify_bug(ICDIR):
     The same event is later processed with Irene (where a protection
     that skips empty events has been added) to ensure that no crash occur."""
 
-    infile = os.path.join(ICDIR, 'database/test_data/irene_bug_Kr_ACTIVE_7bar_MCRD.h5')
+    infile = os.path.join(ICDATADIR, 'irene_bug_Kr_ACTIVE_7bar_MCRD.h5')
     with tb.open_file(infile, 'r') as h5in:
 
         pmtrd  = h5in.root.pmtrd
@@ -75,10 +75,10 @@ def test_diomira_identify_bug(ICDIR):
 
 
 @mark.slow
-def test_diomira_copy_mc_and_offset(config_tmpdir):
-    PATH_IN = os.path.join(os.environ['ICDIR'], 'database/test_data/', 'electrons_40keV_z250_MCRD.h5')
-    PATH_OUT = os.path.join(config_tmpdir,                             'electrons_40keV_z250_RWF.h5')
-    # PATH_OUT = os.path.join(os.environ['IC_DATA'],                             'electrons_40keV_z250_test_RWF.h5')
+def test_diomira_copy_mc_and_offset(ICDATADIR, config_tmpdir):
+    PATH_IN  = os.path.join(ICDATADIR    , 'electrons_40keV_z250_MCRD.h5')
+    PATH_OUT = os.path.join(config_tmpdir, 'electrons_40keV_z250_RWF.h5' )
+    #PATH_OUT = os.path.join(ICDATADIR, 'electrons_40keV_z250_test_RWF.h5')
 
     start_evt  = Diomira.event_number_from_input_file_name(PATH_IN)
     run_number = 0

--- a/invisible_cities/cities/diomira_test.py
+++ b/invisible_cities/cities/diomira_test.py
@@ -11,6 +11,7 @@ import tables as tb
 import numpy  as np
 
 from pytest import mark
+from pytest import raises
 
 from .. core                 import system_of_units as units
 from .. core.configure       import configure
@@ -150,3 +151,20 @@ def test_diomira_mismatch_between_input_and_database(ICDATADIR, output_tmpdir):
 
     # we are just interested in checking whether the code runs or not
     assert cnt.n_events_tot == 1
+
+
+@mark.slow
+def test_diomira_trigger_on_masked_pmt_raises_ValueError(ICDATADIR, output_tmpdir):
+    file_in  = os.path.join(ICDATADIR    , 'electrons_40keV_z250_MCRD.h5')
+    file_out = os.path.join(output_tmpdir, 'electrons_40keV_z250_RWF_test_trigger.h5')
+
+    conf = configure('diomira invisible_cities/config/diomira.conf'.split())
+    conf.update(dict(run_number   = -4500, # Must be a run number with dead pmts
+                     files_in     = file_in,
+                     file_out     = file_out,
+                     trigger_type = "S2",
+                     tr_channels  = (0,), # This is a masked PMT for this run
+                     event_range  = (0, 1)))
+
+    with raises(ValueError):
+        Diomira(**conf).run()


### PR DESCRIPTION
This PR:
- Demonstrates that `Diomira` doesn't work with masked pmts unless the input is already masked and fixes it.
- Demonstrates that there isn't any protection at all against triggering on masked channels. Now it raises an error.
- Speeds up Diomira a bit by not deconvoluting all waveforms (only those needed for trigger simulation).