### PR TITLE
Addition of simulation of low frequency noise

### DIFF
--- a/invisible_cities/database/download.py
+++ b/invisible_cities/database/download.py
@@ -96,9 +96,26 @@ def loadDB(dbname='NEWDB'):
 ,  `Probability` float NOT NULL
 );''')
 
+    cursorSql3.execute('''CREATE TABLE IF NOT EXISTS `PMTFEMapping` (
+    `MinRun` integer NOT NULL
+,  `MaxRun` integer NOT NULL
+,  `SensorID` integer NOT NULL
+,  `FEBox` integer NOT NULL
+);''')
+
+    cursorSql3.execute('''CREATE TABLE IF NOT EXISTS `PMTFELowFrequencyNoise` (
+    `MinRun` integer NOT NULL
+,  `MaxRun` integer NOT NULL
+,  `Frequency` float NOT NULL
+,  `FE0Magnitude` float NOT NULL
+,  `FE1Magnitude` float NOT NULL
+,  `FE2Magnitude` float NOT NULL
+);''')
+
 
     tables = ['DetectorGeo','PmtBlr','ChannelGain','ChannelMapping','ChannelMask',
-          'PmtNoiseRms','ChannelPosition','SipmBaseline', 'SipmNoisePDF']
+              'PmtNoiseRms','ChannelPosition','SipmBaseline', 'SipmNoisePDF',
+              'PMTFEMapping', 'PMTFELowFrequencyNoise']
 
 
     # Copy all tables

--- a/invisible_cities/database/load_db.py
+++ b/invisible_cities/database/load_db.py
@@ -111,3 +111,21 @@ order by SensorID, BinEnergyPes;'''.format(abs(run_number))
     noise = np.array(data).reshape(nsipms, nbins)
 
     return noise, noise_bins, baselines
+
+
+def PMTLowFrequencyNoise(run_number=1e5, dbfile=DATABASE_LOCATION):
+    conn = sqlite3.connect(dbfile)
+    cursor = conn.cursor()
+
+    sqlmapping = '''select SensorID, FEBox from PMTFEMapping
+    where MinRun <= {0} and (MaxRun >= {0} or MaxRun is NULL)
+    order by SensorID;'''.format(abs(run_number))
+    mapping = pd.read_sql_query(sqlmapping, conn)
+
+    ## Now get the frequencies and magnitudes (and ?) for each box
+    sqlmagnitudes = '''select Frequency, FE0Magnitude, FE1Magnitude, FE2Magnitude
+    from PMTFELowFrequencyNoise where MinRun <= {0}
+    and (MaxRun >= {0} or MaxRun is NULL)'''.format(abs(run_number))
+    frequencies = pd.read_sql_query(sqlmagnitudes, conn)
+
+    return mapping, frequencies.values

--- a/invisible_cities/database/load_db.py
+++ b/invisible_cities/database/load_db.py
@@ -113,6 +113,7 @@ order by SensorID, BinEnergyPes;'''.format(abs(run_number))
     return noise, noise_bins, baselines
 
 
+@lru_cache(maxsize=10)
 def PMTLowFrequencyNoise(run_number=1e5, dbfile=DATABASE_LOCATION):
     conn = sqlite3.connect(dbfile)
     cursor = conn.cursor()

--- a/invisible_cities/database/load_db_test.py
+++ b/invisible_cities/database/load_db_test.py
@@ -141,3 +141,28 @@ def test_database_is_being_cached(db_fun):
     else:
         assert np.all(first_call.values == second_call.values)
     assert time_second_call < 1e6 * time_first_call
+
+
+def test_frontend_mapping():
+    """ Check the mapping has the expected shape etc """
+
+    fe_mapping, _ = DB.PMTLowFrequencyNoise()
+
+    columns = ['SensorID', 'FEBox']
+
+    assert columns == list(fe_mapping)
+    assert fe_mapping.SensorID.nunique() == 12
+    assert fe_mapping.FEBox.nunique()    == 3
+
+
+def test_pmt_noise_frequencies():
+    """ Check the magnitudes and frequencies
+    are of the expected length """
+    _, frequencies = DB.PMTLowFrequencyNoise()
+
+    ## Currently simulate frequencies in range(312.5, 25000) Hz
+    freq_expected = np.arange(1, 80) * 312.5
+    ## Expected four columns: frequency, mag FE0, mag FE1, mag FE2
+    assert frequencies.shape[0] == 79
+    assert frequencies.shape[1] == 4
+    assert np.all(frequencies[:, 0] == freq_expected)

--- a/invisible_cities/sierpe/low_frequency_noise.py
+++ b/invisible_cities/sierpe/low_frequency_noise.py
@@ -12,30 +12,69 @@ from .. database import load_db as DB
 
 
 def frequency_contribution(rfrequency, magnitude, phase, time_bins):
-
+    """
+    Returns the contribution over the whole buffer of
+    a frequency, magnitude, phase point.
+    
+    Parameters
+    ----------
+    rfrequency : float, rotational frequency
+    magnitude  : float, magnitude of oscillation
+    phase      : float, phase of oscillation
+    """
     return 2 * magnitude * np.cos(rfrequency * time_bins + phase)
 
 
+def buffer_and_limits(buffer_length, buffer_bin_width, FE_data):
+    """
+    Makes the basic definitions which are common
+    to all calls to the low_frequency_noise function.
+
+    Parameters
+    ----------
+    buffer_length    : length of buffer to be simulated in no. samples
+    buffer_bin_width : sample width in buffer
+    FE_data          : np.ndarray with the frequencies to be simulated
+
+    Returns
+    -------
+    partial wrapped frequency_contribution function for the time bins needed
+    lower and upper limits for the frequency bins to be simulated.
+
+    """
+    times = buffer_bin_width * np.arange(buffer_length)
+    freq_contribution = partial(frequency_contribution, time_bins=times)
+
+    frequency_low  = FE_data - np.diff(FE_data)[0] / 2
+    frequency_high = FE_data + np.diff(FE_data)[0] / 2
+
+    return freq_contribution, frequency_low, frequency_high
+
+
 def low_frequency_noise(run_number, buffer_length, buffer_bin_width=25e-9):
+    """
+    Randomises frequencies, magnitudes and phases and
+    returns a function that can be used to get the
+    simulated low frequency noise for a particular PMT
+    """
 
     FE_mapping, FE_data = DB.PMTLowFrequencyNoise(run_number)
 
     ## Need to protect for old runs where PMT indx != sensorID
-    sensor_id     = DB.DataPMT(run_number).SensorID.values
+    sens_id       = DB.DataPMT(run_number).SensorID.values
 
     n_febox       = FE_data.shape[1] - 1
     n_frequencies = FE_data.shape[0]
 
-    times = buffer_bin_width * np.arange(buffer_length)
-    freq_contribution = partial(frequency_contribution, time_bins=times)
+    freq_contrib, freq_low, freq_high = buffer_and_limits(buffer_length,
+                                                          buffer_bin_width,
+                                                          FE_data[:, 0])
 
     ## Randomise frequencies
-    frequency_low  = FE_data[:, 0] - np.diff(FE_data[:, 0])[0] / 2
-    frequency_high = FE_data[:, 0] + np.diff(FE_data[:, 0])[0] / 2
-    rot_frequencies   = 2 * np.pi * np.random.uniform(frequency_low, frequency_high)
-    rot_frequencies   = np.tile(rot_frequencies, n_febox)
+    rot_frequencies = 2 * np.pi * np.random.uniform(freq_low, freq_high)
+    rot_frequencies = np.tile(rot_frequencies, n_febox)
 
-    ## Randomise magnitudes and phases
+    ## Randomise magnitudes and phases. mag_rms ~ 0.5 * mag_mean
     magnitudes = np.array(tuple(map(np.random.normal    ,
                                     FE_data[:, 1:]      ,
                                     FE_data[:, 1:] * 0.5)))
@@ -44,16 +83,16 @@ def low_frequency_noise(run_number, buffer_length, buffer_bin_width=25e-9):
 
     phases     = np.random.uniform(-np.pi, np.pi, magnitudes.shape)
 
-    noise = np.array(tuple(map(freq_contribution,
-                               rot_frequencies  ,
-                               magnitudes       ,
-                               phases           )))
+    noise = np.array(tuple(map(freq_contrib   ,
+                               rot_frequencies,
+                               magnitudes     ,
+                               phases         )))
     noise = noise.reshape(n_febox, n_frequencies, buffer_length).sum(axis=1)
 
     def get_low_frequency_noise(indx_pmt):
         """ Returns the appropriate vector """
 
-        febox = FE_mapping.FEBox[FE_mapping.SensorID==sensor_id[indx_pmt]].values[0]
-        return noise[febox]
+        febox = FE_mapping.FEBox[FE_mapping.SensorID==sens_id[indx_pmt]].values
+        return noise[febox[0]]
 
     return get_low_frequency_noise

--- a/invisible_cities/sierpe/low_frequency_noise.py
+++ b/invisible_cities/sierpe/low_frequency_noise.py
@@ -1,0 +1,59 @@
+""" Classes and functions describing the oscillation in pmt
+baselines.
+AL, November 2017.
+"""
+
+
+import numpy as np
+
+from functools import partial
+
+from .. database import load_db as DB
+
+
+def frequency_contribution(rfrequency, magnitude, phase, time_bins):
+
+    return 2 * magnitude * np.cos(rfrequency * time_bins + phase)
+
+
+def low_frequency_noise(run_number, buffer_length, buffer_bin_width=25e-9):
+
+    FE_mapping, FE_data = DB.PMTLowFrequencyNoise(run_number)
+
+    ## Need to protect for old runs where PMT indx != sensorID
+    sensor_id     = DB.DataPMT(run_number).SensorID.values
+
+    n_febox       = FE_data.shape[1] - 1
+    n_frequencies = FE_data.shape[0]
+
+    times = buffer_bin_width * np.arange(buffer_length)
+    freq_contribution = partial(frequency_contribution, time_bins=times)
+
+    ## Randomise frequencies
+    frequency_low  = FE_data[:, 0] - np.diff(FE_data[:, 0])[0] / 2
+    frequency_high = FE_data[:, 0] + np.diff(FE_data[:, 0])[0] / 2
+    rot_frequencies   = 2 * np.pi * np.random.uniform(frequency_low, frequency_high)
+    rot_frequencies   = np.tile(rot_frequencies, n_febox)
+
+    ## Randomise magnitudes and phases
+    magnitudes = np.array(tuple(map(np.random.normal    ,
+                                    FE_data[:, 1:]      ,
+                                    FE_data[:, 1:] * 0.5)))
+    ## Reshape to ease mapping
+    magnitudes = magnitudes.T.reshape(magnitudes.size,)
+
+    phases     = np.random.uniform(-np.pi, np.pi, magnitudes.shape)
+
+    noise = np.array(tuple(map(freq_contribution,
+                               rot_frequencies  ,
+                               magnitudes       ,
+                               phases           )))
+    noise = noise.reshape(n_febox, n_frequencies, buffer_length).sum(axis=1)
+
+    def get_low_frequency_noise(indx_pmt):
+        """ Returns the appropriate vector """
+
+        febox = FE_mapping.FEBox[FE_mapping.SensorID==sensor_id[indx_pmt]].values[0]
+        return noise[febox]
+
+    return get_low_frequency_noise

--- a/invisible_cities/sierpe/low_frequency_noise_test.py
+++ b/invisible_cities/sierpe/low_frequency_noise_test.py
@@ -20,17 +20,18 @@ def test_buffer_and_limits():
 
     buffer_len        = 40 ## dummy 1 mus buffer
     buffer_sample_wid = 25e-9
-    frequencies       = np.arange(15000, 20000, 500) ## subset of frequences
+    freqency_bin      = 500
+    frequencies       = np.arange(15000, 20000, frequency_bin)
     
     freq_cont, lowf, highf = lfn.buffer_and_limits(buffer_len       ,
                                                    buffer_sample_wid,
                                                    frequencies      )
 
     assert np.all(freq_cont.keywords['time_bins'] == buffer_sample_wid * np.arange(buffer_len))
-    assert np.all(np.diff(lowf) == 500)
-    assert np.all(np.diff(highf) == 500)
-    assert lowf[0] == frequencies[0] - 250
-    assert highf[-1] == frequencies[-1] + 250
+    assert np.all(np.diff(lowf) == frequency_bin)
+    assert np.all(np.diff(highf) == frequency_bin)
+    assert lowf[0] == frequencies[0] - frequency_bin / 2
+    assert highf[-1] == frequencies[-1] + frequency_bin / 2
 
 
 def test_low_frequency_noise():
@@ -46,11 +47,12 @@ def test_low_frequency_noise():
 
     assert pmt_noise.shape[1] == buffer_len
 
-    ## Which should be the same and which not depends on
-    ## the mapping whhich is a databse issue but they shouldn't
-    ## all be the same only some.
-    ## Some are different
+    ## Which pmts should have the same noise and which not
+    ## depends on the mapping which is a databse issue.
+    ## They shouldn't all be the same though as they should be
+    ## grouped by febox.
+    ## First check some are different
     assert np.any(np.diff(pmt_noise, axis = 0))
-    ## but not all
+    ## then that not all are
     assert not np.all(np.diff(pmt_noise, axis = 0))
     

--- a/invisible_cities/sierpe/low_frequency_noise_test.py
+++ b/invisible_cities/sierpe/low_frequency_noise_test.py
@@ -1,0 +1,56 @@
+import pytest
+
+import numpy as np
+
+from numpy.testing import assert_allclose
+
+from .             import low_frequency_noise as lfn
+
+
+def test_frequency_contribution():
+
+    time_bins = 25e-9 * np.arange(80)
+
+    freq_contribution = lfn.frequency_contribution(1, 1, 0, time_bins)
+
+    assert_allclose(freq_contribution, 2 * np.cos(time_bins))
+
+
+def test_buffer_and_limits():
+
+    buffer_len        = 40 ## dummy 1 mus buffer
+    buffer_sample_wid = 25e-9
+    frequencies       = np.arange(15000, 20000, 500) ## subset of frequences
+    
+    freq_cont, lowf, highf = lfn.buffer_and_limits(buffer_len       ,
+                                                   buffer_sample_wid,
+                                                   frequencies      )
+
+    assert np.all(freq_cont.keywords['time_bins'] == buffer_sample_wid * np.arange(buffer_len))
+    assert np.all(np.diff(lowf) == 500)
+    assert np.all(np.diff(highf) == 500)
+    assert lowf[0] == frequencies[0] - 250
+    assert highf[-1] == frequencies[-1] + 250
+
+
+def test_low_frequency_noise():
+
+    ## Variable for basic definitions
+    run_no     = 6000
+    buffer_len = 32000 ## 800 mus buffer
+
+    noise_func = lfn.low_frequency_noise(run_no, buffer_len)
+
+    ## Get an array with all pmts
+    pmt_noise = np.array(list(map(noise_func, np.arange(12))))
+
+    assert pmt_noise.shape[1] == buffer_len
+
+    ## Which should be the same and which not depends on
+    ## the mapping whhich is a databse issue but they shouldn't
+    ## all be the same only some.
+    ## Some are different
+    assert np.any(np.diff(pmt_noise, axis = 0))
+    ## but not all
+    assert not np.all(np.diff(pmt_noise, axis = 0))
+    

--- a/invisible_cities/sierpe/low_frequency_noise_test.py
+++ b/invisible_cities/sierpe/low_frequency_noise_test.py
@@ -20,7 +20,7 @@ def test_buffer_and_limits():
 
     buffer_len        = 40 ## dummy 1 mus buffer
     buffer_sample_wid = 25e-9
-    freqency_bin      = 500
+    frequency_bin      = 500
     frequencies       = np.arange(15000, 20000, frequency_bin)
     
     freq_cont, lowf, highf = lfn.buffer_and_limits(buffer_len       ,


### PR DESCRIPTION
Simulation of low frequency noise effects
seen in the PMTs to the sensor simulation.

Involves changes to the database to allow
parameters from the detector to be updated
whern needed.

load_db.py:
New funciton added 'PMTLowFrequencyNoise'
which reads the mapping of PMTs to
front end boxes and the frequencies
and magnitudes to be used in the simulation.

low_frequency_noise.py:
New function that randomises contributions
and returns a function to access these
according to front end board mapping