### PR TITLE
Add functions to filter based on Event ID

### DIFF
--- a/invisible_cities/core/core_functions.py
+++ b/invisible_cities/core/core_functions.py
@@ -218,7 +218,7 @@ def df_map(func, df, field):
     return out
 
 
-def dict_filter(cond, dic):
+def dict_filter_by_value(cond, dic):
     """Apply filter to dictionary values maintaining correspondence.
 
     Parameters
@@ -234,6 +234,22 @@ def dict_filter(cond, dic):
         Contains the key, value pairs in dic satisfying cond.
     """
     return {key: val for key, val in dic.items() if cond(val)}
+
+
+def dict_filter_by_key(cond, dic):
+    """Apply filter to dictionary keys maintaining correspondence.
+    Parameters
+    ----------
+    cond : callable
+        Condition to be satisfied.
+    dic : dictionary
+        Dictionary on which cond is applied.
+    Returns
+    -------
+    filterdic : dictionary
+        Contains the key, value pairs in dic satisfying cond.
+    """
+    return {key: val for key, val in dic.items() if cond(key)}
 
 
 def farray_from_string(sfl):

--- a/invisible_cities/core/core_functions_test.py
+++ b/invisible_cities/core/core_functions_test.py
@@ -218,9 +218,13 @@ def test_df_map():
     l2 = core.df_map(lambda x: x*1000, leptons, 'mass')
     assert l2.mass.values[0] == 511
 
-def test_dict_filter():
-    core.dict_filter(lambda x: x>5,
+def test_dict_filter_by_value():
+    core.dict_filter_by_value(lambda x: x>5,
       {'a':1,'b':20,'c':3,'d':40}) == {'b': 20, 'd': 40}
+
+def test_dict_filter_by_key():
+    core.dict_filter_by_key(lambda x: x in 'ac',
+      {'a':1,'b':20,'c':3,'d':40}) == {'a': 1, 'c': 3}
 
 def test_farray_from_string():
     core.farray_from_string('1 10 100')[2] == 100

--- a/invisible_cities/reco/dst_functions.py
+++ b/invisible_cities/reco/dst_functions.py
@@ -52,3 +52,23 @@ def load_lifetime_xy_corrections(filename, *,
     return LifetimeXYCorrection(f.reshape(x.size, y.size),
                                 u.reshape(x.size, y.size),
                                 x, y, **kwargs)
+
+def dst_event_id_selection(data, event_ids):
+    """Filter a DST by a list of event IDs.
+    Parameters
+    ----------
+    data      : pandas DataFrame
+        DST to be filtered.
+    event_ids : list
+        List of event ids that will be kept.
+    Returns
+    -------
+    filterdata : pandas DataFrame
+        Filtered DST
+    """
+    if 'event' in data:
+        sel = np.isin(data.event.values, event_ids)
+        return data[sel]
+    else:
+        print(r'DST does not have an "event" field. Data returned is unfiltered.')
+        return data

--- a/invisible_cities/reco/pmaps_functions.py
+++ b/invisible_cities/reco/pmaps_functions.py
@@ -1,7 +1,7 @@
-from ..evm.pmaps      import  PMTResponses
-from ..evm.pmaps      import SiPMResponses
-from . peak_functions import rebin_times_and_waveforms
-
+from ..evm.pmaps           import  PMTResponses
+from ..evm.pmaps           import SiPMResponses
+from . peak_functions      import rebin_times_and_waveforms
+from ..core.core_functions import dict_filter_by_key
 
 def rebin_peak(peak, rebin_factor):
     if rebin_factor == 1: return peak
@@ -19,3 +19,19 @@ def rebin_peak(peak, rebin_factor):
         sipm_r = SiPMResponses(peak.sipms.ids, sipms)
 
     return type(peak)(times, pmt_r, sipm_r)
+
+
+def pmap_event_id_selection(data, event_ids):
+    """Filter a pmap dictionary by a list of event IDs.
+    Parameters
+    ----------
+    data      : dict
+        pmaps to be filtered.
+    event_ids : list
+        List of event ids that will be kept.
+    Returns
+    -------
+    filterdata : dict
+        Filtered pmaps
+    """
+    return dict_filter_by_key(lambda x: x in event_ids, data)

--- a/invisible_cities/reco/pmaps_functions_test.py
+++ b/invisible_cities/reco/pmaps_functions_test.py
@@ -3,8 +3,11 @@ import numpy as np
 from hypothesis            import given
 from hypothesis.strategies import integers
 from hypothesis.strategies import floats
+from hypothesis.strategies import dictionaries
+from hypothesis.strategies import lists
 
 from .. evm .pmaps_test     import peaks
+from .. evm .pmaps_test     import pmaps
 from .. evm .pmaps          import  PMTResponses
 from .. evm .pmaps          import SiPMResponses
 from .. core.testing_utils  import assert_SensorResponses_equality
@@ -74,3 +77,11 @@ def test_rebin_peak(pk, fraction):
                             rebinned_pmts,
                             rebinned_sipms)
     assert_Peak_equality(rebinned_pk, expected_pk)
+
+
+@given(dictionaries(keys=integers(min_value=-1e5, max_value=1e5), values=pmaps(), max_size=5), lists(integers(min_value=-1e5, max_value=1e5)))
+def test_pmap_event_id_selection(pmaps, events):
+    filtered_pmaps = pmf.pmap_event_id_selection(pmaps, events)
+    assert set(filtered_pmaps) == set(pmaps) & set(events)
+    for evt, pmap in filtered_pmaps.items():
+        assert pmap == pmaps[evt]


### PR DESCRIPTION
This PR adds two functions to filter data based on the event id, one for DSTs and another for pmaps. The latest one uses a more generic function (also added in the PR) which filters dictionaries based on their keys. There was a previous dictionary filter but only on the values, this function has been renamed to clearly state the difference between both cases.