### PR TITLE
Flatten mask in display_matrix

### DIFF
--- a/invisible_cities/icaro/hst_functions.py
+++ b/invisible_cities/icaro/hst_functions.py
@@ -146,6 +146,8 @@ def display_matrix(x, y, z, mask=None, **kwargs):
 
     if mask is None:
         mask = np.ones_like(z_, dtype=bool)
+    else:
+        mask = mask.flatten()
     h  = hist2d(x_[mask], y_[mask], (x_binning,
                                      y_binning),
                 weights = z_[mask],


### PR DESCRIPTION
The display function `display_matrix` takes an optional mask array that allows to plot only those values of the matrix accepted by the mask. This feature had not been previously tested, and thus we had not noted that the mask had to be flattened. This is now fixed. 