### PR TITLE
Changes in calibration cities for other setups

### DIFF
--- a/invisible_cities/calib/calib_functions.py
+++ b/invisible_cities/calib/calib_functions.py
@@ -2,7 +2,8 @@
 Contains functions used in calibration.
 """
 
-import numpy as np
+import numpy  as np
+import tables as tb
 
 from .. core.system_of_units_c import units
 from .. core.core_functions    import in_range
@@ -107,3 +108,20 @@ def filter_limits(limits, buffer_length):
     if n_false_second_half % 2: within_buffer[- n_false_second_half - 1] = False
 
     return limits[within_buffer]
+
+
+def copy_sensor_table(h5in, h5out):
+    # Copy sensor table if exists (needed for Non DB calibrations)
+
+    with tb.open_file(h5in) as dIn:
+        if 'Sensors' not in dIn.root:
+            return
+        group    = h5out.create_group(h5out.root, "Sensors")
+
+        if 'DataPMT' in dIn.root.Sensors:
+            datapmt  = dIn.root.Sensors.DataPMT
+            datapmt.copy(newparent=group)
+
+        if 'DataSiPM' in dIn.root.Sensors:
+            datasipm = dIn.root.Sensors.DataSiPM
+            datasipm.copy(newparent=group)

--- a/invisible_cities/calib/calib_functions_test.py
+++ b/invisible_cities/calib/calib_functions_test.py
@@ -92,3 +92,26 @@ def test_filter_limits_outside():
     assert len(filtered_dlimits) < len(unfiltered_dlimits)
     assert len(filtered_llimits) % 2 == 0
     assert len(filtered_dlimits) % 2 == 0
+
+
+## def test_copy_sensor_table(config_tmpdir):
+
+##     ## Create an empty input file to begin
+##     in_name = os.path.join(config_tmpdir, 'test_copy_in.h5')
+##     out_name = os.path.join(config_tmpdir, 'test_copy_out.h5')
+##     with tb.open_file(in_name, 'w') as input_file:
+##         input_file.create_group(input_file.root, 'dummy')
+    
+##     ## Test copy where Sensors group not present etc.
+##     with tb.open_file(in_name, 'a') as inF, tb.open_file(out_name, 'w') as outF:
+
+##         ## Nothing to copy
+##         cf.copy_sensor_table(inF, outF)
+
+##         ## Sensor group with no table
+##         inF.create_group(inF.root, 'Sensors')
+##         cf.copy_sensor_table(inF, outF)
+##         assert 'Sensors' in outF.root
+
+##         ## Only PMTs
+##         inF.

--- a/invisible_cities/calib/pmtgain.py
+++ b/invisible_cities/calib/pmtgain.py
@@ -85,7 +85,7 @@ class Pmtgain(CalibratedCity):
 
     def without_deconv(self, RWF):
         CWF = csf.subtract_mode(RWF)
-        return CWF[self.pmt_active]
+        return CWF[self.pmt_active_list]
 
     def event_loop(self, NEVT, dataVectors):
         """actions:

--- a/invisible_cities/calib/pmtgain.py
+++ b/invisible_cities/calib/pmtgain.py
@@ -126,6 +126,9 @@ class Pmtgain(CalibratedCity):
 
 
     def get_writers(self, h5out):
+        ## Copy sensor info (good for non DB tests)
+        cf.copy_sensor_table(self.input_files[0], h5out)
+        
         bin_centres = shift_to_bin_centers(self.histbins)
         HIST        = partial(hist_writer,
                               h5out,
@@ -146,14 +149,3 @@ class Pmtgain(CalibratedCity):
     def display_IO_info(self):
         super().display_IO_info()
         print(self.sp)
-
-    def _copy_sensor_table(self, h5in):
-        # Copy sensor table if exists (needed for GATE)
-        if 'Sensors' not in h5in.root: return
-
-        group    = self.output_file.create_group(self.output_file.root, "Sensors")
-        datapmt  = h5in.root.Sensors.DataPMT
-        datasipm = h5in.root.Sensors.DataSiPM
-
-        datapmt .copy(newparent=group)
-        datasipm.copy(newparent=group)

--- a/invisible_cities/calib/pmtgain.py
+++ b/invisible_cities/calib/pmtgain.py
@@ -56,6 +56,8 @@ class Pmtgain(CalibratedCity):
             self.pmt_processing = self.deconv_pmt
         elif conf.proc_mode == "gain_mau":
             self.pmt_processing = self.deconv_pmt_mau
+        elif conf.proc_mode == "gain_nodeconv":
+            self.pmt_processing = self.without_deconv
         else:
             raise ValueError(f"Unrecognized processing mode: {conf.proc_mode}")
 
@@ -80,6 +82,10 @@ class Pmtgain(CalibratedCity):
     def deconv_pmt_mau(self, RWF):
         CWF = self.deconv_pmt(RWF)
         return csf.pmt_subtract_mau(CWF, n_MAU=self.n_MAU)
+
+    def without_deconv(self, RWF):
+        CWF = csf.subtract_mode(RWF)
+        return CWF[self.pmt_active]
 
     def event_loop(self, NEVT, dataVectors):
         """actions:
@@ -113,7 +119,7 @@ class Pmtgain(CalibratedCity):
             # LED (correlated)
             led_ints  = cf.spaced_integrals(pmt_adc, self.l_limits)[:, ::2]
             pmt_spe  += cf.bin_waveforms(led_ints, self.histbins)
-
+            
             # Dark (anti-correlated)
             dark_ints  = cf.spaced_integrals(pmt_adc, self.d_limits)[:, ::2]
             pmt_dark  += cf.bin_waveforms(dark_ints, self.histbins)

--- a/invisible_cities/calib/pmtgain.py
+++ b/invisible_cities/calib/pmtgain.py
@@ -119,7 +119,7 @@ class Pmtgain(CalibratedCity):
             # LED (correlated)
             led_ints  = cf.spaced_integrals(pmt_adc, self.l_limits)[:, ::2]
             pmt_spe  += cf.bin_waveforms(led_ints, self.histbins)
-            
+
             # Dark (anti-correlated)
             dark_ints  = cf.spaced_integrals(pmt_adc, self.d_limits)[:, ::2]
             pmt_dark  += cf.bin_waveforms(dark_ints, self.histbins)
@@ -134,7 +134,7 @@ class Pmtgain(CalibratedCity):
     def get_writers(self, h5out):
         ## Copy sensor info (good for non DB tests)
         cf.copy_sensor_table(self.input_files[0], h5out)
-        
+
         bin_centres = shift_to_bin_centers(self.histbins)
         HIST        = partial(hist_writer,
                               h5out,

--- a/invisible_cities/calib/pmtgain_test.py
+++ b/invisible_cities/calib/pmtgain_test.py
@@ -19,7 +19,7 @@ from .  pmtgain        import Pmtgain
 from .. core.configure import configure
 
 
-@mark.parametrize("proc_opt", ('gain', 'gain_mau'))
+@mark.parametrize("proc_opt", ('gain', 'gain_mau', 'gain_nodeconv'))
 def test_pmtgain_pulsedata(config_tmpdir, ICDATADIR, proc_opt):
     PATH_IN   = os.path.join(ICDATADIR    , 'pmtledpulsedata.h5')
     PATH_OUT  = os.path.join(config_tmpdir, 'pmtledpulsedata_HIST.h5')

--- a/invisible_cities/calib/sipmgain.py
+++ b/invisible_cities/calib/sipmgain.py
@@ -116,6 +116,9 @@ class Sipmgain(CalibratedCity):
 
 
     def get_writers(self, h5out):
+        ## Copy sensor info (good for non DB tests)
+        cf.copy_sensor_table(self.input_files[0], h5out)
+        
         bin_centres = shift_to_bin_centers(self.histbins)
         HIST        = partial(hist_writer,
                               h5out,
@@ -136,14 +139,3 @@ class Sipmgain(CalibratedCity):
     def display_IO_info(self):
         super().display_IO_info()
         print(self.sp)
-
-    def _copy_sensor_table(self, h5in):
-        # Copy sensor table if exists (needed for GATE)
-        if 'Sensors' not in h5in.root: return
-
-        group    = self.output_file.create_group(self.output_file.root, "Sensors")
-        datapmt  = h5in.root.Sensors.DataPMT
-        datasipm = h5in.root.Sensors.DataSiPM
-
-        datapmt .copy(newparent=group)
-        datasipm.copy(newparent=group)

--- a/invisible_cities/calib/sipmpdf_test.py
+++ b/invisible_cities/calib/sipmpdf_test.py
@@ -18,8 +18,8 @@ from .  sipmpdf           import Sipmpdf
 from .. core   .configure import configure
 
 
-@mark.slow
-def test_sipmpdf_sipmdarkcurrent(config_tmpdir, ICDATADIR):
+@mark.parametrize("adc_plots", (True, False))
+def test_sipmpdf_sipmdarkcurrent(config_tmpdir, ICDATADIR, adc_plots):
     PATH_IN    = os.path.join(ICDATADIR    , 'sipmdarkcurrentdata.h5' )
     PATH_OUT   = os.path.join(config_tmpdir, 'sipmdarkcurrentdata_HIST.h5')
     nrequired  = 2
@@ -28,7 +28,8 @@ def test_sipmpdf_sipmdarkcurrent(config_tmpdir, ICDATADIR):
     conf.update(dict(run_number   = 4000,
                      files_in     = PATH_IN,
                      file_out     = PATH_OUT,
-                     event_range  = (0, nrequired)))
+                     event_range  = (0, nrequired),
+                     adc_only     = adc_plots))
 
     sipmpdf = Sipmpdf(**conf)
     sipmpdf.run()

--- a/invisible_cities/config/sipmpdf.conf
+++ b/invisible_cities/config/sipmpdf.conf
@@ -9,6 +9,8 @@ include('$ICDIR/config/calibrated_city.conf')
 # run number
 run_number = 4821
 
+adc_only = False
+
 # Histogram bins
 min_bin   = -10.
 max_bin   =  20.

--- a/invisible_cities/evm/nh5.py
+++ b/invisible_cities/evm/nh5.py
@@ -30,6 +30,15 @@ class DataSensor(tb.IsDescription):
     noise_rms  = tb.Float32Col(pos=4)
 
 
+class SensorTable(tb.IsDescription):
+    """
+    Stores the Sensors group, mimicking what is saved
+    by the decoder.
+    """
+    channel  = tb.Int32Col(pos=0)
+    sensorID = tb.Int32Col(pos=1)
+
+    
 class MCExtentInfo(tb.IsDescription):
     """Store the last row of each table as metadata using
     Pytables.

--- a/invisible_cities/reco/tbl_functions.py
+++ b/invisible_cities/reco/tbl_functions.py
@@ -110,9 +110,18 @@ def get_vectors(h5f):
         RWF array for PMTs
     """
 
-    pmtrwf = h5f.root.RD.pmtrwf
-    pmtblr = h5f.root.RD.pmtblr
-    sipmrwf = h5f.root.RD.sipmrwf
+    pmtrwf = np.zeros((1, 12, 1))
+    pmtblr = np.zeros((1, 12, 1))
+    sipmrwf = np.zeros((1, 1792, 1))
+    if 'pmtrwf' in h5f.root.RD:
+        pmtrwf = h5f.root.RD.pmtrwf
+
+    if 'pmtblr' in h5f.root.RD:
+        pmtblr = h5f.root.RD.pmtblr
+
+    if 'sipmrwf' in h5f.root.RD:
+        sipmrwf = h5f.root.RD.sipmrwf
+        
     return pmtrwf, pmtblr, sipmrwf
 
 
@@ -139,8 +148,8 @@ def get_rwf_vectors(h5in):
     NEVT_pmt , _, _          = pmtrwf .shape
     NEVT_simp, _, _          = sipmrwf.shape
 
-    assert NEVT_simp == NEVT_pmt
-    return NEVT_pmt, pmtrwf, sipmrwf, pmtblr
+    #assert NEVT_simp == NEVT_pmt
+    return max(NEVT_pmt, NEVT_simp), pmtrwf, sipmrwf, pmtblr
 
 
 def get_rd_vectors(h5in):


### PR DESCRIPTION
Reintroduced the copy of sensor information
from the raw files to the histogram files.
In this way a setup without reliable database
sensor mapping.

Protections introduced so that framework works
with data where there are no data from one
type of sensor.

centralised copy_sensor_table

Update to make the code work if there are no PMTs or Sipms

Fixed accidentally deleted 1 sensor type protections

Temporary patch to read files without sipmrwf

Improved sipmpdf adc_only mode