### PR TITLE
Fix tornado version to 4.5.1 py36_0

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -80,6 +80,7 @@ dependencies:
 - python=3.6.2=0
 - scipy=0.19.1=np113py36_0
 - sphinx=1.6.3=py36_0
+- tornado=4.5.1=py36_0
 - pip:
   - flaky==3.4.0
   - hypothesis==3.32.0


### PR DESCRIPTION
I had some issues using Jupyter Notebook and finally, Gonzalo and I solved by fixing tornado package version to 4.5.1 py36_0