### PR TITLE
Fix bug reading the MC response of the last sensor written in one event

### DIFF
--- a/invisible_cities/io/mcinfo_io.py
+++ b/invisible_cities/io/mcinfo_io.py
@@ -327,6 +327,10 @@ def read_mcsns_response(h5f, event_range=(0, 1e9)) ->Mapping[int, Mapping[int, W
 
             iwvf += 1
 
+        bin_width = bin_width_PMT if sensor_id < 1000 else bin_width_SiPM
+        times     = np.array(time_bins) * bin_width
+        current_event[current_sensor_id] = Waveform(times, charges, bin_width)
+
         evt_number             = h5extents[iext]['evt_number']
         all_events[evt_number] = current_event
 

--- a/invisible_cities/io/mcinfo_io_test.py
+++ b/invisible_cities/io/mcinfo_io_test.py
@@ -214,3 +214,10 @@ def test_load_sensors_data(mc_sensors_nexus_data):
     samples = list(zip(bins, wvf.charges))
 
     assert np.allclose(samples, sipm)
+
+    with tb.open_file(efile, mode='r') as h5in:
+        last_written_id = h5in.root.MC.sensor_positions[-1][0]
+        last_read_id = list(waveforms.keys())[-1]
+
+        assert last_read_id == last_written_id
+

--- a/invisible_cities/io/mcinfo_io_test.py
+++ b/invisible_cities/io/mcinfo_io_test.py
@@ -215,6 +215,13 @@ def test_load_sensors_data(mc_sensors_nexus_data):
 
     assert np.allclose(samples, sipm)
 
+
+def test_read_last_sensor_response(mc_sensors_nexus_data):
+    efile, _, _, _, _, _ = mc_sensors_nexus_data
+
+    mcsensors_dict = load_mcsensor_response(efile)
+    waveforms = mcsensors_dict[0]
+
     with tb.open_file(efile, mode='r') as h5in:
         last_written_id = h5in.root.MC.sensor_positions[-1][0]
         last_read_id = list(waveforms.keys())[-1]


### PR DESCRIPTION
The function that reads the Monte Carlo waveforms of the sensors was not reading the last sensor in each event. I have added a test which reveals this bug and fixed the code accordingly.