### PR TITLE
Fix dependency versioning

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -105,8 +105,16 @@ EOF
     conda env create -f ${YML_FILENAME}
 }
 
+function make_environment_if_missing {
+    if ! conda env list | grep ${CONDA_ENV_NAME}
+    then
+        make_environment
+    fi
+}
+
 function switch_to_conda_env {
     conda deactivate # in case some other environment was already active
+    make_environment_if_missing ${CONDA_ENV_NAME}
     conda activate ${CONDA_ENV_NAME}
 }
 


### PR DESCRIPTION
This addresses a bug in #496: it (sometimes?) crashed when needing to switch to an environment that had not been created yet.

The fix consits of ensuring that, if the environment does not yet exist, it is created before the switch is attempted.

(I have no idea how to write automated tests for the stuff in `manage.sh`, especially the ones related to switching environment ... which makes working on this very painful and error-prone.)