### PR TITLE
Set correct size to voxels

### DIFF
--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -65,10 +65,15 @@ def voxelize_hits(hits             : Sequence[BHit],
 
     def centres(a : np.ndarray) -> np.ndarray:
         return (a[1:] + a[:-1]) / 2
+    def   sizes(a : np.ndarray) -> np.ndarray:
+        return  a[1:] - a[:-1]
 
-    cx, cy, cz = map(centres, edges)
+    (   cx,     cy,     cz) = map(centres, edges)
+    size_x, size_y, size_z  = map(sizes  , edges)
     nz = np.nonzero(E)
-    return [Voxel(cx[x], cy[y], cz[z], E[x,y,z], voxel_dimensions) for (x,y,z) in np.stack(nz).T]
+    true_dimensions = np.array([size_x[0], size_y[0], size_z[0]])
+
+    return [Voxel(cx[x], cy[y], cz[z], E[x,y,z], true_dimensions) for (x,y,z) in np.stack(nz).T]
 
 
 class Contiguity(Enum):

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -34,10 +34,9 @@ def bounding_box(seq : BHit) -> Sequence[np.ndarray]:
 def voxelize_hits(hits             : Sequence[BHit],
                   voxel_dimensions : np.ndarray,
                   strict_voxel_size: bool = False) -> List[Voxel]:
-    """1. Hits are enclosed by a bounding box.
-       2. Bounding box is discretized (via a histogramdd).
-       3. The energy of all the hits inside each discrete "voxel" is added.
-     """
+    # 1. Find bounding box of all hits.
+    # 2. Allocate hits to regular sub-boxes within bounding box, using histogramdd.
+    # 3. Calculate voxel energies by summing energies of hits within each sub-box.
     if not hits:
         raise NoHits
     hlo, hhi = bounding_box(hits)

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -35,8 +35,8 @@ def voxelize_hits(hits             : Sequence[BHit],
                   voxel_dimensions : np.ndarray,
                   strict_voxel_size: bool = False) -> List[Voxel]:
     """1. Hits are enclosed by a bounding box.
-       2. Boundix box is discretized (via a hitogramdd).
-       3. The energy of all the hits insidex each discreet "voxel" is added.
+       2. Bounding box is discretized (via a histogramdd).
+       3. The energy of all the hits inside each discrete "voxel" is added.
      """
     if not hits:
         raise NoHits

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -160,8 +160,8 @@ def test_voxelize_hits_flexible_gives_correct_voxels_size(hits, requested_voxel_
         return np.isclose(n, round(n))
 
     for pos1, pos2 in combinations(positions, 2):
-        for i in range(3):
-            assert is_close_to_integer((pos1[i] - pos2[i]) / voxel_size[i])
+        for separation, size in zip(pos2 - pos1, voxel_size):
+            assert is_close_to_integer(separation / size)
 
 
 @given(bunch_of_hits, box_sizes)

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -157,11 +157,11 @@ def test_voxelize_hits_flexible_gives_correct_voxels_size(hits, requested_voxel_
     voxel_size = voxels[0].size
 
     def is_close_to_integer(n):
-        return np.isclose(n, round(n))
+        return np.isclose(n, np.rint(n))
 
     for pos1, pos2 in combinations(positions, 2):
-        for separation, size in zip(pos2 - pos1, voxel_size):
-            assert is_close_to_integer(separation / size)
+        separation_over_size = (pos2 - pos1) / voxel_size
+        assert is_close_to_integer(separation_over_size).all()
 
 
 @given(bunch_of_hits, box_sizes)

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -57,6 +57,8 @@ box_sizes = builds(np.array, lists(box_dimension,
                                    min_size = 3,
                                    max_size = 3))
 
+eps = 3e-12
+
 
 def test_voxelize_hits_should_detect_no_hits():
     with raises(NoHits):
@@ -137,7 +139,7 @@ def test_voxelize_hits_respects_voxel_dimensions(hits, requested_voxel_dimension
 def test_voxelize_hits_gives_maximum_voxels_size(hits, requested_voxel_dimensions):
     voxels = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False)
     for v in voxels:
-        assert (v.size <= requested_voxel_dimensions).all()
+        assert (v.size <= requested_voxel_dimensions + 2 * eps).all()
 
 @given(bunch_of_hits, box_sizes)
 def test_voxelize_hits_strict_gives_required_voxels_size(hits, requested_voxel_dimensions):

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -135,11 +135,13 @@ def test_voxelize_hits_respects_voxel_dimensions(hits, requested_voxel_dimension
         assert (np.isclose(off_by, 0   ) |
                 np.isclose(off_by, unit)).all()
 
+
 @given(bunch_of_hits, box_sizes)
 def test_voxelize_hits_gives_maximum_voxels_size(hits, requested_voxel_dimensions):
     voxels = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False)
     for v in voxels:
         assert (v.size <= requested_voxel_dimensions + 2 * eps).all()
+
 
 @given(bunch_of_hits, box_sizes)
 def test_voxelize_hits_strict_gives_required_voxels_size(hits, requested_voxel_dimensions):
@@ -149,13 +151,25 @@ def test_voxelize_hits_strict_gives_required_voxels_size(hits, requested_voxel_d
 
 
 @given(bunch_of_hits, box_sizes)
+def test_voxelize_hits_flexible_gives_correct_voxels_size(hits, requested_voxel_dimensions):
+    voxels = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False)
+    positions = [v.pos for v in voxels]
+    voxel_size = voxels[0].size
+
+    def is_close_to_integer(n):
+        return np.isclose(n, round(n))
+
+    for pos1, pos2 in combinations(positions, 2):
+        for i in range(3):
+            assert is_close_to_integer((pos1[i] - pos2[i]) / voxel_size[i])
+
+
+@given(bunch_of_hits, box_sizes)
 def test_make_voxel_graph_keeps_all_voxels(hits, voxel_dimensions):
     voxels = voxelize_hits    (hits  , voxel_dimensions)
     tracks = make_track_graphs(voxels)
     voxels_in_tracks = set().union(*(set(t.nodes()) for t in tracks))
     assert set(voxels) == voxels_in_tracks
-
-
 
 
 @parametrize(' spec,           extrema',

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -57,7 +57,7 @@ box_sizes = builds(np.array, lists(box_dimension,
                                    min_size = 3,
                                    max_size = 3))
 
-eps = 3e-12
+eps = 3e-12 # value that works for margin
 
 
 def test_voxelize_hits_should_detect_no_hits():
@@ -140,7 +140,7 @@ def test_voxelize_hits_respects_voxel_dimensions(hits, requested_voxel_dimension
 def test_voxelize_hits_gives_maximum_voxels_size(hits, requested_voxel_dimensions):
     voxels = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False)
     for v in voxels:
-        assert (v.size <= requested_voxel_dimensions + 2 * eps).all()
+        assert (v.size <= requested_voxel_dimensions + 4 * eps).all()
 
 
 @given(bunch_of_hits, box_sizes)


### PR DESCRIPTION
I've noticed that in the current code of `voxelize_hits` in `paolina_functions`, the voxels are given as size the dimensions requested by the client. However, the code actually changes slightly these dimensions, in order to fit better the hits, event by event. Therefore, the `make_track_graphs` algorithm assumes the wrong size when building the tracks.
This PR fixes this issue.  I invite @jacg to be a reviewer of this PR, since he's familiar with the code. 