### PR TITLE
A property interval to minmax

### DIFF
--- a/invisible_cities/types/ic_types.py
+++ b/invisible_cities/types/ic_types.py
@@ -60,6 +60,9 @@ class minmax:
     def bracket(self): return self.max - self.min
 
     @property
+    def interval(self): return (self.min, self.max) 
+
+    @property
     def center(self): return (self.max + self.min) / 2
 
     def contains(self, x):

--- a/invisible_cities/types/ic_types_test.py
+++ b/invisible_cities/types/ic_types_test.py
@@ -36,6 +36,10 @@ cmms            = builds(make_cminmax, sensible_floats, sensible_floats)
 xys             = builds(make_xy, sensible_floats, sensible_floats)
 cxys            = builds(make_xyc, sensible_floats, sensible_floats)
 
+@given(sensible_floats, sensible_floats)
+def test_minmax_interval(a,b):
+    if a > b: a, b = b, a
+    assert np.allclose(minmax(a,b).interval , (a,b), rtol=1e-4)
 
 @given(sensible_floats, sensible_floats)
 def test_minmax_does_not_accept_min_greater_than_max(a,b):


### PR DESCRIPTION
A minmax can be used to specify a range. Property interval allows to return the minmax as a pair for that specific purpose. 