### PR TITLE
Fix missing `gain_mau` option in pmtgain

### DIFF
--- a/invisible_cities/calib/pmtgain.py
+++ b/invisible_cities/calib/pmtgain.py
@@ -11,10 +11,11 @@ from functools import partial
 
 import numpy  as np
 
-from .                        import      calib_functions as cf
-from .. io  .         hist_io import          hist_writer
-from .. io  .run_and_event_io import run_and_event_writer
-from .. core.core_functions   import shift_to_bin_centers
+from .                         import      calib_functions as cf
+from .. reco                   import calib_sensors_functions as csf
+from .. io   .         hist_io import          hist_writer
+from .. io   .run_and_event_io import run_and_event_writer
+from .. icaro.hst_functions    import shift_to_bin_centers
 
 from .. core  .system_of_units_c import units
 from .. cities.base_cities       import CalibratedCity

--- a/invisible_cities/calib/pmtgain_test.py
+++ b/invisible_cities/calib/pmtgain_test.py
@@ -12,13 +12,15 @@ import os
 
 import tables as tb
 
+from pytest        import mark
 from numpy.testing import assert_array_equal
 
 from .  pmtgain        import Pmtgain
 from .. core.configure import configure
 
 
-def test_pmtgain_pulsedata(config_tmpdir, ICDATADIR):
+@mark.parametrize("proc_opt", ('gain', 'gain_mau'))
+def test_pmtgain_pulsedata(config_tmpdir, ICDATADIR, proc_opt):
     PATH_IN   = os.path.join(ICDATADIR    , 'pmtledpulsedata.h5')
     PATH_OUT  = os.path.join(config_tmpdir, 'pmtledpulsedata_HIST.h5')
     nrequired = 2
@@ -27,7 +29,8 @@ def test_pmtgain_pulsedata(config_tmpdir, ICDATADIR):
     conf.update(dict(run_number   = 4000,
                      files_in     = PATH_IN,
                      file_out     = PATH_OUT,
-                     event_range  = (0, nrequired)))
+                     event_range  = (0, nrequired),
+                     proc_mode    = proc_opt      ))
 
     pmtgain = Pmtgain(**conf)
     pmtgain.run()

--- a/invisible_cities/calib/sipmgain_test.py
+++ b/invisible_cities/calib/sipmgain_test.py
@@ -20,7 +20,8 @@ from .. core.configure import configure
 
 
 @mark.slow
-def test_sipmgain_pulsedata(config_tmpdir, ICDATADIR):
+@mark.parametrize("proc_opt", ('subtract_mode', 'subtract_median'))
+def test_sipmgain_pulsedata(config_tmpdir, ICDATADIR, proc_opt):
     PATH_IN   = os.path.join(ICDATADIR     , 'sipmledpulsedata.h5')
     PATH_OUT  = os.path.join(config_tmpdir, 'sipmledpulsedata_HIST.h5')
     nrequired = 2
@@ -29,7 +30,8 @@ def test_sipmgain_pulsedata(config_tmpdir, ICDATADIR):
     conf.update(dict(run_number   = 4000,
                      files_in     = PATH_IN,
                      file_out     = PATH_OUT,
-                     event_range  = (0, nrequired)))
+                     event_range  = (0, nrequired),
+                     proc_mode    = proc_opt      ))
 
     sipmgain = Sipmgain(**conf)
     sipmgain.run()

--- a/invisible_cities/reco/calib_sensors_functions.py
+++ b/invisible_cities/reco/calib_sensors_functions.py
@@ -110,6 +110,16 @@ def calibrate_pmts(cwfs, adc_to_pes, n_MAU=100, thr_MAU=3):
     return ccwfs, ccwfs_mau, cwf_sum, cwf_sum_mau
 
 
+def pmt_subtract_mau(cwfs, n_MAU=100):
+    """
+    Subtract a MAU from the input waveforms.
+    """
+    MAU         = np.full(n_MAU, 1 / n_MAU)
+    mau         = signal.lfilter(MAU, 1, cwfs, axis=1)
+
+    return cwfs - mau
+
+
 def calibrate_sipms(sipm_wfs, adc_to_pes, thr, *, bls_mode=BlsMode.mode):
     """
     Subtracts the baseline, calibrates waveforms to pes


### PR DESCRIPTION
Re-added function for the second option which
had been removed accidentally in previous
PR review.