### PR TITLE
Fix Irene bug caused by Numpy upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
   fast_finish: true
   allow_failures:
   - os: osx
+  - env: IC_PYTHON_VERSION=3.7
 
 env:
   - IC_PYTHON_VERSION=3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
   - os: osx
 
 env:
+  - IC_PYTHON_VERSION=3.7
   - IC_PYTHON_VERSION=3.6
 
 os:

--- a/bash_manage.sh
+++ b/bash_manage.sh
@@ -27,7 +27,7 @@ manage.sh()
     if [[ ${prev2} == "manage.sh" ]] ; then
             case "${prev}" in
                         install_and_check|install|work_in_python_version|make_environment)
-                        local versions="3.6"
+                        local versions="3.6 3.7"
                     COMPREPLY=( $(compgen -W "${versions}" -- ${cur}) )
                     return 0
                     ;;
@@ -73,7 +73,7 @@ source_manage.sh()
     if [[ ${prev2} == "manage.sh" ]] ; then
             case "${prev}" in
                         install_and_check|install|work_in_python_version|make_environment)
-                        local versions="3.6"
+                        local versions="3.6 3.7"
                     COMPREPLY=( $(compgen -W "${versions}" -- ${cur}) )
                     return 0
                     ;;

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -387,11 +387,11 @@ def test_irene_split_trigger(config_tmpdir, ICDIR, s12params):
         cnt = irene.end()
 
     #check there is a warning for unknown trigger types
-    assert len(record) == 1
+    assert len(record) >= 1
     evt_warn = 2
     trg_warn = 5
     message = "Event {} has an unknown trigger type ({})".format(evt_warn, trg_warn)
-    assert record[0].message.args[0] == message
+    assert sum(1 for r in record if r.message.args[0] == message) == 1
 
     nactual = cnt.n_events_tot
     if nrequired > 0:

--- a/manage.sh
+++ b/manage.sh
@@ -72,7 +72,7 @@ function install_conda {
     fi
 }
 
-CONDA_ENV_TAG=2018-06-30
+CONDA_ENV_TAG=2018-07-28
 CONDA_ENV_NAME=IC-${PYTHON_VERSION}-${CONDA_ENV_TAG}
 
 function make_environment {
@@ -90,15 +90,15 @@ dependencies:
 - networkx=2.1
 - notebook=5.5.0
 - numpy=1.14.5
-- pandas=0.23.1
-- pymysql=0.8.1
+- pandas=0.23.3
+- pymysql=0.9.2
 - pytables=3.4.4
 - pytest=3.6.2
 - scipy=1.1.0
 - sphinx=1.7.5
 - tornado=5.0.2
 - flaky=3.4.0
-- hypothesis=3.57
+- hypothesis=3.59.1
 - pytest-xdist=1.22.2
 EOF
 

--- a/manage.sh
+++ b/manage.sh
@@ -89,7 +89,7 @@ dependencies:
 - matplotlib=2.2.2
 - networkx=2.1
 - notebook=5.6.0
-- numpy=1.14.5
+- numpy=1.15.0
 - pandas=0.23.3
 - pymysql=0.9.2
 - pytables=3.4.4

--- a/manage.sh
+++ b/manage.sh
@@ -72,7 +72,7 @@ function install_conda {
     fi
 }
 
-CONDA_ENV_TAG=2018-07-28
+CONDA_ENV_TAG=2018-07-29
 CONDA_ENV_NAME=IC-${PYTHON_VERSION}-${CONDA_ENV_TAG}
 
 function make_environment {
@@ -84,18 +84,18 @@ function make_environment {
 name: ${CONDA_ENV_NAME}
 dependencies:
 - python=${PYTHON_VERSION}
-- cython=0.28.3
+- cython=0.28.4
 - jupyter=1.0.0
 - matplotlib=2.2.2
 - networkx=2.1
-- notebook=5.5.0
+- notebook=5.6.0
 - numpy=1.14.5
 - pandas=0.23.3
 - pymysql=0.9.2
 - pytables=3.4.4
-- pytest=3.6.2
+- pytest=3.6.3
 - scipy=1.1.0
-- sphinx=1.7.5
+- sphinx=1.7.6
 - tornado=5.0.2
 - flaky=3.4.0
 - hypothesis=3.59.1


### PR DESCRIPTION
We were using Numpy 1.14.5. 1.15.0 is available, but `test_irene_split_trigger` breaks if we use the new version of Numpy.