### PR TITLE
Improve mc copy

### DIFF
--- a/invisible_cities/io/mcinfo_io.py
+++ b/invisible_cities/io/mcinfo_io.py
@@ -223,10 +223,10 @@ def read_mcinfo_evt (mctables: (tb.Table, tb.Table, tb.Table, tb.Table),
             while ipart <= ipart_end:
                 particle_rows.append(h5particles[ipart])
                 ipart += 1
-            
-            # It is possible for the 'generators' dataset to have a different length compared to the 'extents' dataset. In particular, it may occur that the 'generators' dataset is empty. In this case, do not add any rows to 'generators'.
-            if len(h5generators) == len(h5extents):
-                generator_rows.append(h5generators[last_row])
+
+            # It is possible for the 'generators' dataset to be empty. In this case, do not add any rows to 'generators'.
+            if len(h5generators) != 0:
+                generator_rows.append(h5generators[iext])
 
             break
 

--- a/invisible_cities/io/mcinfo_io.py
+++ b/invisible_cities/io/mcinfo_io.py
@@ -85,40 +85,43 @@ class mc_info_writer:
             self.reset()
 
         extents = mctables[0]
+        # Note: filtered out events do not make it to evt_number, but are included in extents dataset
         for iext in range(self.last_row, len(extents)):
             this_row = extents[iext]
-            if this_row['evt_number'] < evt_number: continue
-            if this_row['evt_number'] > evt_number: break
-            if iext == 0:
-                if self.first_file:
-                    modified_hit          = this_row['last_hit']
-                    modified_particle     = this_row['last_particle']
+            if this_row['evt_number'] == evt_number:
+                if iext == 0:
+                    if self.first_file:
+                        modified_hit          = this_row['last_hit']
+                        modified_particle     = this_row['last_particle']
+                        self.first_extent_row = False
+                        self.first_file       = False
+                    else:
+                        modified_hit          = this_row['last_hit'] + self.last_written_hit + 1
+                        modified_particle     = this_row['last_particle'] + self.last_written_particle + 1
+                        self.first_extent_row = False
+
+                elif self.first_extent_row:
+                    previous_row          = extents[iext-1]
+                    modified_hit          = this_row['last_hit'] - previous_row['last_hit'] + self.last_written_hit - 1
+                    modified_particle     = this_row['last_particle'] - previous_row['last_particle'] + self.last_written_particle - 1
                     self.first_extent_row = False
                     self.first_file       = False
                 else:
-                    modified_hit          = this_row['last_hit'] + self.last_written_hit + 1
-                    modified_particle     = this_row['last_particle'] + self.last_written_particle + 1
-                    self.first_extent_row = False
+                    previous_row      = extents[iext-1]
+                    modified_hit      = this_row['last_hit'] - previous_row['last_hit'] + self.last_written_hit
+                    modified_particle = this_row['last_particle'] - previous_row['last_particle'] + self.last_written_particle
 
-            elif self.first_extent_row:
-                previous_row          = extents[iext-1]
-                modified_hit          = this_row['last_hit'] - previous_row['last_hit'] + self.last_written_hit - 1
-                modified_particle     = this_row['last_particle'] - previous_row['last_particle'] + self.last_written_particle - 1
-                self.first_extent_row = False
-                self.first_file       = False
-            else:
-                previous_row      = extents[iext-1]
-                modified_hit      = this_row['last_hit'] - previous_row['last_hit'] + self.last_written_hit
-                modified_particle = this_row['last_particle'] - previous_row['last_particle'] + self.last_written_particle
+                modified_row                  = self.extent_table.row
+                modified_row['evt_number']    = evt_number
+                modified_row['last_hit']      = modified_hit
+                modified_row['last_particle'] = modified_particle
+                modified_row.append()
 
-            modified_row                  = self.extent_table.row
-            modified_row['evt_number']    = evt_number
-            modified_row['last_hit']      = modified_hit
-            modified_row['last_particle'] = modified_particle
-            modified_row.append()
+                self.last_written_hit      = modified_hit
+                self.last_written_particle = modified_particle
 
-            self.last_written_hit      = modified_hit
-            self.last_written_particle = modified_particle
+                break
+
         self.extent_table.flush()
 
         hits, particles, generators = read_mcinfo_evt(mctables, evt_number, self.last_row)

--- a/invisible_cities/io/mcinfo_io_test.py
+++ b/invisible_cities/io/mcinfo_io_test.py
@@ -86,6 +86,34 @@ def test_mc_info_writer_output_non_consecutive_events(output_tmpdir, ICDATADIR, 
                 assert             partr['particle_name'] == filtered_partr['particle_name']
 
 
+@mark.serial
+@parametrize('file_to_check, evt_to_be_read',
+            (('test_background_mcinfo_skip_evt700000000.h5', 640000000),
+             ('test_background_mcinfo_skip_evt640000000.h5', 700000000),
+             ('test_background_mcinfo_skip_evt640000000.h5', 40197500)))
+def test_mc_info_writer_generatoroutput_non_consecutive_events(output_tmpdir, ICDATADIR, file_to_check, evt_to_be_read):
+
+    filein = os.path.join(ICDATADIR, 'mcfile_withgeneratorinfo_3evts_MCRD.h5')
+    filecheck = os.path.join(output_tmpdir, file_to_check)
+
+    with tb.open_file(filein) as h5in:
+        with tb.open_file(filecheck) as h5filtered:
+            mc_info          = get_mc_info(h5in)
+            filtered_mc_info = get_mc_info(h5filtered)
+            # test the content of events to be sure that they are written
+            # correctly
+            hit_rows, particle_rows, generator_rows = read_mcinfo_evt(mc_info,
+                                                                      evt_to_be_read)
+            filtered_hit_rows, filtered_particle_rows, filtered_generator_rows = read_mcinfo_evt(filtered_mc_info,
+                                                                                                 evt_to_be_read)
+
+            for genr, filtered_genr in zip(generator_rows, filtered_generator_rows):
+                assert np.allclose(genr['evt_number']   , filtered_genr['evt_number'])
+                assert np.allclose(genr['atomic_number'], filtered_genr['atomic_number'])
+                assert np.allclose(genr['mass_number']  , filtered_genr['mass_number'])
+                assert             genr['region'] ==      filtered_genr['region']
+
+
 def test_mc_info_writer_reset(output_tmpdir, ICDATADIR, krypton_MCRD_file):
     filein  = os.path.join(ICDATADIR, krypton_MCRD_file)
     fileout = os.path.join(output_tmpdir, "test_mc_info_writer_reset.h5")

--- a/invisible_cities/io/mcinfo_io_test.py
+++ b/invisible_cities/io/mcinfo_io_test.py
@@ -87,31 +87,20 @@ def test_mc_info_writer_output_non_consecutive_events(output_tmpdir, ICDATADIR, 
 
 
 @mark.serial
-@parametrize('file_to_check, evt_to_be_read',
-            (('test_background_mcinfo_skip_evt700000000.h5', 640000000),
-             ('test_background_mcinfo_skip_evt640000000.h5', 700000000),
-             ('test_background_mcinfo_skip_evt640000000.h5', 40197500)))
-def test_mc_info_writer_generatoroutput_non_consecutive_events(output_tmpdir, ICDATADIR, file_to_check, evt_to_be_read):
-
-    filein = os.path.join(ICDATADIR, 'mcfile_withgeneratorinfo_3evts_MCRD.h5')
-    filecheck = os.path.join(output_tmpdir, file_to_check)
+@parametrize('file_to_check',
+            ('test_background_mcinfo_skip_evt700000000.h5',
+             'test_background_mcinfo_skip_evt640000000.h5'))
+def test_mc_info_writer_generatoroutput_non_consecutive_events(output_tmpdir, file_to_check):
+    filein = os.path.join(output_tmpdir, file_to_check)
 
     with tb.open_file(filein) as h5in:
-        with tb.open_file(filecheck) as h5filtered:
-            mc_info          = get_mc_info(h5in)
-            filtered_mc_info = get_mc_info(h5filtered)
-            # test the content of events to be sure that they are written
-            # correctly
-            hit_rows, particle_rows, generator_rows = read_mcinfo_evt(mc_info,
-                                                                      evt_to_be_read)
-            filtered_hit_rows, filtered_particle_rows, filtered_generator_rows = read_mcinfo_evt(filtered_mc_info,
-                                                                                                 evt_to_be_read)
+        mc_info          = get_mc_info(h5in)
 
-            for genr, filtered_genr in zip(generator_rows, filtered_generator_rows):
-                assert np.allclose(genr['evt_number']   , filtered_genr['evt_number'])
-                assert np.allclose(genr['atomic_number'], filtered_genr['atomic_number'])
-                assert np.allclose(genr['mass_number']  , filtered_genr['mass_number'])
-                assert             genr['region'] ==      filtered_genr['region']
+        # test the content of events to be sure that the extents rows are ion sync with generators rows
+        evt_numbers_in_extents    = h5in.root.MC.extents[:]['evt_number']
+        evt_numbers_in_generators = h5in.root.MC.generators[:]['evt_number']
+
+        np.testing.assert_array_equal(evt_numbers_in_extents, evt_numbers_in_generators)
 
 
 def test_mc_info_writer_reset(output_tmpdir, ICDATADIR, krypton_MCRD_file):


### PR DESCRIPTION
This PR is for fixing the copying of MC truth information, in particular the MC generator information on decaying isotope and decay volume in the detector. In the master branch, the copy is wrong if the two following conditions are met at the same time:

1. Some event is being filtered out between input and output. This can be the case, for example, in irene, dorothea or penthesilea cities.

2. Event numbers are not in increasing order in the input file. This can be the case, for example, in background MC files.   

When back from vacations, @paolafer is probably the best person to review this.
