### PR TITLE
Fix pmap io

### DIFF
--- a/invisible_cities/io/pmaps_io.py
+++ b/invisible_cities/io/pmaps_io.py
@@ -117,19 +117,25 @@ def load_pmaps(filename):
     return pmap_dict
 
 
+import itertools
+import operator
+def unique(values):
+    return np.array(tuple(map(operator.itemgetter(0), itertools.groupby(values))))
+
+
 def build_pmt_responses(pmtdf, ipmtdf):
-    times   =            pmtdf.time.values
-    pmt_ids = np.unique(ipmtdf.npmt.values)
-    enes    =           ipmtdf.ene .values.reshape(pmt_ids.size,
-                                                     times.size)
+    times   =         pmtdf.time.values
+    pmt_ids = unique(ipmtdf.npmt.values)
+    enes    =        ipmtdf.ene .values.reshape(pmt_ids.size,
+                                                times.size)
     return times, PMTResponses(pmt_ids, enes)
 
 
 def build_sipm_responses(sidf):
     if len(sidf) == 0: return SiPMResponses.build_empty_instance()
 
-    sipm_ids = np.unique(sidf.nsipm.values)
-    enes     =           sidf.ene  .values
+    sipm_ids = unique(sidf.nsipm.values)
+    enes     =        sidf.ene  .values
     n_times  = enes.size // sipm_ids.size
     enes     = enes.reshape(sipm_ids.size, n_times)
     return SiPMResponses(sipm_ids, enes)

--- a/invisible_cities/io/pmaps_io.py
+++ b/invisible_cities/io/pmaps_io.py
@@ -119,7 +119,7 @@ def load_pmaps(filename):
 
 def build_pmt_responses(pmtdf, ipmtdf):
     times   =            pmtdf.time.values
-    pmt_ids = np.unique(ipmtdf.npmt.values)
+    pmt_ids = pd.unique(ipmtdf.npmt.values)
     enes    =           ipmtdf.ene .values.reshape(pmt_ids.size,
                                                      times.size)
     return times, PMTResponses(pmt_ids, enes)
@@ -128,7 +128,7 @@ def build_pmt_responses(pmtdf, ipmtdf):
 def build_sipm_responses(sidf):
     if len(sidf) == 0: return SiPMResponses.build_empty_instance()
 
-    sipm_ids = np.unique(sidf.nsipm.values)
+    sipm_ids = pd.unique(sidf.nsipm.values)
     enes     =           sidf.ene  .values
     n_times  = enes.size // sipm_ids.size
     enes     = enes.reshape(sipm_ids.size, n_times)

--- a/invisible_cities/io/pmaps_io.py
+++ b/invisible_cities/io/pmaps_io.py
@@ -117,19 +117,24 @@ def load_pmaps(filename):
     return pmap_dict
 
 
+def unique(values):
+    unique, indices = np.unique(values, return_index=True)
+    return unique[np.argsort(indices)]
+
+
 def build_pmt_responses(pmtdf, ipmtdf):
-    times   =            pmtdf.time.values
-    pmt_ids = np.unique(ipmtdf.npmt.values)
-    enes    =           ipmtdf.ene .values.reshape(pmt_ids.size,
-                                                     times.size)
+    times   =         pmtdf.time.values
+    pmt_ids = unique(ipmtdf.npmt.values)
+    enes    =        ipmtdf.ene .values.reshape(pmt_ids.size,
+                                                times.size)
     return times, PMTResponses(pmt_ids, enes)
 
 
 def build_sipm_responses(sidf):
     if len(sidf) == 0: return SiPMResponses.build_empty_instance()
 
-    sipm_ids = np.unique(sidf.nsipm.values)
-    enes     =           sidf.ene  .values
+    sipm_ids = unique(sidf.nsipm.values)
+    enes     =        sidf.ene  .values
     n_times  = enes.size // sipm_ids.size
     enes     = enes.reshape(sipm_ids.size, n_times)
     return SiPMResponses(sipm_ids, enes)


### PR DESCRIPTION
@jmbenlloch has found a bug in the pmap reader. The SiPMs waveforms were not properly matched to each sensor. This was caused by `np.unique` which, besides removing duplicates, sorts the elements. This can also be a problem in the PMTs waveforms, although the PMTs are, in principle, always sorted.

A couple of tests have been added to demonstrate the situation and to ensure this doesn't happen again in the future.

The solution consists of replacing `np.unique` by `pd.unique`, which preserves the original order. There is one caveat, though: `pd.unique` removes only ***consecutive*** duplicate elements. This is ok as our data is stored on a sensor-by-sensor basis and there should not be non-consecutive duplicate elements.

Two other alternative implementations have been also considered, but the one using `pd.unique` is the fastest one as demonstrated in the plot attached.

![image](https://user-images.githubusercontent.com/8233521/38728817-3ed89f50-3f11-11e8-9fd2-38c0c936cc54.png)
