### PR TITLE
First version of channel parameter output

### DIFF
--- a/invisible_cities/database/load_db.py
+++ b/invisible_cities/database/load_db.py
@@ -73,7 +73,7 @@ order by pos.SensorID'''.format(abs(run_number))
     ## Add default value to Sigma for runs without measurement
     if not data.Sigma.values.any():
         data.Sigma = 2.24
-        
+
     return data
 
 @lru_cache(maxsize=10)
@@ -111,4 +111,3 @@ order by SensorID, BinEnergyPes;'''.format(abs(run_number))
     noise = np.array(data).reshape(nsipms, nbins)
 
     return noise, noise_bins, baselines
-

--- a/invisible_cities/database/load_db.py
+++ b/invisible_cities/database/load_db.py
@@ -111,3 +111,4 @@ order by SensorID, BinEnergyPes;'''.format(abs(run_number))
     noise = np.array(data).reshape(nsipms, nbins)
 
     return noise, noise_bins, baselines
+

--- a/invisible_cities/io/channel_param_io.py
+++ b/invisible_cities/io/channel_param_io.py
@@ -1,0 +1,79 @@
+import tables as tb
+from .. reco     import tbl_functions as tbl
+
+
+## A dictionary to define the structure of the output table
+## At initialization, the function specific entries will
+## be defined.
+calibration_parameters = {
+    'SensorID' : tb.UInt32Col(pos=0)
+    }
+
+
+## Suggested parameter list
+## Useful for generic/default fit functions
+generic_params = ["normalization", "poisson_mu"    ,
+                  "pedestal"     , "pedestal_sigma",
+                  "gain"         , "gain_sigma"    ,
+                  "fit_limits"   , "n_gaussians_chi2" ]
+
+
+def create_param_table(h5out, sensor_type, func_name, param_names, covariance=None):
+    ## First sort out the column names:
+    for i, par in enumerate(param_names):
+        calibration_parameters[par] = tb.Float32Col(pos=i + 1, shape=2)
+
+    if covariance:
+        # We're saving the covariance matrix too
+        calibration_parameters["covariance"] = tb.Float32Col(pos=len(param_names)+1,
+                                                             shape=covariance   )
+    
+    ## If the group 'FITPARAMS' doesn't already exist, create it
+    try:                       PARAM_group = getattr(h5out.root, "FITPARAMS")
+    except tb.NoSuchNodeError: PARAM_group = h5out.create_group(h5out.root,
+                                                                "FITPARAMS")
+    ## Define a table for this fitting function
+    param_table = h5out.create_table(PARAM_group,
+                                     "FIT_"+sensor_type+"_"+func_name,
+                                     calibration_parameters,
+                                     "Calibration parameters",
+                                     tbl.filters("NOCOMPR"))
+    return param_table
+
+
+def store_fit_values(param_table, sensor_id, fit_result):
+
+    channel = param_table.row
+    channel["SensorID"] = sensor_id
+    for key, param in fit_result.items():
+        channel[key] = param
+    channel.append()
+    param_table.flush()
+
+
+def channel_param_writer(h5out, *, sensor_type,
+                         func_name, param_names,
+                         covariance=None):
+    """
+    Define a group, table and writer function for the ouput
+    of fit parameters.
+    input:
+    h5out : the predefined hdf5 output file
+    sensor_type : e.g. pmt, sipm or FE
+    func_name : A string with the name of the fitting function being used
+    param_names : A list of parameter names
+    covariance : None or a tuple with the shape of the covariance matrix
+    """
+    
+    param_table = create_param_table(h5out, sensor_type,
+                                     func_name, param_names, covariance)
+    def store_channel_fit(sensor_id, fit_result):
+        """
+        input:
+        channel_id : Sensor number
+        fit_result : dict with keys as parameter names
+                     Fit parameters should be (value, error)
+        """
+        store_fit_values(param_table, sensor_id, fit_result)
+    
+    return store_channel_fit

--- a/invisible_cities/io/channel_param_io.py
+++ b/invisible_cities/io/channel_param_io.py
@@ -75,7 +75,7 @@ def channel_param_writer(h5out, *, sensor_type,
     def store_channel_fit(sensor_id, fit_result):
         """
         input:
-        channel_id : Sensor number
+        sensor_id : Sensor number
         fit_result : dict with keys as parameter names
                      Fit parameters should be (value, error)
         """

--- a/invisible_cities/io/channel_param_io.py
+++ b/invisible_cities/io/channel_param_io.py
@@ -35,6 +35,25 @@ def store_fit_values(param_table, sensor_id, fit_result):
     param_table.flush()
 
 
+def make_table_dictionary(param_names, covariance=None):
+    """
+    returns a dictionary to be used in the
+    table definition.
+    """
+
+    parameter_dict = {'SensorID' : tb.UInt32Col(pos=0)}
+    for i, par in enumerate(param_names):
+        parameter_dict[par] = tb.Float32Col(pos=i + 1, shape=2)
+
+    if covariance:
+        # We're saving the covariance matrix too
+        cov_pos = len(param_names) + 1
+        parameter_dict["covariance"] = tb.Float32Col(pos=cov_pos,
+                                                     shape=covariance)
+
+    return parameter_dict
+
+
 def channel_param_writer(h5out, *, sensor_type,
                          func_name, param_names,
                          covariance=None):
@@ -49,14 +68,7 @@ def channel_param_writer(h5out, *, sensor_type,
     covariance : None or a tuple with the shape of the covariance matrix
     """
 
-    parameter_dict = {'SensorID' : tb.UInt32Col(pos=0)}
-    for i, par in enumerate(param_names):
-        parameter_dict[par] = tb.Float32Col(pos=i + 1, shape=2)
-
-    if covariance:
-        # We're saving the covariance matrix too
-        parameter_dict["covariance"] = tb.Float32Col(pos=len(param_names)+1,
-                                                     shape=covariance   )
+    parameter_dict = make_table_dictionary(param_names, covariance)
     
     param_table = create_param_table(h5out, sensor_type,
                                      func_name, parameter_dict)

--- a/invisible_cities/io/channel_param_io.py
+++ b/invisible_cities/io/channel_param_io.py
@@ -11,7 +11,7 @@ generic_params = ["normalization", "poisson_mu"    ,
 
 
 def create_param_table(h5out, sensor_type, func_name, parameter_dict):
-    
+
     ## If the group 'FITPARAMS' doesn't already exist, create it
     try:                       PARAM_group = getattr(h5out.root, "FITPARAMS")
     except tb.NoSuchNodeError: PARAM_group = h5out.create_group(h5out.root,
@@ -69,7 +69,7 @@ def channel_param_writer(h5out, *, sensor_type,
     """
 
     parameter_dict = make_table_dictionary(param_names, covariance)
-    
+
     param_table = create_param_table(h5out, sensor_type,
                                      func_name, parameter_dict)
     def store_channel_fit(sensor_id, fit_result):
@@ -80,7 +80,7 @@ def channel_param_writer(h5out, *, sensor_type,
                      Fit parameters should be (value, error)
         """
         store_fit_values(param_table, sensor_id, fit_result)
-    
+
     return store_channel_fit
 
 
@@ -164,4 +164,3 @@ def parameters_and_errors(table_row, parameters):
 
     return param_dict, error_dict
 
-    

--- a/invisible_cities/io/channel_param_io_test.py
+++ b/invisible_cities/io/channel_param_io_test.py
@@ -17,25 +17,30 @@ def test_generic_parameters(config_tmpdir):
     filename = os.path.join(config_tmpdir, 'test_param.h5')
 
     outDict = {}
+    val_list = []
+    n_rows = 5
     with tb.open_file(filename, 'w') as dataOut:
         pWrite = channel_param_writer(dataOut, sensor_type="test",
                                       func_name="generic",
                                       param_names=generic_params)
 
-        for i, par in enumerate(generic_params):
-            outDict[par] = [i, i / 10]
+        for sens in range(n_rows):
+            for i, par in enumerate(generic_params):
+                outDict[par] = [i, (i + sens) / 10]
 
-        pWrite(0, outDict)
+            pWrite(sens, outDict)
+            val_list.append(list(outDict.values()))
 
     col_list = ['SensorID'] + list(outDict.keys())
-    val_list = np.concatenate(list(outDict.values()))
+    val_list = np.concatenate(val_list)
     with tb.open_file(filename) as dataIn:
 
         tblRead = dataIn.root.FITPARAMS.FIT_test_generic
-        assert tblRead.nrows == 1
+        assert tblRead.nrows == n_rows
         assert len(tblRead.colnames) == len(generic_params) + 1
         assert tblRead.colnames == col_list
-        assert_allclose(np.concatenate(list(tblRead[0])[1:]), val_list)
+        all_values = [ list(x)[1:] for x in tblRead[:] ]
+        assert_allclose(np.concatenate(all_values), val_list)
 
 
 def test_simple_parameters_with_covariance(config_tmpdir):
@@ -76,8 +81,7 @@ def test_make_table_dictionary():
 def test_store_fit_values(config_tmpdir):
     filename = os.path.join(config_tmpdir, 'test_param.h5')
 
-    dummy_dict = {'SensorID' : tb.UInt32Col(pos=0),
-                  'par0' : tb.UInt32Col(pos=1)}
+    dummy_dict = make_table_dictionary(['par0'])
 
     with tb.open_file(filename, 'w') as dataOut:
         PARAM_group = dataOut.create_group(dataOut.root, "testgroup")

--- a/invisible_cities/io/channel_param_io_test.py
+++ b/invisible_cities/io/channel_param_io_test.py
@@ -1,0 +1,58 @@
+import os
+
+import numpy  as np
+import tables as tb
+
+from numpy.testing import assert_allclose
+
+from . channel_param_io import       generic_params
+from . channel_param_io import channel_param_writer
+
+
+def test_generic_parameters(config_tmpdir):
+    filename = os.path.join(config_tmpdir, 'test_param.h5')
+
+    outDict = {}
+    with tb.open_file(filename, 'w') as dataOut:
+        pWrite = channel_param_writer(dataOut, sensor_type="test",
+                                      func_name="generic",
+                                      param_names=generic_params)
+
+        for i, par in enumerate(generic_params):
+            outDict[par] = [i, i / 10]
+
+        pWrite(0, outDict)
+
+    col_list = ['SensorID'] + list(outDict.keys())
+    val_list = np.concatenate(list(outDict.values()))
+    with tb.open_file(filename) as dataIn:
+
+        tblRead = dataIn.root.FITPARAMS.FIT_test_generic
+        assert tblRead.nrows == 1
+        assert len(tblRead.colnames) == len(generic_params) + 1
+        assert tblRead.colnames == col_list
+        assert_allclose(np.concatenate(list(tblRead[0])[1:]), val_list)
+
+
+def test_simple_parameters_with_covariance(config_tmpdir):
+    filename = os.path.join(config_tmpdir, 'test_param.h5')
+
+    simple = ["par0", "par1", "par2"]
+    cov = np.array([[0, 1, 2], [3, 4, 5]])
+    outDict = {}
+    with tb.open_file(filename, 'w') as dataOut:
+        pWrite = channel_param_writer(dataOut, sensor_type="test",
+                                      func_name="simple",
+                                      param_names=simple, covariance=cov.shape)
+
+        for i, par in enumerate(simple):
+            outDict[par] = (i, i / 10)
+        outDict["covariance"] = cov
+        
+        pWrite(0, outDict)
+
+    with tb.open_file(filename) as dataIn:
+
+        file_cov = dataIn.root.FITPARAMS.FIT_test_simple[0]["covariance"]
+        assert_allclose(file_cov, cov)
+    

--- a/invisible_cities/io/channel_param_io_test.py
+++ b/invisible_cities/io/channel_param_io_test.py
@@ -74,7 +74,7 @@ def test_generator_param_reader(config_tmpdir):
             assert_allclose(val_list[sens, :, 1], np.array(list(errs.values())))
             counter += 1
         assert counter == n_rows
-            
+
 
 
 def test_simple_parameters_with_covariance(config_tmpdir):
@@ -91,7 +91,7 @@ def test_simple_parameters_with_covariance(config_tmpdir):
         for i, par in enumerate(simple):
             out_dict[par] = (i, i / 10)
         out_dict["covariance"] = cov
-        
+
         pWrite(0, out_dict)
 
     with tb.open_file(filename) as data_in:
@@ -103,9 +103,9 @@ def test_simple_parameters_with_covariance(config_tmpdir):
 def test_make_table_dictionary():
 
     param_names = ["par0", "par1", "par2"]
-    
+
     par_dict = make_table_dictionary(param_names)
-    
+
     # Add the sensor id to the test list
     param_names = ["SensorID"] + param_names
 
@@ -125,7 +125,7 @@ def test_store_fit_values(config_tmpdir):
                                            dummy_dict,
                                            "test parameters",
                                            tbl.filters("NOCOMPR"))
-        
+
         store_fit_values(param_table, 0, {'par0' : 22})
 
     with tb.open_file(filename) as data_in:

--- a/invisible_cities/io/channel_param_io_test.py
+++ b/invisible_cities/io/channel_param_io_test.py
@@ -21,8 +21,8 @@ def test_generic_parameters(config_tmpdir):
     outDict = {}
     val_list = []
     n_rows = 5
-    with tb.open_file(filename, 'w') as dataOut:
-        pWrite = channel_param_writer(dataOut, sensor_type="test",
+    with tb.open_file(filename, 'w') as data_out:
+        pWrite = channel_param_writer(data_out, sensor_type="test",
                                       func_name="generic",
                                       param_names=generic_params)
 
@@ -35,9 +35,9 @@ def test_generic_parameters(config_tmpdir):
 
     col_list = ['SensorID'] + list(outDict.keys())
     val_list = np.concatenate(val_list)
-    with tb.open_file(filename) as dataIn:
+    with tb.open_file(filename) as data_in:
 
-        tbl_names, param_names, tbls = basic_param_reader(dataIn)
+        tbl_names, param_names, tbls = basic_param_reader(data_in)
         assert len(tbls) == 1
         assert tbls[0].nrows == n_rows
         assert len(param_names[0]) == len(col_list)
@@ -52,8 +52,8 @@ def test_generator_param_reader(config_tmpdir):
     outDict = {}
     val_list = []
     n_rows = 5
-    with tb.open_file(filename, 'w') as dataOut:
-        pWrite = channel_param_writer(dataOut, sensor_type="test",
+    with tb.open_file(filename, 'w') as data_out:
+        pWrite = channel_param_writer(data_out, sensor_type="test",
                                       func_name="generic",
                                       param_names=generic_params)
 
@@ -65,9 +65,9 @@ def test_generator_param_reader(config_tmpdir):
             val_list.append(list(outDict.values()))
 
     val_list = np.array(val_list)
-    with tb.open_file(filename) as dataIn:
+    with tb.open_file(filename) as data_in:
         counter = 0
-        for sens, (vals, errs) in generator_param_reader(dataIn, 'FIT_test_generic'):
+        for sens, (vals, errs) in generator_param_reader(data_in, 'FIT_test_generic'):
             assert sens == counter
             assert len(vals) == len(errs) == len(outDict)
             assert_allclose(val_list[sens, :, 0], np.array(list(vals.values())))
@@ -83,8 +83,8 @@ def test_simple_parameters_with_covariance(config_tmpdir):
     simple = ["par0", "par1", "par2"]
     cov = np.array([[0, 1, 2], [3, 4, 5]])
     outDict = {}
-    with tb.open_file(filename, 'w') as dataOut:
-        pWrite = channel_param_writer(dataOut, sensor_type="test",
+    with tb.open_file(filename, 'w') as data_out:
+        pWrite = channel_param_writer(data_out, sensor_type="test",
                                       func_name="simple",
                                       param_names=simple, covariance=cov.shape)
 
@@ -94,9 +94,9 @@ def test_simple_parameters_with_covariance(config_tmpdir):
         
         pWrite(0, outDict)
 
-    with tb.open_file(filename) as dataIn:
+    with tb.open_file(filename) as data_in:
 
-        file_cov = dataIn.root.FITPARAMS.FIT_test_simple[0]["covariance"]
+        file_cov = data_in.root.FITPARAMS.FIT_test_simple[0]["covariance"]
         assert_allclose(file_cov, cov)
 
 
@@ -117,10 +117,10 @@ def test_store_fit_values(config_tmpdir):
 
     dummy_dict = make_table_dictionary(['par0'])
 
-    with tb.open_file(filename, 'w') as dataOut:
-        PARAM_group = dataOut.create_group(dataOut.root, "testgroup")
+    with tb.open_file(filename, 'w') as data_out:
+        PARAM_group = data_out.create_group(data_out.root, "testgroup")
 
-        param_table = dataOut.create_table(PARAM_group,
+        param_table = data_out.create_table(PARAM_group,
                                            "testtable",
                                            dummy_dict,
                                            "test parameters",
@@ -128,9 +128,9 @@ def test_store_fit_values(config_tmpdir):
         
         store_fit_values(param_table, 0, {'par0' : 22})
 
-    with tb.open_file(filename) as dataIn:
+    with tb.open_file(filename) as data_in:
 
-        tblRead = dataIn.root.testgroup.testtable
+        tblRead = data_in.root.testgroup.testtable
         assert tblRead.nrows == 1
         assert len(tblRead.colnames) == len(dummy_dict)
         assert tblRead.colnames == list(dummy_dict.keys())

--- a/invisible_cities/io/channel_param_io_test.py
+++ b/invisible_cities/io/channel_param_io_test.py
@@ -7,10 +7,12 @@ from numpy.testing import assert_allclose
 
 from .. reco     import tbl_functions as tbl
 
-from . channel_param_io import        generic_params
-from . channel_param_io import      store_fit_values
-from . channel_param_io import  channel_param_writer
-from . channel_param_io import make_table_dictionary
+from . channel_param_io import         generic_params
+from . channel_param_io import       store_fit_values
+from . channel_param_io import   channel_param_writer
+from . channel_param_io import  make_table_dictionary
+from . channel_param_io import     basic_param_reader
+from . channel_param_io import generator_param_reader
 
 
 def test_generic_parameters(config_tmpdir):
@@ -35,12 +37,44 @@ def test_generic_parameters(config_tmpdir):
     val_list = np.concatenate(val_list)
     with tb.open_file(filename) as dataIn:
 
-        tblRead = dataIn.root.FITPARAMS.FIT_test_generic
-        assert tblRead.nrows == n_rows
-        assert len(tblRead.colnames) == len(generic_params) + 1
-        assert tblRead.colnames == col_list
-        all_values = [ list(x)[1:] for x in tblRead[:] ]
+        tbl_names, param_names, tbls = basic_param_reader(dataIn)
+        assert len(tbls) == 1
+        assert tbls[0].nrows == n_rows
+        assert len(param_names[0]) == len(col_list)
+        assert param_names[0] == col_list
+        all_values = [ list(x)[1:] for x in tbls[0][:] ]
         assert_allclose(np.concatenate(all_values), val_list)
+
+
+def test_generator_param_reader(config_tmpdir):
+    filename = os.path.join(config_tmpdir, 'test_param.h5')
+
+    outDict = {}
+    val_list = []
+    n_rows = 5
+    with tb.open_file(filename, 'w') as dataOut:
+        pWrite = channel_param_writer(dataOut, sensor_type="test",
+                                      func_name="generic",
+                                      param_names=generic_params)
+
+        for sens in range(n_rows):
+            for i, par in enumerate(generic_params):
+                outDict[par] = [i, (i + sens) / 10]
+
+            pWrite(sens, outDict)
+            val_list.append(list(outDict.values()))
+
+    val_list = np.array(val_list)
+    with tb.open_file(filename) as dataIn:
+        counter = 0
+        for sens, (vals, errs) in generator_param_reader(dataIn, 'FIT_test_generic'):
+            assert sens == counter
+            assert len(vals) == len(errs) == len(outDict)
+            assert_allclose(val_list[sens, :, 0], np.array(list(vals.values())))
+            assert_allclose(val_list[sens, :, 1], np.array(list(errs.values())))
+            counter += 1
+        assert counter == n_rows
+            
 
 
 def test_simple_parameters_with_covariance(config_tmpdir):

--- a/invisible_cities/io/channel_param_io_test.py
+++ b/invisible_cities/io/channel_param_io_test.py
@@ -18,7 +18,7 @@ from . channel_param_io import generator_param_reader
 def test_generic_parameters(config_tmpdir):
     filename = os.path.join(config_tmpdir, 'test_param.h5')
 
-    outDict = {}
+    out_dict = {}
     val_list = []
     n_rows = 5
     with tb.open_file(filename, 'w') as data_out:
@@ -28,12 +28,12 @@ def test_generic_parameters(config_tmpdir):
 
         for sens in range(n_rows):
             for i, par in enumerate(generic_params):
-                outDict[par] = [i, (i + sens) / 10]
+                out_dict[par] = [i, (i + sens) / 10]
 
-            pWrite(sens, outDict)
-            val_list.append(list(outDict.values()))
+            pWrite(sens, out_dict)
+            val_list.append(list(out_dict.values()))
 
-    col_list = ['SensorID'] + list(outDict.keys())
+    col_list = ['SensorID'] + list(out_dict.keys())
     val_list = np.concatenate(val_list)
     with tb.open_file(filename) as data_in:
 
@@ -49,7 +49,7 @@ def test_generic_parameters(config_tmpdir):
 def test_generator_param_reader(config_tmpdir):
     filename = os.path.join(config_tmpdir, 'test_param.h5')
 
-    outDict = {}
+    out_dict = {}
     val_list = []
     n_rows = 5
     with tb.open_file(filename, 'w') as data_out:
@@ -59,17 +59,17 @@ def test_generator_param_reader(config_tmpdir):
 
         for sens in range(n_rows):
             for i, par in enumerate(generic_params):
-                outDict[par] = [i, (i + sens) / 10]
+                out_dict[par] = [i, (i + sens) / 10]
 
-            pWrite(sens, outDict)
-            val_list.append(list(outDict.values()))
+            pWrite(sens, out_dict)
+            val_list.append(list(out_dict.values()))
 
     val_list = np.array(val_list)
     with tb.open_file(filename) as data_in:
         counter = 0
         for sens, (vals, errs) in generator_param_reader(data_in, 'FIT_test_generic'):
             assert sens == counter
-            assert len(vals) == len(errs) == len(outDict)
+            assert len(vals) == len(errs) == len(out_dict)
             assert_allclose(val_list[sens, :, 0], np.array(list(vals.values())))
             assert_allclose(val_list[sens, :, 1], np.array(list(errs.values())))
             counter += 1
@@ -82,17 +82,17 @@ def test_simple_parameters_with_covariance(config_tmpdir):
 
     simple = ["par0", "par1", "par2"]
     cov = np.array([[0, 1, 2], [3, 4, 5]])
-    outDict = {}
+    out_dict = {}
     with tb.open_file(filename, 'w') as data_out:
         pWrite = channel_param_writer(data_out, sensor_type="test",
                                       func_name="simple",
                                       param_names=simple, covariance=cov.shape)
 
         for i, par in enumerate(simple):
-            outDict[par] = (i, i / 10)
-        outDict["covariance"] = cov
+            out_dict[par] = (i, i / 10)
+        out_dict["covariance"] = cov
         
-        pWrite(0, outDict)
+        pWrite(0, out_dict)
 
     with tb.open_file(filename) as data_in:
 


### PR DESCRIPTION
channel_param_io and associated test added.
Thought for generic use with any sensor type
or other numbered channel.

Updated names to be a bit more consistent with DB

improved names

added explicit sensor info in table title