### PR TITLE
Patch 456: fix standard deviation and bug with `drop_nan=False`

### DIFF
--- a/invisible_cities/core/fit_functions.py
+++ b/invisible_cities/core/fit_functions.py
@@ -197,10 +197,10 @@ def profileX(xdata, ydata, nbins=100,
 
     mean      = gb.mean().values
     deviation = gb.std () if std else gb.std() / gb.size()**0.5
-    indices   = deviation.index.values
+    indices   = deviation.index.values - 1
 
     if drop_nan:
-        return bin_centers[indices - 1], mean, deviation.values
+        return bin_centers[indices], mean, deviation.values
 
     mean_               = np.full_like(bin_centers, np.nan)
     deviation_          = np.full_like(bin_centers, np.nan)

--- a/invisible_cities/core/fit_functions_test.py
+++ b/invisible_cities/core/fit_functions_test.py
@@ -373,6 +373,28 @@ def test_profile_statistic_values_simple(func, xdata, ydata, xrange, yrange):
     assert   ye[0] == approx(3.0276503540974917)
 
 
+@mark.parametrize("     func                  xdata                 ydata                     ".split(),
+                  ((fitf.profileX, np.array([0] * 10 + [1] * 10), np.tile (np.arange(10),    2)),
+                   (fitf.profileY, np.tile (np.arange(10),    2), np.array([0] * 10 + [1] * 10))))
+@mark.parametrize("drop_nan", (True, False))
+def test_profile_data_in_edges(func, xdata, ydata, drop_nan):
+    # This test ensures the intervals are half-open [a, b)
+    xp, yp, ye = func(xdata, ydata, 2, std=True, drop_nan=drop_nan)
+
+    expected_xp = [0.25              ]
+    expected_yp = [4.50              ]
+    expected_ye = [3.0276503540974917]
+    if not drop_nan:
+        expected_xp.append( 0.75 )
+        expected_yp.append(np.nan)
+        expected_ye.append(np.nan)
+
+    assert len(xp) == len(yp) == len(ye) == len(expected_xp)
+    assert np.allclose(xp, expected_xp, equal_nan=True)
+    assert np.allclose(yp, expected_yp, equal_nan=True)
+    assert np.allclose(ye, expected_ye, equal_nan=True)
+
+
 @mark.slow
 def test_profileXY_full_range():
     N    = 10000

--- a/invisible_cities/core/fit_functions_test.py
+++ b/invisible_cities/core/fit_functions_test.py
@@ -359,6 +359,20 @@ def test_empty_dataset_yields_nans(func, xdata, ydata):
     assert np.all(np.isnan(ye))
 
 
+@mark.parametrize("     func          xdata          ydata        xrange    yrange".split(),
+                  ((fitf.profileX, np.ones  (10), np.arange(10),  (0, 2),     None),
+                   (fitf.profileY, np.arange(10), np.ones  (10),    None,   (0, 2))))
+def test_profile_statistic_values_simple(func, xdata, ydata, xrange, yrange):
+    # Ensure the return values are exactly what they should
+    # be in a simple case
+    xp, yp, ye = func(xdata, ydata, 1, xrange=xrange, yrange=yrange, std=True)
+
+    assert len(xp) == len(yp) == len(ye) == 1
+    assert   xp[0] == approx(1                 )
+    assert   yp[0] == approx(4.5               )
+    assert   ye[0] == approx(3.0276503540974917)
+
+
 @mark.slow
 def test_profileXY_full_range():
     N    = 10000


### PR DESCRIPTION
This is a patch to #456. The test suite didn't catch two errors in the previous PR:
- The definition of the standard deviation changed, but it was subtle, particularly for large datasets (See the description of [97c2423](https://github.com/nextic/IC/commit/97c2423ed9b1f1c16d4a97f20882288f3c627933)).
- When the value of the keyword-argument `drop_nan` is `False`, the output arrays had their values shifted one position to the right.

The test suite has been extended to ensure these two bugs don't show up again. Also, the current definition of the standard deviation is the right one.