### PR TITLE
Replace implementation of profile functions with faster ones

### DIFF
--- a/invisible_cities/calib/pmtgain.py
+++ b/invisible_cities/calib/pmtgain.py
@@ -11,10 +11,10 @@ from functools import partial
 
 import numpy  as np
 
-from .                         import      calib_functions as cf
-from .. io   .         hist_io import          hist_writer
-from .. io   .run_and_event_io import run_and_event_writer
-from .. icaro.hst_functions    import shift_to_bin_centers
+from .                        import      calib_functions as cf
+from .. io  .         hist_io import          hist_writer
+from .. io  .run_and_event_io import run_and_event_writer
+from .. core.core_functions   import shift_to_bin_centers
 
 from .. core  .system_of_units_c import units
 from .. cities.base_cities       import CalibratedCity

--- a/invisible_cities/calib/sipmgain.py
+++ b/invisible_cities/calib/sipmgain.py
@@ -14,9 +14,9 @@ import numpy  as np
 from .. core.system_of_units_c import units
 from .                         import calib_functions         as cf
 from .. reco                   import calib_sensors_functions as csf
-from .. io   .         hist_io import          hist_writer
-from .. io   .run_and_event_io import run_and_event_writer
-from .. icaro.hst_functions    import shift_to_bin_centers
+from .. io  .         hist_io  import          hist_writer
+from .. io  .run_and_event_io  import run_and_event_writer
+from .. core.core_functions    import shift_to_bin_centers
 
 from .. cities.base_cities import CalibratedCity
 from .. cities.base_cities import EventLoop

--- a/invisible_cities/calib/sipmpdf.py
+++ b/invisible_cities/calib/sipmpdf.py
@@ -11,11 +11,11 @@ from functools import partial
 
 import numpy  as np
 
-from .                         import calib_functions         as cf
-from .. reco                   import calib_sensors_functions as csf
-from .. io   .         hist_io import          hist_writer
-from .. io   .run_and_event_io import run_and_event_writer
-from .. icaro.hst_functions    import shift_to_bin_centers
+from .                        import calib_functions         as cf
+from .. reco                  import calib_sensors_functions as csf
+from .. io  .         hist_io import          hist_writer
+from .. io  .run_and_event_io import run_and_event_writer
+from .. core.core_functions   import shift_to_bin_centers
 
 from .. cities.base_cities import CalibratedCity
 from .. cities.base_cities import EventLoop

--- a/invisible_cities/core/core_functions.py
+++ b/invisible_cities/core/core_functions.py
@@ -282,3 +282,10 @@ def mean_handle_empty(array):
 
 def  std_handle_empty(array):
     return np.std (array) if len(array) else np.nan
+
+
+def shift_to_bin_centers(x):
+    """
+    Return bin centers, given bin lower edges.
+    """
+    return x[:-1] + np.diff(x) * 0.5

--- a/invisible_cities/core/core_functions_test.py
+++ b/invisible_cities/core/core_functions_test.py
@@ -10,12 +10,13 @@ from pytest import approx
 from pytest import mark
 from pytest import raises
 
-from flaky                 import flaky
-from hypothesis            import given
-from hypothesis.strategies import integers
-from hypothesis.strategies import floats
-from hypothesis.strategies import sampled_from
-from hypothesis.strategies import composite
+from flaky                  import flaky
+from hypothesis             import given
+from hypothesis.strategies  import integers
+from hypothesis.strategies  import floats
+from hypothesis.strategies  import sampled_from
+from hypothesis.strategies  import composite
+from hypothesis.extra.numpy import arrays
 
 sane_floats = partial(floats, allow_nan=False, allow_infinity=False)
 
@@ -284,3 +285,10 @@ def test_std_handle_empty_nonempty_input  (array):
 
 def test_std_handle_empty_empty_input():
     assert np.isnan(core.std_handle_empty([]))
+
+
+@given(arrays(float, 10, floats(min_value=-1e5, max_value=1e5)))
+def test_shift_to_bin_centers(x):
+    x_shifted = core.shift_to_bin_centers(x)
+    truth     = [np.mean(x[i:i+2]) for i in range(x.size-1)]
+    npt.assert_allclose(x_shifted, truth, rtol=1e-6, atol=1e-6)

--- a/invisible_cities/core/fit_functions_test.py
+++ b/invisible_cities/core/fit_functions_test.py
@@ -291,8 +291,8 @@ def test_profile1D_uniform_distribution_std(func):
 
 
 @mark.parametrize("func xdata ydata".split(),
-                  ((fitf.profileX, FLOAT_ARRAY(100), FLOAT_ARRAY(100)),
-                   (fitf.profileY, FLOAT_ARRAY(100), FLOAT_ARRAY(100))))
+                  ((fitf.profileX, FLOAT_ARRAY(100, -1e3, 1e3), FLOAT_ARRAY(100, -1e3, 1e3)),
+                   (fitf.profileY, FLOAT_ARRAY(100, -1e3, 1e3), FLOAT_ARRAY(100, -1e3, 1e3))))
 def test_profile1D_custom_range(func, xdata, ydata):
     xrange     = (-100, 100)
     kw         = "yrange" if func.__name__.endswith("Y") else "xrange"

--- a/invisible_cities/icaro/hst_functions.py
+++ b/invisible_cities/icaro/hst_functions.py
@@ -5,8 +5,9 @@ import textwrap
 import numpy             as np
 import matplotlib.pyplot as plt
 
-from .. core              import fit_functions as fitf
-from .. evm.ic_containers import Measurement
+from .. core                import fit_functions as fitf
+from .. core.core_functions import shift_to_bin_centers
+from .. evm.ic_containers   import Measurement
 
 
 def create_new_figure(kwargs):
@@ -32,13 +33,6 @@ def hbins(x, nsigma=5, nbins=10):
     xmax = np.average(x) + nsigma * np.std(x)
     bins = np.linspace(xmin, xmax, nbins + 1)
     return bins
-
-
-def shift_to_bin_centers(x):
-    """
-    Return bin centers, given bin lower edges.
-    """
-    return x[:-1] + np.diff(x) * 0.5
 
 
 def plot(*args, **kwargs):

--- a/invisible_cities/icaro/hst_functions_test.py
+++ b/invisible_cities/icaro/hst_functions_test.py
@@ -1,18 +1,9 @@
 import numpy as np
-from   numpy.testing import assert_equal, assert_allclose
 
-from hypothesis             import given
-from hypothesis.strategies  import floats
-from hypothesis.extra.numpy import arrays
+from   numpy.testing import assert_equal
+from   numpy.testing import assert_allclose
 
 from . import hst_functions as hst
-
-
-@given(arrays(float, 10, floats(min_value=-1e5, max_value=1e5)))
-def test_shift_to_bin_centers(x):
-    x_shifted = hst.shift_to_bin_centers(x)
-    truth     = [np.mean(x[i:i+2]) for i in range(x.size-1)]
-    assert_allclose(x_shifted, truth, rtol=1e-6, atol=1e-6)
 
 
 def test_resolution_no_errors():

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -2,18 +2,18 @@ from collections import namedtuple
 
 import numpy as np
 
-from .. core                 import fit_functions as fitf
-from .. core .stat_functions import poisson_sigma
-from .. core .exceptions     import ParameterNotSet
-from .. icaro.hst_functions  import shift_to_bin_centers
-from .. reco .corrections    import Correction
-from .. reco .corrections    import Fcorrection
-from .. reco .corrections    import LifetimeCorrection
-from .. reco .corrections    import LifetimeRCorrection
-from .. reco .corrections    import LifetimeXYCorrection
-from .. reco .corrections    import opt_nearest
-from .. reco .corrections    import opt_linear
-from .. reco .corrections    import opt_cubic
+from .. core                import fit_functions as fitf
+from .. core.exceptions     import ParameterNotSet
+from .. core.stat_functions import poisson_sigma
+from .. core.core_functions import shift_to_bin_centers
+from .. reco.corrections    import Correction
+from .. reco.corrections    import Fcorrection
+from .. reco.corrections    import LifetimeCorrection
+from .. reco.corrections    import LifetimeRCorrection
+from .. reco.corrections    import LifetimeXYCorrection
+from .. reco.corrections    import opt_nearest
+from .. reco.corrections    import opt_linear
+from .. reco.corrections    import opt_cubic
 
 from numpy.testing import assert_allclose
 from pytest        import fixture

--- a/invisible_cities/reco/spe_response_test.py
+++ b/invisible_cities/reco/spe_response_test.py
@@ -6,11 +6,11 @@ from pytest import fixture
 from flaky  import flaky
 from numpy.testing import assert_allclose
 
-from .. icaro. hst_functions import shift_to_bin_centers
-from .. core .stat_functions import poisson_sigma
-from .. core .core_functions import in_range
-from .. core                 import fit_functions        as fitf
-from .                       import spe_response         as spe
+from .. core.stat_functions import poisson_sigma
+from .. core.core_functions import shift_to_bin_centers
+from .. core.core_functions import in_range
+from .. core                import fit_functions        as fitf
+from .                      import spe_response         as spe
 
 
 @mark.parametrize("         bins               expected ".split(),


### PR DESCRIPTION
In this PR, the functions `profile*` are replaced with a faster implementation. The new implementations use standard functions, which follows the principle of not reinventing the wheel. 

However, for simpler cases there is a better set of functions in `scipy.stats`: `binned_statistics`, `binned_statistics_2d` and `binned_statistics_dd`. Those functions are designed to do exactly what we are want to do: bin data on some axes and apply operations on the remaining one. But there is one caveat: they can only return one statistic per bin. We need to get 3 in our case: mean, std and count, which would imply three calls to those functions, worsening the overall performance of the function. Thus, I have explored a implementation using `pandas`'  dataframes, which is a factor 2-3 faster than our original implementation (in 1-d) and a factor 3-4 faster than the implementation using `scipy` functions. Those speed factors increase very rapidly with the number of dimensions of the original dataset.