### PR TITLE
Fix bug last written sensor

### DIFF
--- a/invisible_cities/io/mcinfo_io.py
+++ b/invisible_cities/io/mcinfo_io.py
@@ -18,6 +18,10 @@ from typing import Mapping
 
 # use Mapping (duck type) rather than dict
 
+units_dict = {'nanosecond' : units.nanosecond,  'ns' : units.nanosecond,
+              'microsecond': units.microsecond, 'mus': units.microsecond,
+              'millisecond': units.millisecond, 'ms' : units.millisecond}
+
 
 class mc_info_writer:
     """Write MC info to file."""
@@ -272,9 +276,9 @@ def read_mcsns_response(h5f, event_range=(0, 1e9)) ->Mapping[int, Mapping[int, W
             param_value = row['param_value'].decode('utf-8','ignore')
             numb, unit  = param_value.split()
             if param_name.find('Pmt') > 0:
-                bin_width_PMT = float(numb)
+                bin_width_PMT = float(numb) * units_dict[unit]
             elif param_name.find('SiPM') >= 0:
-                bin_width_SiPM = float(numb)
+                bin_width_SiPM = float(numb) * units_dict[unit]
 
 
     if bin_width_PMT is None:

--- a/invisible_cities/io/mcinfo_io.py
+++ b/invisible_cities/io/mcinfo_io.py
@@ -18,7 +18,8 @@ from typing import Mapping
 
 # use Mapping (duck type) rather than dict
 
-units_dict = {'nanosecond' : units.nanosecond,  'ns' : units.nanosecond,
+units_dict = {'picosecond' : units.picosecond,  'ps' : units.picosecond,
+              'nanosecond' : units.nanosecond,  'ns' : units.nanosecond,
               'microsecond': units.microsecond, 'mus': units.microsecond,
               'millisecond': units.millisecond, 'ms' : units.millisecond}
 

--- a/invisible_cities/io/mcinfo_io.py
+++ b/invisible_cities/io/mcinfo_io.py
@@ -313,7 +313,7 @@ def read_mcsns_response(h5f, event_range=(0, 1e9)) ->Mapping[int, Mapping[int, W
                 time_bins.append(wvf_row['time_bin'])
                 charges.  append(wvf_row['charge'])
             else:
-                bin_width = bin_width_PMT if sensor_id < 1000 else bin_width_SiPM
+                bin_width = bin_width_PMT if current_sensor_id < 1000 else bin_width_SiPM
                 times     = np.array(time_bins) * bin_width
 
                 current_event[current_sensor_id] = Waveform(times, charges, bin_width)
@@ -327,7 +327,7 @@ def read_mcsns_response(h5f, event_range=(0, 1e9)) ->Mapping[int, Mapping[int, W
 
             iwvf += 1
 
-        bin_width = bin_width_PMT if sensor_id < 1000 else bin_width_SiPM
+        bin_width = bin_width_PMT if current_sensor_id < 1000 else bin_width_SiPM
         times     = np.array(time_bins) * bin_width
         current_event[current_sensor_id] = Waveform(times, charges, bin_width)
 

--- a/invisible_cities/io/mcinfo_io_test.py
+++ b/invisible_cities/io/mcinfo_io_test.py
@@ -241,6 +241,3 @@ def test_pick_correct_sensor_binning(mc_sensors_nexus_data):
     last_sipm_bin_width = waveforms[last_sipm_id].bin_width
 
     assert last_sipm_bin_width == 1. * units.microsecond
-
-   # with tb.open_file(efile, mode='r') as h5in:
-    #    row_first_pmt = h5in.root.MC.waveforms[751:752]

--- a/invisible_cities/io/mcinfo_io_test.py
+++ b/invisible_cities/io/mcinfo_io_test.py
@@ -11,6 +11,8 @@ from .  mcinfo_io import load_mcsensor_response
 from .  mcinfo_io import mc_info_writer
 from .  mcinfo_io import read_mcinfo_evt
 
+from .. core import system_of_units as units
+
 from .. reco.tbl_functions import get_mc_info
 
 from pytest import mark
@@ -228,3 +230,17 @@ def test_read_last_sensor_response(mc_sensors_nexus_data):
 
         assert last_read_id == last_written_id
 
+
+def test_pick_correct_sensor_binning(mc_sensors_nexus_data):
+    efile, _, _, _, _, _ = mc_sensors_nexus_data
+
+    mcsensors_dict = load_mcsensor_response(efile)
+    waveforms = mcsensors_dict[0]
+
+    last_sipm_id = 11054
+    last_sipm_bin_width = waveforms[last_sipm_id].bin_width
+
+    assert last_sipm_bin_width == 1. * units.microsecond
+
+   # with tb.open_file(efile, mode='r') as h5in:
+    #    row_first_pmt = h5in.root.MC.waveforms[751:752]


### PR DESCRIPTION
There was a bug in the code of `read_mcsns_response`: when storing a new `Waveform` object, the bin width of the following one was taken. A test has been added to show this bug, and the code has been fixed. In this process, I've realized that the bin width was actually being saved without units, so I have also added this feature. The test added can serve also as a test for the units being saved correctly.