### PR TITLE
Add covariance matrix to FitFunction's output

### DIFF
--- a/invisible_cities/core/fit_functions.py
+++ b/invisible_cities/core/fit_functions.py
@@ -147,7 +147,7 @@ def fit(func, x, y, seed=(), fit_range=None, **kwargs):
     chi2, pval = get_chi2_and_pvalue(y, fitx, ndof, sigma_r)
 
 
-    return FitFunction(fitf, vals, errors, chi2, pval)
+    return FitFunction(fitf, vals, errors, chi2, pval, cov)
 
 
 def profileX(xdata, ydata, nbins=100,

--- a/invisible_cities/core/fit_functions_test.py
+++ b/invisible_cities/core/fit_functions_test.py
@@ -121,6 +121,22 @@ def test_covariance_matrix_shape():
     assert f.cov.shape == (3, 3)
 
 
+def test_covariance_matrix_values():
+    def line(x, m, n):
+        return m * x + n
+
+    x   = np.array([1, 2, 3, 4])
+    y   = np.array([1 ,2, 3, 4])
+    err = np.full(4, 0.1)
+
+    expected_cov = np.array([[0.002, -0.005],
+                            [-0.005, 0.015]])
+
+    f = fitf.fit(line, x, y, seed=(1, 0), sigma=err)
+
+    assert_allclose(f.cov, expected_cov)
+
+
 @mark.slow
 @flaky(max_runs=10, min_passes=9)
 def test_chi2_log_errors():

--- a/invisible_cities/core/fit_functions_test.py
+++ b/invisible_cities/core/fit_functions_test.py
@@ -107,6 +107,20 @@ def test_chi2_poisson_errors():
     assert 0.60 < f.chi2 < 1.5
 
 
+def test_covariance_matrix_shape():
+    mu    = np.random.uniform(-100, 100)
+    sigma = np.random.uniform(   0, 100)
+    A     =  1e9
+    x     = np.linspace(mu - 5 * sigma, mu + 5 * sigma, 100)
+    y     = fitf.gauss(x, A, mu, sigma)
+    y     = np.random.poisson(y)
+    errs  = poisson_sigma(y)
+
+    f = fitf.fit(fitf.gauss, x, y, seed=(A, mu, sigma), sigma=errs)
+
+    assert f.cov.shape == (3, 3)
+
+
 @mark.slow
 @flaky(max_runs=10, min_passes=9)
 def test_chi2_log_errors():

--- a/invisible_cities/evm/ic_containers.py
+++ b/invisible_cities/evm/ic_containers.py
@@ -36,7 +36,7 @@ for name, attrs in (
         ('S1PMaps'        , 'S1 S1_PMT S1p S1p_PMT'),
         ('PMaps'          , 'S1 S2 S2Si'),
         ('Peak'           , 't E'),
-        ('FitFunction'    , 'fn values errors chi2 pvalue'),
+        ('FitFunction'    , 'fn values errors chi2 pvalue cov'),
         ('TriggerParams'  , 'trigger_channels min_number_channels charge height width'),
         ('PeakData'       , 'charge height width'),
         ('Measurement'    , 'value uncertainty')):


### PR DESCRIPTION
FitFunction tuple now contains the covariance
matrix of the fit to ease error propagation.

covariance matrix added in fit_functions.fit