### PR TITLE
Reduce number of non-valid histo examples for tests

### DIFF
--- a/invisible_cities/evm/histos_test.py
+++ b/invisible_cities/evm/histos_test.py
@@ -43,12 +43,13 @@ def bins_arrays(draw, dimension=0):
     if dimension <= 0:
         dimension = draw(sampled_from((1,2)))
 
-    bin_margins   = draw(arrays(float, (dimension, 2),
-                         floats(-1e3, 1e3, allow_nan=False, allow_infinity=False)))
-    for bin_margin in bin_margins:
-        assume(round(bin_margin.min(), 2) < round(bin_margin.max(), 2))
+    bin_lower_margins = draw(arrays(float, dimension,
+                             floats(-1e3, 1e3, allow_nan=False, allow_infinity=False)))
+    bin_additive      = draw(arrays(float, dimension,
+                             floats(1.1 , 1e3, allow_nan=False, allow_infinity=False)))
+    bin_upper_margins = bin_lower_margins + bin_additive
 
-    bins = [ np.linspace(bin_margin.min(), bin_margin.max(), draw(integers(2, 20))) for bin_margin in bin_margins ]
+    bins = [ np.linspace(bin_lower_margins[i], bin_upper_margins[i], draw(integers(2, 20))) for i, _ in enumerate(bin_lower_margins) ]
 
     return bins
 
@@ -69,9 +70,8 @@ def filled_histograms(draw, dimension=0, fixed_bins=None):
     shape  = draw(integers(50, 100)),
     data   = []
     for i in range(dimension):
-        lower_limit = bins[i][0]  * draw(floats(0.5, 1.5))
-        upper_limit = bins[i][-1] * draw(floats(0.5, 1.5))
-        assume(lower_limit < upper_limit)
+        lower_limit = bins[i][0]  - draw(floats(0.5, 1e8, allow_nan=False, allow_infinity=False))
+        upper_limit = bins[i][-1] + draw(floats(0.5, 1e8, allow_nan=False, allow_infinity=False))
         data.append(draw(arrays(float, shape, floats(lower_limit, upper_limit,
                                                      allow_nan=False, allow_infinity=False))))
     data = np.array(data)

--- a/invisible_cities/reco/histogram_functions_test.py
+++ b/invisible_cities/reco/histogram_functions_test.py
@@ -44,8 +44,15 @@ def test_join_histo_managers_with_different_histograms(histogram_list1, histogra
     histogram_manager2       = HistoManager(list_of_histograms2)
     joined_histogram_manager = histf.join_histo_managers(histogram_manager1, histogram_manager2)
 
-    list_of_names = set(histogram_manager1.histos) | set(histogram_manager2.histos)
-    assert len(list_of_names) == len(joined_histogram_manager.histos)
+    unique_histograms = set(histogram_manager1.histos) | set(histogram_manager2.histos)
+    common_histograms = set(histogram_manager1.histos) & set(histogram_manager2.histos)
+
+    remove_names      = []
+    for name in unique_histograms:
+        if name in common_histograms:
+            if not np.all(a == b for a, b in zip(histogram_manager1[name].bins, histogram_manager2[name].bins)):
+                remove_names.append(name)
+    list_of_names = unique_histograms - set(remove_names)
 
     for histoname, histogram in joined_histogram_manager.histos.items():
         assert histoname in list_of_names


### PR DESCRIPTION
Every now and then a HealthCheck error in this direction appeared (only a
few valid examples out of 50), this should address this issue at the
cost of slower test generation.