### PR TITLE
Improve histograms tests

### DIFF
--- a/invisible_cities/evm/histos_test.py
+++ b/invisible_cities/evm/histos_test.py
@@ -20,7 +20,8 @@ from hypothesis.strategies  import one_of
 from .. evm.histos  import HistoManager, Histogram
 
 
-characters = tuple(string.ascii_letters + string.digits + "-")
+characters = tuple(string.ascii_letters + string.digits)
+letters    = tuple(string.ascii_letters)
 
 def assert_histogram_equality(histogram1, histogram2):
     assert np.all     (a == b for a, b in zip(histogram1.bins, histogram2.bins))
@@ -57,7 +58,7 @@ def filled_histograms(draw, dimension=0, fixed_bins=None):
     else:
         bins = draw(bins_arrays(dimension=dimension))
 
-    title  = draw(text(characters, min_size=1))
+    title  = draw(text(letters, min_size=1)) + draw(text(characters, min_size=1))
     labels = draw(lists(text(characters, min_size=1), min_size=dimension, max_size=dimension))
     shape  = draw(integers(50, 100)),
     data   = []
@@ -77,7 +78,7 @@ def empty_histograms(draw, dimension=0):
     if dimension <= 0:
         dimension = draw(sampled_from((1,2)))
     bins   = draw(bins_arrays(dimension=dimension))
-    title  = draw(text(characters, min_size=1))
+    title  = draw(text(letters, min_size=1)) + draw(text(characters, min_size=1))
     labels = draw(lists(text(characters, min_size=1), min_size=dimension, max_size=dimension))
     args   = title, bins, labels
     return args, Histogram(title, bins, labels)

--- a/invisible_cities/io/hist_io_test.py
+++ b/invisible_cities/io/hist_io_test.py
@@ -26,10 +26,10 @@ from .. evm.histos_test     import histograms_lists
 from .. evm.histos_test     import assert_histogram_equality
 
 
-characters = tuple(string.ascii_letters + string.digits + "-")
+letters    = tuple(string.ascii_letters)
 
 @settings(suppress_health_check=(HealthCheck.too_slow,))
-@given   (histograms_lists(), text(characters, min_size=1))
+@given   (histograms_lists(), text(letters, min_size=1))
 def test_save_histomanager_to_file_write_mode(output_tmpdir, histogram_list, group):
     args, list_of_histograms = histogram_list
     histogram_manager        = HistoManager(list_of_histograms)
@@ -53,7 +53,7 @@ def test_save_histomanager_to_file_write_mode(output_tmpdir, histogram_list, gro
 
 
 @settings(suppress_health_check=(HealthCheck.too_slow,))
-@given   (histograms_lists(), text(characters, min_size=1))
+@given   (histograms_lists(), text(letters, min_size=1))
 def test_save_histomanager_to_file_append_mode(output_tmpdir, histogram_list, group):
     args, list_of_histograms = histogram_list
     histogram_manager        = HistoManager(list_of_histograms[:1])
@@ -79,7 +79,7 @@ def test_save_histomanager_to_file_append_mode(output_tmpdir, histogram_list, gr
 
 
 @settings(suppress_health_check=(HealthCheck.too_slow,))
-@given   (histograms_lists(), text(characters, min_size=1), text(characters, min_size=1, max_size=1).filter(lambda x: x not in ["w", "a"]))
+@given   (histograms_lists(), text(letters, min_size=1), text(letters, min_size=1, max_size=1).filter(lambda x: x not in ["w", "a"]))
 def test_save_histomanager_to_file_raises_ValueError(output_tmpdir, histogram_list, group, write_mode):
     args, list_of_histograms = histogram_list
     histogram_manager        = HistoManager(list_of_histograms)

--- a/invisible_cities/io/hist_io_test.py
+++ b/invisible_cities/io/hist_io_test.py
@@ -26,7 +26,7 @@ from .. evm.histos_test     import histograms_lists
 from .. evm.histos_test     import assert_histogram_equality
 
 
-letters    = tuple(string.ascii_letters)
+letters    = string.ascii_letters
 
 @settings(suppress_health_check=(HealthCheck.too_slow,))
 @given   (histograms_lists(), text(letters, min_size=1))
@@ -79,7 +79,7 @@ def test_save_histomanager_to_file_append_mode(output_tmpdir, histogram_list, gr
 
 
 @settings(suppress_health_check=(HealthCheck.too_slow,))
-@given   (histograms_lists(), text(letters, min_size=1), text(letters, min_size=1, max_size=1).filter(lambda x: x not in ["w", "a"]))
+@given   (histograms_lists(), text(letters, min_size=1), text(letters, min_size=1, max_size=1).filter(lambda x: x not in 'wa'))
 def test_save_histomanager_to_file_raises_ValueError(output_tmpdir, histogram_list, group, write_mode):
     args, list_of_histograms = histogram_list
     histogram_manager        = HistoManager(list_of_histograms)

--- a/invisible_cities/reco/histogram_functions_test.py
+++ b/invisible_cities/reco/histogram_functions_test.py
@@ -44,8 +44,15 @@ def test_join_histo_managers_with_different_histograms(histogram_list1, histogra
     histogram_manager2       = HistoManager(list_of_histograms2)
     joined_histogram_manager = histf.join_histo_managers(histogram_manager1, histogram_manager2)
 
-    list_of_names = set(histogram_manager1.histos) | set(histogram_manager2.histos)
-    assert len(list_of_names) == len(joined_histogram_manager.histos)
+    unique_histograms = set(histogram_manager1.histos) | set(histogram_manager2.histos)
+    common_histograms = set(histogram_manager1.histos) & set(histogram_manager2.histos)
+
+    remove_names      = []
+    for name in unique_histograms:
+        if name in common_histograms:
+            if not np.all(a == b for a, b in zip(histogram_manager1[name].bins, histogram_manager2[name].bins)):
+                remove_names.append(name)
+    list_of_names = unique_histograms - set(remove_names)
 
     for histoname, histogram in joined_histogram_manager.histos.items():
         assert histoname in list_of_names
@@ -88,7 +95,7 @@ def test_create_histomanager_from_dicts(bins):
         assert_histogram_equality(histogram, histograms_dict[histoname])
 
 
-@settings(suppress_health_check=(HealthCheck.too_slow, HealthCheck.filter_too_much,))
+@settings(suppress_health_check=(HealthCheck.too_slow, HealthCheck.filter_too_much,), deadline=2000)
 @given   (histograms_lists(), histograms_lists())
 def test_join_histograms_from_file(output_tmpdir, histogram_list1, histogram_list2):
     _, list_of_histograms1   = histogram_list1
@@ -109,7 +116,7 @@ def test_join_histograms_from_file(output_tmpdir, histogram_list1, histogram_lis
         assert_histogram_equality(joined_histogram_manager1[histoname], joined_histogram_manager2[histoname])
 
 
-@settings(suppress_health_check=(HealthCheck.too_slow, HealthCheck.filter_too_much,))
+@settings(suppress_health_check=(HealthCheck.too_slow, HealthCheck.filter_too_much,), deadline=2000)
 @given   (histograms_lists())
 def test_join_histograms_from_file_and_write(output_tmpdir, histogram_list):
     _, list_of_histograms   = histogram_list

--- a/invisible_cities/reco/monitor_functions_test.py
+++ b/invisible_cities/reco/monitor_functions_test.py
@@ -18,6 +18,7 @@ from .. evm.pmaps_test       import pmaps
 from .. evm.pmaps_test       import sensor_responses
 
 
+@settings(deadline=2000)
 @given(pmaps())
 def test_fill_pmap_var_1d(pmaps):
     var_dict      = defaultdict(list)
@@ -56,6 +57,7 @@ def test_fill_pmap_var_1d(pmaps):
         counter += nsipm
 
 
+@settings(deadline=2000)
 @given(pmaps())
 def test_fill_pmap_var_2d(pmaps):
     var_dict      = defaultdict(list)


### PR DESCRIPTION
Optimization of the hypotheses generation to make tests faster. 
Removed deadline for 4 tests that were borderline (it was giving a warning that the current value was to be changed).
Silenced the NaturalNameWarning to avoid noise running the tests. This will be revised in the future.