### PR TITLE
Dependency versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ branches:
     - /^docs\..*$/
 
 install:
-  - source manage.sh work_in_python_version ${IC_PYTHON_VERSION}
+  - source manage.sh work_in_python_version_no_tests ${IC_PYTHON_VERSION}
 
 script:
   - HYPOTHESIS_PROFILE=hard bash manage.sh run_tests_par 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ branches:
     - /^docs\..*$/
 
 install:
-  - source manage.sh install ${IC_PYTHON_VERSION}
+  - source manage.sh work_in_python_version ${IC_PYTHON_VERSION}
 
 script:
   - HYPOTHESIS_PROFILE=hard bash manage.sh run_tests_par 4

--- a/README.rst
+++ b/README.rst
@@ -8,9 +8,9 @@ Quickstart guide
 
 + Clone the repository
 
-+ `cd` into the `IC` directory
++ :code:`cd` into the `IC` directory
 
-+ `source manage.sh work_in_python_version 3.6`
++ :code:`source manage.sh work_in_python_version 3.6`
 
 The last step will, if necessary, install conda and create an
 appropriate conda environment, as well as setting environment
@@ -32,7 +32,7 @@ suite. This can be done with
    source manage.sh compile_and_test_par
 
 If you check out a commit which requires an older set of dependencies,
-the `compile_and_test` commands will automatically switch to an
+the :code:`compile_and_test` commands will automatically switch to an
 appropriate environment, creating it on the fly if necessary.
 
 :Travis CI: |travis|

--- a/README.rst
+++ b/README.rst
@@ -6,63 +6,34 @@ IC stands for Invisible Cities and also for Italo Calvino, the author of the mas
 Quickstart guide
 ----------------
 
-If you have just cloned the repository for the first time, then issue
-the command
++ Clone the repository
+
++ `cd` into the `IC` directory
+
++ `source manage.sh work_in_python_version 3.6`
+
+The last step will, if necessary, install conda and create an
+appropriate conda environment, as well as setting environment
+variables which are needed for the correct functioning of IC.
+
+The installation steps will be skipped if conda and the required
+environment are already available, so subsequent invocations of the
+command should be much quicker than the first.
+
+You will need to perform the last two steps in every shell in which
+you want to run IC.
+
+To check your progress when you are developing, you will want to
+compile any Cython components that have changed and run the test
+suite. This can be done with
 
 .. code-block::
 
-  source manage.sh install_and_check 3.6
+   source manage.sh compile_and_test_par
 
-Where the 3.6 can be replaced with any sensible Python version you
-like. (On 2017-06-27 we dropped support for Python 3.5, so Python 3.6
-will be the only supported version until 3.7 is released and the third
-party modules we use are uploaded to conda and pip.)
-   
-If you have already done the above procedure once, then you should
-already have an `IC3.6` conda environment available, as long as
-${HOME}/miniconda3/bin (or an earlier conda installation) is in your
-`PATH`. (You may like to add the location of your conda installation
-to your shell startup file.) To start working in an IC environment you
-set up earlier issue the command
-
-.. code-block::
-
-  source manage.sh work_in_python_version 3.6
-
-(replacing 3.6 with whatever python version is relevant for your
-case.)
-
-If you wish to develop and test in a python version in which you have
-not worked on IC before, you will need to create the corresponding
-conda environment:
-
-.. code-block::
-
-  source manage.sh make_environment 3.5
-
-(replacing 3.5 with whatever python version is relevant for your
-case.) After this you will be able to work in that environment by
-selecting it as before
-
-.. code-block::
-
-  source manage.sh work_in_python_version 3.5
-
-To check your progress when you are developing you will want to
-compile Cython components and run the test suite. This can be done
-with
-
-.. code-block::
-
-   bash manage.sh compile_and_test
-
-If the test database changes, you will need to download the most
-recent version:
-
-.. code-block::
-
-   bash manage.sh download_test_db
-   
+If you check out a commit which requires an older set of dependencies,
+the `compile_and_test` commands will automatically switch to an
+appropriate environment, creating it on the fly if necessary.
 
 :Travis CI: |travis|
 

--- a/bash_manage.sh
+++ b/bash_manage.sh
@@ -54,6 +54,7 @@ source_manage.sh()
                         local opts="install_and_check\
                                     install\
                                     work_in_python_version\
+                                    work_in_python_version_no_tests\
                                     make_environment\
                                     run_tests\
                                     run_tests_par\

--- a/invisible_cities/core/fit_functions.py
+++ b/invisible_cities/core/fit_functions.py
@@ -295,7 +295,7 @@ def profileXY(xdata, ydata, zdata, nbinsx, nbinsy,
     bin_numbers_x = np.digitize(xdata, bin_edges_x, right=False)
     bin_numbers_y = np.digitize(ydata, bin_edges_y, right=False)
     df            = pd.DataFrame(dict(binx=bin_numbers_x, biny=bin_numbers_y, z=zdata))
-    gb            = df.groupby(("binx", "biny")).z
+    gb            = df.groupby(["binx", "biny"]).z
 
     shape     = nbinsx, nbinsy
     mean      = np.zeros(shape)

--- a/invisible_cities/io/pmaps_io_test.py
+++ b/invisible_cities/io/pmaps_io_test.py
@@ -216,8 +216,8 @@ def test_build_pmt_responses(KrMC_pmaps_dfs, signal_type):
     if   signal_type is S1:   df,  _, _, pmt_df,      _ = KrMC_pmaps_dfs
     elif signal_type is S2:    _, df, _,      _, pmt_df = KrMC_pmaps_dfs
 
-    df_groupby     =     df.groupby(("event", "peak"))
-    pmt_df_groupby = pmt_df.groupby(("event", "peak"))
+    df_groupby     =     df.groupby(["event", "peak"])
+    pmt_df_groupby = pmt_df.groupby(["event", "peak"])
     for (_, df_peak), (_, pmt_df_peak) in zip(df_groupby, pmt_df_groupby):
         times, pmt_r = pmpio.build_pmt_responses(df_peak, pmt_df_peak)
 
@@ -228,7 +228,7 @@ def test_build_pmt_responses(KrMC_pmaps_dfs, signal_type):
 
 def test_build_sipm_responses(KrMC_pmaps_dfs):
     _, _, df_event, _, _ = KrMC_pmaps_dfs
-    for _, df_peak in df_event.groupby(("event", "peak")):
+    for _, df_peak in df_event.groupby(["event", "peak"]):
         sipm_r = pmpio.build_sipm_responses(df_peak)
 
         assert sipm_r.all_waveforms.flatten() == approx(df_peak.ene.values)
@@ -250,8 +250,8 @@ def test_build_pmt_responses_unordered():
 
     expected_pmts = np.array([1, 3, 2, 0, 4])
     expected_enes = np.arange(10)
-    for (_, peak_pmt), (_, peak_ipmt) in zip(data_pmt .groupby(("event", "peak")),
-                                             data_ipmt.groupby(("event", "peak"))):
+    for (_, peak_pmt), (_, peak_ipmt) in zip(data_pmt .groupby(["event", "peak"]),
+                                             data_ipmt.groupby(["event", "peak"])):
         _, pmt_r = pmpio.build_pmt_responses(peak_pmt, peak_ipmt)
         assert pmt_r.ids                     == exactly(expected_pmts)
         assert pmt_r.all_waveforms.flatten() == exactly(expected_enes)
@@ -266,7 +266,7 @@ def test_build_sipm_responses_unordered():
 
     expected_sipms = np.array([1, 3, 2, 0, 4])
     expected_enes  = np.arange(10)
-    for _, peak in data.groupby(("event", "peak")):
+    for _, peak in data.groupby(["event", "peak"]):
         sipm_r = pmpio.build_sipm_responses(peak)
         assert sipm_r.ids                     == exactly(expected_sipms)
         assert sipm_r.all_waveforms.flatten() == exactly(expected_enes)

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -104,7 +104,7 @@ def voxels_from_track_graph(track: Graph) -> List[Voxel]:
 
 def shortest_paths(track_graph : Graph) -> Dict[Voxel, Dict[Voxel, float]]:
     """Compute shortest path lengths between all nodes in a weighted graph."""
-    return nx.all_pairs_dijkstra_path_length(track_graph, weight='distance')
+    return dict(nx.all_pairs_dijkstra_path_length(track_graph, weight='distance'))
 
 
 def find_extrema_and_length(distance : Dict[Voxel, Dict[Voxel, float]]) -> Tuple[Voxel, Voxel, float]:

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -115,11 +115,11 @@ def find_extrema_and_length(distance : Dict[Voxel, Dict[Voxel, float]]) -> Tuple
         only_voxel = next(iter(distance))
         return (only_voxel, only_voxel, 0.)
     first, last, max_distance = None, None, 0
-    for source, target in combinations(distance, 2):
-        d = distance[source][target]
+    for (voxel1, dist_from_voxel_1_to), (voxel2, _) in combinations(distance.items(), 2):
+        d = dist_from_voxel_1_to[voxel2]
         if d > max_distance:
-            first, last, max_distance = source, target, d
-    return (first, last, max_distance)
+            first, last, max_distance = voxel1, voxel2, d
+    return first, last, max_distance
 
 
 def find_extrema(track: Graph) -> Tuple[Voxel, Voxel]:

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -150,7 +150,7 @@ def test_voxelize_hits_strict_gives_required_voxels_size(hits, requested_voxel_d
 def test_make_voxel_graph_keeps_all_voxels(hits, voxel_dimensions):
     voxels = voxelize_hits    (hits  , voxel_dimensions)
     tracks = make_track_graphs(voxels)
-    voxels_in_tracks = set().union(*(set(t.nodes_iter()) for t in tracks))
+    voxels_in_tracks = set().union(*(set(t.nodes()) for t in tracks))
     assert set(voxels) == voxels_in_tracks
 
 

--- a/invisible_cities/sierpe/fee.py
+++ b/invisible_cities/sierpe/fee.py
@@ -179,14 +179,16 @@ class FEE:
         self.C1_pmt = (self.coeff_blr_pmt / self.coeff_c_pmt) * (self.C2 / np.pi)
         self.R1_pmt = 1 / (self.coeff_c_pmt * self.C1_pmt * self.f_sample * np.pi)
         self.A1_pmt = self.R1_pmt * self.Zin / (self.R1_pmt + self.Zin)  # ohms
+
         self.A2_pmt = gain / self.A1_pmt  # ohms/ohms = []
+
         self.Cr_pmt = 1 + self.C1_pmt / self.C2
         self.ZC_pmt = self.Zin / self.Cr_pmt
         self.noise_FEEPMB_rms = noise_FEEPMB_rms
         self.LSB = lsb
         self.voltsToAdc = self.LSB / units.volt
         self.DAQnoise_rms = noise_DAQ_rms
-        
+
 
     def __str__(self):
         s = """
@@ -209,14 +211,14 @@ class FEE:
          LSB = {16:7.2g} mV,
          volts to adc = {17:7.2g},
          DAQnoise_rms = {18:7.2g},
-         freq_LHPFd (PMTs) = {19:s},
-         coef_blr (PMTs)= {20:s},
+         freq_LHPFd (PMTs) = {19},
+         coef_blr (PMTs)= {20},
          freq_zero = {21:7.5g},
          coeff_c = {22:7.5g},
-         coeff_c (PMTs)= {23:s},
-         R1 (PMTs)= {24:s} ohm,
-         A1 (PMTs)= {25:s} ohm,
-         A2 (PMTs)= {26:s}
+         coeff_c (PMTs)= {23},
+         R1 (PMTs)= {24} ohm,
+         A1 (PMTs)= {25} ohm,
+         A2 (PMTs)= {26}
         )
         """.format(self.C1               / units.nF,
                    self.C2               / units.nF,
@@ -249,6 +251,7 @@ class FEE:
 
     def __repr__(self):
         return self.__str__()
+
 
 
 def noise_adc(fee, signal_in_adc):
@@ -397,4 +400,4 @@ def daq_decimator(f_sample1, f_sample2, signal_in):
     """
 
     scale = int(f_sample1 / f_sample2)
-    return signal.decimate(signal_in, scale, ftype='fir', zero_phase=False)
+    return signal.decimate(signal_in, scale, n=30, ftype='fir', zero_phase=False)

--- a/invisible_cities/sierpe/fee_test.py
+++ b/invisible_cities/sierpe/fee_test.py
@@ -53,55 +53,10 @@ def test_fee_params():
     assert FE.f_LPF2 == 10 * units.MHZ
     assert FE.OFFSET == 2500   # offset adc
 
-def test_show_scipy_nasty_feature():
+
+def test_show_signal_decimate_signature():
     """
-    Scipy 1.1.0 changes shamelessly the default behaviour of signal.decimate
-    From the manual:
-
-    v 0.19
-
-    scipy.signal.decimate(x, q, n=None, ftype='iir', axis=-1, zero_phase=None)[source]
-    Downsample the signal after applying an anti-aliasing filter.
-
-
-    Parameters:
-    x : ndarray
-    The signal to be downsampled, as an N-dimensional array.
-    q : int
-    The downsampling factor.
-
-    n : int, optional
-    The order of the filter (1 less than the length for ‘fir’).
-    Defaults to 8 for ‘iir’ and 30 for ‘fir’.
-
-    v 1.1
-
-    n : int, optional
-    The order of the filter (1 less than the length for ‘fir’).
-    Defaults to 8 for ‘iir’ and 20 times the downsampling factor for ‘fir’.
-
-    Thus the behaviour of n changes completely and the default is no longer valid.
-    """
-    ipmt = 0
-    spe = FE.SPE()
-    fee = FE.FEE(noise_FEEPMB_rms = 0 * units.mA, noise_DAQ_rms = 0)
-
-    spe_i = FE.spe_pulse(spe, t0 = 100 * units.ns, tmax = 200 * units.ns)
-    spe_v     = FE.signal_v_fee(fee, spe_i,ipmt)
-
-    scale = 25
-    spe_adc = signal.decimate(spe_v     * FE.v_to_adc(), scale, ftype='fir', zero_phase=False)
-    adc_to_pes     = np.sum(spe_adc    [3:7])
-
-    try:
-        assert 23 < adc_to_pes     < 23.1
-    except AssertionError:
-        pass
-
-def test_fix_scipy_nasty_feature():
-    """
-    This is fixed by setting n to the same value it has in version 0.2
-    (which was 30 by default)
+    This test shows explicitly the signature os signal.decimate, including the need to set n=30
 
     """
     ipmt = 0

--- a/manage.sh
+++ b/manage.sh
@@ -56,7 +56,7 @@ function install_conda {
             ;;
     esac
 
-    if which conda ; then
+    if conda --version ; then
         echo Conda already installed. Skipping conda installation.
     else
         echo Installing conda for $CONDA_OS

--- a/manage.sh
+++ b/manage.sh
@@ -160,10 +160,10 @@ function run_tests {
 function run_tests_par {
     ensure_environment_matches_checked_out_version
     # Run the test suite
-    EXIT=0
-    pytest -v -n ${N_PROC} -m "not serial" --no-success-flaky-report || EXIT=$?
-    pytest -v              -m      serial  --no-success-flaky-report || EXIT=$?
-    exit $EXIT
+    STATUS=0
+    pytest -v -n ${N_PROC} -m "not serial" --no-success-flaky-report || STATUS=$?
+    pytest -v              -m      serial  --no-success-flaky-report || STATUS=$?
+    [[ $STATUS = 0 ]]
 }
 
 function ic_env {

--- a/manage.sh
+++ b/manage.sh
@@ -3,6 +3,14 @@
 COMMAND=$1
 ARGUMENT=$2
 
+## Interpret meaning of command line argument depending on which
+## function will receive it.
+
+case $COMMAND in
+    run_tests_par | compile_and_test_par)     N_PROC=${ARGUMENT:-auto} ;;
+    *)                                PYTHON_VERSION=${ARGUMENT}       ;;
+esac
+
 
 function install_and_check {
     install
@@ -217,15 +225,8 @@ function clean {
     done
 }
 
+
 THIS=manage.sh
-
-## Interpret meaning of command line argument depending on which
-## function will receive it.
-
-case $COMMAND in
-    run_tests_par | compile_and_test_par)     N_PROC=${ARGUMENT:-auto} ;;
-    *)                                PYTHON_VERSION=${ARGUMENT}       ;;
-esac
 
 ## Main command dispatcher
 

--- a/manage.sh
+++ b/manage.sh
@@ -160,8 +160,8 @@ function run_tests_par {
     ensure_environment_matches_checked_out_version
     # Run the test suite
     STATUS=0
-    pytest -v -n ${N_PROC} -m "not serial" --no-success-flaky-report || STATUS=$?
-    pytest -v              -m      serial  --no-success-flaky-report || STATUS=$?
+    pytest -v -n ${N_PROC:-auto} -m "not serial" --no-success-flaky-report || STATUS=$?
+    pytest -v                    -m      serial  --no-success-flaky-report || STATUS=$?
     [[ $STATUS = 0 ]]
 }
 

--- a/manage.sh
+++ b/manage.sh
@@ -52,10 +52,9 @@ function install_conda {
             curl https://repo.continuum.io/miniconda/Miniconda3-4.5.4-${CONDA_OS}-x86_64.sh -o miniconda.sh
         fi
         bash miniconda.sh -b -p $HOME/miniconda
-        export PATH="$HOME/miniconda/bin:$PATH"
-        echo Prepended $HOME/miniconda/bin to your PATH. Please add it to your shell profile for future sessions.
-        conda config --set always_yes yes --set changeps1 no
-        echo Prepended $HOME/miniconda/bin to your PATH. Please add it to your shell profile for future sessions.
+        CONDA_SH=$HOME/miniconda/etc/profile.d/conda.sh
+        source $CONDA_SH
+        echo Activated conda by sourcing $CONDA_SH
     fi
 }
 
@@ -92,7 +91,7 @@ EOF
 
 function python_version_env {
     # Activate the relevant conda env
-    source activate IC${PYTHON_VERSION}
+    conda activate IC${PYTHON_VERSION}
     # Set IC environment variables and download database
     ic_env
 }

--- a/manage.sh
+++ b/manage.sh
@@ -47,9 +47,9 @@ function install_conda {
     else
         echo Installing conda for $CONDA_OS
         if which wget; then
-            wget https://repo.continuum.io/miniconda/Miniconda3-4.3.21-${CONDA_OS}-x86_64.sh -O miniconda.sh
+            wget https://repo.continuum.io/miniconda/Miniconda3-4.5.4-${CONDA_OS}-x86_64.sh -O miniconda.sh
         else
-            curl https://repo.continuum.io/miniconda/Miniconda3-4.3.21-${CONDA_OS}-x86_64.sh -o miniconda.sh
+            curl https://repo.continuum.io/miniconda/Miniconda3-4.5.4-${CONDA_OS}-x86_64.sh -o miniconda.sh
         fi
         bash miniconda.sh -b -p $HOME/miniconda
         export PATH="$HOME/miniconda/bin:$PATH"

--- a/manage.sh
+++ b/manage.sh
@@ -131,22 +131,28 @@ function work_in_python_version_no_tests {
     compile_cython_components
 }
 
-function run_tests {
+function ensure_environment_matches_checked_out_version {
+
+    # Ensure that the currently active conda environment name contains
+    # the tag that corresponds to this version of the code
+    if [[ $CONDA_DEFAULT_ENV != *$CONDA_ENV_TAG ]]; then
+        switch_to_conda_env
+    fi
+
     # Ensure that the test database is present
     if [ ! -f invisible_cities/database/localdb.sqlite3 ]; then
         download_test_db
     fi
+}
 
+function run_tests {
+    ensure_environment_matches_checked_out_version
     # Run the test suite
     pytest -v --no-success-flaky-report
 }
 
 function run_tests_par {
-    # Ensure that the test database is present
-    if [ ! -f invisible_cities/database/localdb.sqlite3 ]; then
-        download_test_db
-    fi
-
+    ensure_environment_matches_checked_out_version
     # Run the test suite
     EXIT=0
     pytest -v -n ${N_PROC} -m "not serial" --no-success-flaky-report || EXIT=$?

--- a/manage.sh
+++ b/manage.sh
@@ -72,7 +72,7 @@ function install_conda {
     fi
 }
 
-CONDA_ENV_TAG=2018-05-03
+CONDA_ENV_TAG=2018-06-30
 CONDA_ENV_NAME=IC-${PYTHON_VERSION}-${CONDA_ENV_TAG}
 
 function make_environment {
@@ -83,24 +83,23 @@ function make_environment {
     cat <<EOF > ${YML_FILENAME}
 name: ${CONDA_ENV_NAME}
 dependencies:
-- cython=0.26=py36_0
-- jupyter=1.0.0=py36_3
-- matplotlib=2.0.2=np113py36_0
-- networkx=1.11=py36_0
-- notebook=5.0.0=py36_0
-- numpy=1.13.1=py36_0
-- pandas=0.20.3=py36_0
-- pymysql=0.7.9=py36_0
-- pytables=3.4.2=np113py36_0
-- pytest=3.2.1=py36_0
-- python=3.6.2=0
-- scipy=0.19.1=np113py36_0
-- sphinx=1.6.3=py36_0
-- tornado=4.5.1=py36_0
-- pip:
-  - flaky==3.4.0
-  - hypothesis==3.32.0
-  - pytest-xdist==1.20.0
+- python=${PYTHON_VERSION}
+- cython=0.28.3
+- jupyter=1.0.0
+- matplotlib=2.2.2
+- networkx=2.1
+- notebook=5.5.0
+- numpy=1.14.5
+- pandas=0.23.1
+- pymysql=0.8.1
+- pytables=3.4.4
+- pytest=3.6.2
+- scipy=1.1.0
+- sphinx=1.7.5
+- tornado=5.0.2
+- flaky=3.4.0
+- hypothesis=3.57
+- pytest-xdist=1.22.2
 EOF
 
     conda env create -f ${YML_FILENAME}

--- a/manage.sh
+++ b/manage.sh
@@ -116,7 +116,7 @@ function work_in_python_version {
 
     python_version_env
     compile_cython_components
-    run_tests
+    run_tests_par
 }
 
 function run_tests {

--- a/manage.sh
+++ b/manage.sh
@@ -104,6 +104,11 @@ function python_version_env {
 }
 
 function work_in_python_version {
+    work_in_python_version_no_tests
+    run_tests_par
+}
+
+function work_in_python_version_no_tests {
     if ! which conda >> /dev/null
     then
        install_conda
@@ -116,7 +121,6 @@ function work_in_python_version {
 
     python_version_env
     compile_cython_components
-    run_tests_par
 }
 
 function run_tests {
@@ -226,18 +230,19 @@ esac
 ## Main command dispatcher
 
 case $COMMAND in
-    install_and_check)      install_and_check ;;
-    install)                install ;;
-    work_in_python_version) work_in_python_version ;;
-    make_environment)       make_environment ;;
-    run_tests)              run_tests ;;
-    run_tests_par)          run_tests_par ;;
-    compile_and_test)       compile_and_test ;;
-    compile_and_test_par)   compile_and_test_par ;;
-    download_test_db)       download_test_db ;;
-    download_test_db_dev)   download_test_db_dev ;;
-    clean)                  clean ;;
-    show_ic_env)            show_ic_env ;;
+    install_and_check)               install_and_check ;;
+    install)                         install ;;
+    work_in_python_version)          work_in_python_version ;;
+    work_in_python_version_no_tests) work_in_python_version_no_tests ;;
+    make_environment)                make_environment ;;
+    run_tests)                       run_tests ;;
+    run_tests_par)                   run_tests_par ;;
+    compile_and_test)                compile_and_test ;;
+    compile_and_test_par)            compile_and_test_par ;;
+    download_test_db)                download_test_db ;;
+    download_test_db_dev)            download_test_db_dev ;;
+    clean)                           clean ;;
+    show_ic_env)                     show_ic_env ;;
 
     *) echo Unrecognized command: ${COMMAND}
        echo
@@ -246,6 +251,7 @@ case $COMMAND in
        echo "source $THIS install_and_check X.Y"
        echo "source $THIS install X.Y"
        echo "source $THIS work_in_python_version X.Y"
+       echo "source $THIS work_in_python_version_no_tests X.Y"
        echo "source $THIS switch_to_conda_env X.Y"
        echo "bash   $THIS make_environment X.Y"
        echo "bash   $THIS run_tests"

--- a/manage.sh
+++ b/manage.sh
@@ -11,6 +11,12 @@ case $COMMAND in
     *)                                PYTHON_VERSION=${ARGUMENT}       ;;
 esac
 
+# If PYTHON_VERSION was not specified as an argument, deduce it from
+# the conda environment
+
+if [[ $PYTHON_VERSION = "" ]]; then
+    PYTHON_VERSION=${CONDA_DEFAULT_ENV:3:3}
+fi
 
 function install_and_check {
     install


### PR DESCRIPTION
An attempt at addressing #495.

The idea is:

+ Include a dependency configuration tag in a committed file (`manage.sh` for now).
+ Povide `manage.sh` commands which
   + create conda environments which have the tag in their name and contain the correct set of dependencies
   + switch conda environment
+ Make the `manage.sh` testing commands automatically switch to the conda env which is appropriate for the currently checked out code.
+ The environments are made lazily: no environment is created until it is needed, which will only happen if
   + A commit which needs that environment is checked out, and
   + The user asks for the environment to be created, ether
      + explicitly, or
      + implicitly, by using `manage.sh` to run tests.

The tags are, for now, of the form `YYYY-MM-DD`, but we could use relase tag names instead. It might be a good idea to update the dependencies on every release: that way we'll never get too far behind the march of progress.

An example: If you clone and install the repo containing this branch today, you will create a conda env called `IC-3.6-2018-06-30`. If you then check out a commit which corresponds to an earlier dependency configuration, as soon as you run the tests with `source manage.sh run_tests(_par)`, a second conda environment called `IC-3.6-2018-05-03` will be created and activate implicitly. Checking out the tip of the branch once more, and running the tests (with `manage.sh`) will automatically switch to the first environment.

The whole lot needs to be cleaned up, made more robust, and the database should be updated automatically too. We also need to think about how to deal with commits which predate the addition of this feature.

I can imagine that better approaches could be invented. Let me know what you think.

It seems that we don't have the manpower to think about this carefully and the only way to prevent this from being ingnored and festering forever, is to approve and commit the first thing that looks like it works.