### PR TITLE
Change types in MC true info

### DIFF
--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -118,8 +118,9 @@ def test_irene_electrons_40keV(config_tmpdir, ICDIR, s12params, thr_sipm_type, t
 
             # check events numbers & timestamps
             evts_in     = h5in .root.Run.events[:nactual]
-            evts_out_u8 = h5out.root.Run.events[:nactual]
+            evts_out_i4 = h5out.root.Run.events[:nactual]
 
+            evts_out_u8 = evts_out_i4.astype([('evt_number', '<u8'), ('timestamp', '<u8')])
             np.testing.assert_array_equal(evts_in, evts_out_u8)
 
 

--- a/invisible_cities/cities/isidora_test.py
+++ b/invisible_cities/cities/isidora_test.py
@@ -53,6 +53,8 @@ def test_isidora_electrons_40keV(config_tmpdir, ICDIR):
 
             # check events numbers & timestamps
             evts_in     = h5in .root.Run.events[:nactual]
-            evts_out_u8 = h5out.root.Run.events[:nactual]
+            evts_out_i4 = h5out.root.Run.events[:nactual]
+
+            evts_out_u8 = evts_out_i4.astype([('evt_number', '<u8'), ('timestamp', '<u8')])
 
             np.testing.assert_array_equal(evts_in, evts_out_u8)

--- a/invisible_cities/evm/nh5.py
+++ b/invisible_cities/evm/nh5.py
@@ -34,9 +34,9 @@ class MCExtentInfo(tb.IsDescription):
     """Store the last row of each table as metadata using
     Pytables.
     """
-    evt_number    = tb.Int16Col(pos=0)
-    last_hit      = tb.Int16Col(pos=1)
-    last_particle = tb.Int16Col(pos=2)
+    evt_number    = tb.Int64Col(pos=0)
+    last_hit      = tb.UInt64Col(pos=1)
+    last_particle = tb.UInt64Col(pos=2)
 
 
 class MCHitInfo(tb.IsDescription):

--- a/invisible_cities/evm/nh5.py
+++ b/invisible_cities/evm/nh5.py
@@ -7,7 +7,7 @@ class RunInfo(tb.IsDescription):
 
 
 class EventInfo(tb.IsDescription):
-    evt_number = tb.UInt64Col(shape=(), pos=0)
+    evt_number = tb.Int32Col(shape=(), pos=0)
     timestamp  = tb.UInt64Col(shape=(), pos=1)
 
 
@@ -34,7 +34,7 @@ class MCExtentInfo(tb.IsDescription):
     """Store the last row of each table as metadata using
     Pytables.
     """
-    evt_number    = tb.Int64Col(pos=0)
+    evt_number    = tb.Int32Col(pos=0)
     last_hit      = tb.UInt64Col(pos=1)
     last_particle = tb.UInt64Col(pos=2)
 

--- a/invisible_cities/io/mcinfo_io.py
+++ b/invisible_cities/io/mcinfo_io.py
@@ -162,8 +162,9 @@ def read_mcinfo_evt (mctables: (tb.Table, tb.Table, tb.Table),
             ihit = ipart = 0
             if iext > 0:
                 previous_row = h5extents[iext-1]
-                ihit         = previous_row['last_hit'] + 1
-                ipart        = previous_row['last_particle'] + 1
+
+                ihit         = int(previous_row['last_hit']) + 1
+                ipart        = int(previous_row['last_particle']) + 1
 
             ihit_end  = this_row['last_hit']
             ipart_end = this_row['last_particle']


### PR DESCRIPTION
This PR is the adaption of the IC code to a problem of overflow in nexus MC true tables. 
The types of the columns of the `extents` table have been changed from `unsigned int` or `int` to `uint64` or `int64` in order to be able to represent a larger number of events. Strangely (to me), it turns out that, when adding a `uint64` to an `int`, python gives as a result a `float64` (see, for instance, [this thread](https://github.com/numpy/numpy/issues/7126)). Therefore, in this PR I simply cast my `uint64` variable to `int`, which, if I'm not wrong, is the same as a `long` in python, so it should be ok. Opinions?