### PR TITLE
Fix to potential error in NoiseSampler

### DIFF
--- a/invisible_cities/core/random_sampling.py
+++ b/invisible_cities/core/random_sampling.py
@@ -66,6 +66,7 @@ class NoiseSampler:
         self.nsamples    = sample_size
         self.smear       = smear
         self.active      = DB.DataSiPM(run_number).Active.values[:, np.newaxis]
+        self.adc_to_pes  = DB.DataSiPM(run_number).adc_to_pes.values.astype(np.double)[:, np.newaxis]
         self.nsensors    = self.active.size
 
         self.probs       = np.apply_along_axis(normalize_distribution, 1,
@@ -90,7 +91,7 @@ class NoiseSampler:
         sample  = np.apply_along_axis(self._sampler, 1, self.probs)
         if self.smear:
             sample += self._smearer()
-        sample += self.baselines
+        sample = self.adc_to_pes * sample + self.baselines
         return self.mask(sample)
 
     def compute_thresholds(self, noise_cut=0.99, pes_to_adc=1):

--- a/invisible_cities/core/random_sampling_test.py
+++ b/invisible_cities/core/random_sampling_test.py
@@ -207,15 +207,19 @@ def test_noise_sampler_take_sample(datasipm, noise_sampler):
     noise_sampler, _, smear, *_ = noise_sampler
     samples = noise_sampler.sample()
     for i, active in enumerate(datasipm.Active):
-        sample = samples[i]
+        sample        = samples[i]
+        adc_to_pe     = noise_sampler.adc_to_pes[i]
+        baseline      = noise_sampler.baselines[i]
+        bins_adc      = noise_sampler.xbins * adc_to_pe
+        bin_width_adc = noise_sampler.dx * adc_to_pe
         if active:
             if smear:
                 # Find closest energy bin and ensure it is close enough.
-                diffs      = noise_sampler.xbins - sample[:, np.newaxis]
+                diffs      = bins_adc + baseline - sample[:, np.newaxis]
                 closest    = np.min(np.abs(diffs), axis=1)
-                assert np.all(closest <= noise_sampler.dx)
+                assert np.all(closest <= bin_width_adc)
             else:
-                assert np.all(np.in1d(sample, noise_sampler.xbins))
+                assert np.all(np.in1d(sample, bins_adc + baseline))
         else:
             assert not np.any(sample)
 

--- a/invisible_cities/reco/sensor_functions.py
+++ b/invisible_cities/reco/sensor_functions.py
@@ -51,7 +51,5 @@ def simulate_pmt_response(event, pmtrd, adc_to_pes, run_number = 0):
 def simulate_sipm_response(event, sipmrd, sipms_noise_sampler, sipm_adc_to_pes):
     """Add noise to the sipms with the NoiseSampler class and return
     the noisy waveform (in adc)."""
-    # add noise (in PES) to true waveform
-    dataSiPM = sipmrd[event] + sipms_noise_sampler.sample()
-    # return total signal in adc counts
-    return wfm.to_adc(dataSiPM, sipm_adc_to_pes)
+    # add noise (in ADC) to true waveform and return total signal in ADC
+    return wfm.to_adc(sipmrd[event], sipm_adc_to_pes) + sipms_noise_sampler.sample()


### PR DESCRIPTION
Code added baseline to samples before conversion
to ADC which is an error in the case of a
baseline != 0.

Changed class to have access to sipm gains so
that conversion could be done in function.

Affected functions and tests altered to take
change into account.