### PR TITLE
Seeds and bounds

### DIFF
--- a/invisible_cities/calib/calib_functions.py
+++ b/invisible_cities/calib/calib_functions.py
@@ -5,8 +5,13 @@ Contains functions used in calibration.
 import numpy  as np
 import tables as tb
 
+from scipy.signal import find_peaks_cwt
+
 from .. core.system_of_units_c import units
 from .. core.core_functions    import in_range
+from .. core.stat_functions    import poisson_sigma
+from .. core                   import fit_functions as fitf
+from .. database               import load_db       as DB
 
 
 def bin_waveforms(waveforms, bins):
@@ -136,9 +141,78 @@ def dark_scaler(dark_spectrum):
     return scaled_spectrum
 
 
+def seeds_db(sensor_type, run_no, n_chann):
+    """
+    Take gain and sigma values of previous runs in the database
+    to use them as seeds.
+    """
+    if sensor_type == 'sipm':
+        gain_seed       = DB.DataSiPM(run_no).adc_to_pes.iloc[n_chann]
+        gain_sigma_seed = DB.DataSiPM(run_no).Sigma.iloc[n_chann]
+    else:
+        gain_seed       = DB.DataPMT(run_no).adc_to_pes.iloc[n_chann]
+        gain_sigma_seed = DB.DataPMT(run_no).Sigma.iloc[n_chann]
+    return gain_seed, gain_sigma_seed
+
+
+def poisson_mu_seed(sensor_type, bins, spec, ped_vals, scaler):
+    """
+    Calculate poisson mu using the scaler function.
+    """
+    if sensor_type == 'sipm':
+        sel    = (bins>=-5) & (bins<=5)
+        gdist  = fitf.gauss(bins[sel], *ped_vals)
+        dscale = spec[sel].sum() / gdist.sum()
+        errs   = poisson_sigma(spec[sel], default=1)
+        return fitf.fit(scaler,
+                        bins[sel],
+                        spec[sel],
+                        (dscale), sigma=errs).values[0]
+
+    dscale = spec[bins<0].sum() / fitf.gauss(bins[bins<0], *ped_vals).sum()
+    return fitf.fit(scaler,
+                    bins[bins<0],
+                    spec[bins<0], (dscale)).values[0]
+
+
+def sensor_values(sensor_type, n_chann, scaler, spec, bins, ped_vals):
+    """
+    Define different values and ranges of the spectra depending on the sensor type.
+    """
+    if sensor_type == 'sipm':
+        spectra         = spec
+        peak_range      = np.arange(4, 20)
+        min_bin_peak    = 10
+        max_bin_peak    = 22
+        half_peak_width = 5
+        lim_ped         = 10000
+    else:
+        scale           = spec[bins<0].sum() / fitf.gauss(bins[bins<0], *ped_vals).sum()
+        spectra         = spec - fitf.gauss(bins, *ped_vals) * scale
+        peak_range      = np.arange(10, 20)
+        min_bin_peak    = 15
+        max_bin_peak    = 50
+        half_peak_width = 10
+        lim_ped         = 10000
+    return spectra, peak_range, min_bin_peak, max_bin_peak, half_peak_width, lim_ped
+
+
+def pedestal_values(ped_vals, lim_ped, ped_errs):
+    """
+    Define pedestal values for 'gau' functions.
+    """
+    ped_seed     = ped_vals[1]
+    ped_min      = ped_seed - lim_ped * ped_errs[1]
+    ped_max      = ped_seed + lim_ped * ped_errs[1]
+    ped_sig_seed = ped_vals[2]
+    ped_sig_min  = max(0.001, ped_sig_seed - lim_ped * ped_errs[2])
+    ped_sig_max  = ped_sig_seed + lim_ped * ped_errs[2]
+
+    return ped_seed, ped_sig_seed, ped_min, ped_max, ped_sig_min, ped_sig_max
+
+
 def seeds_and_bounds(sensor_type, run_no, n_chann, scaler, bins, spec, ped_vals,
                      ped_errs, func='dfunc', use_db_gain_seeds=True):
-
     """
     Define the seeds and bounds to be used for calibration fits.
 
@@ -175,73 +249,46 @@ def seeds_and_bounds(sensor_type, run_no, n_chann, scaler, bins, spec, ped_vals,
     """
 
     norm_seed = spec.sum()
+    gain_seed, gain_sigma_seed = seeds_db(sensor_type, run_no, n_chann)
+    spectra, p_range, min_b, max_b, hpw, lim_ped = sensor_values(sensor_type, n_chann,
+                                                                 scaler, spec, bins, ped_vals)
 
-    GSeed  = 0
-    GSSeed = 0
-
-    if n_chann > 1000: #SiPMs
-        GainSeeds  = DB.DataSiPM(run_no).adc_to_pes.values
-        SigSeeds   = DB.DataSiPM(run_no).Sigma.values
-        spectra    = spec
-        peak_range = np.arange(4, 20)
-        min_bin    = 10
-        max_bin    = 22
-        hpw        = 5
-        mins       = 5
-        dscale     = spec[bins<5].sum() / fitf.gauss(bins[bins<5], *ped_vals).sum()
-        lim_ped    = 10000
-
-    else: #PMTs
-        GainSeeds  = DB.DataPMT(run_no).adc_to_pes.values
-        SigSeeds   = DB.DataPMT(run_no).Sigma.values
-        dscale     = spec[bins<0].sum() / fitf.gauss(bins[bins<0], *ped_vals).sum()
-        spectra    = spec - fitf.gauss(bins, *ped_vals) * dscale
-        peak_range = np.arange(10, 20)
-        min_bin    = 15
-        max_bin    = 50
-        hpw        = 10
-        mins       = 0
-        lim_ped    = 10000
-
-    if use_db_gain_seeds:
-        GSeed     = GainSeeds[n_chann]
-        GSSeed    = SigSeeds[n_chann]
-
-    else:
-        pDL  = find_peaks_cwt(spectra, peak_range, min_snr=1, noise_perc=5)
-        p1pe = pDL[(bins[pDL]>10) & (bins[pDL]<22)][0]
-        if not p1pe:
-            p1pe = np.argwhere(bins==(min_bin+max_bin)/2)[0][0]
+    if not use_db_gain_seeds:
+        pDL  = find_peaks_cwt(spectra, p_range, min_snr=1, noise_perc=5)
+        p1pe = pDL[(bins[pDL]>min_b) & (bins[pDL]<max_b)]
+        if len(p1pe) == 0:
+            try:
+                p1pe = np.argwhere(bins==(min_b+max_b)/2)[0][0]
+            except IndexError:
+                p1pe = len(bins)-1
         else:
-            p1pe = p1pe[spec[p1pe].argmax()]
+            p1pe = p1pe[spectra[p1pe].argmax()]
 
-        fgaus = fitf.fit(fitf.gauss, bins[p1pe-hpw:p1pe+hpw], spectra[p1pe-hpw:p1pe+hpw],
-                         seed=(spectra[p1pe], bins[p1pe], 7), sigma=np.sqrt(spectra[p1pe-hpw:p1pe+hpw]))
+        fgaus = fitf.fit(fitf.gauss, bins[p1pe-hpw:p1pe+hpw],
+                        spectra[p1pe-hpw:p1pe+hpw],
+                        seed=(spectra[p1pe], bins[p1pe], 7),
+                        sigma=np.sqrt(spectra[p1pe-hpw:p1pe+hpw]),
+                        bounds=[(0, -100, 0), (1e99, 100, 10000)]))
+        gain_seed = fgaus.values[1] - ped_vals[1]
 
-        GSeed = fgaus.values[1] - ped_vals[1]
         if fgaus.values[2] <= ped_vals[2]:
-            GSSeed = 0.5
+            gain_sigma_seed = 0.5
         else:
-            GSSeed = np.sqrt(fgaus.values[2]**2 - ped_vals[2]**2)
+            gain_sigma_seed = np.sqrt(fgaus.values[2]**2 - ped_vals[2]**2)
 
-    errs          = np.sqrt(spectra[bins<mins])
-    errs[errs==0] = 1
-    fscale        = fitf.fit(scaler, bins[bins<mins], spec[bins<mins], (dscale), sigma=errs)
-    mu_seed        = -np.log(fscale.values[0])
+    mu_seed = poisson_mu_seed(sensor_type, bins, spectra, ped_vals, scaler)
     if mu_seed < 0: mu_seed = 0.001
 
+    sd0 = [norm_seed, mu_seed, gain_seed, gain_sigma_seed]
+    bd0 = [[0, 0, 0, 0.001], [1e10, 10000, 10000, 10000]]
+
     if 'gau' in func:
-        ped_seed     = ped_vals[1]
-        ped_min      = ped_seed - lim_ped * ped_errs[1]
-        ped_max      = ped_seed + lim_ped * ped_errs[1]
-        ped_sig_seed = ped_vals[2]
-        ped_sig_min  = max(0.001, ped_sig_seed - lim_ped * ped_errs[2])
-        ped_sig_max  = ped_sig_seed + lim_ped * ped_errs[2]
+        p_seed, p_sig_seed, p_min, p_max, p_sig_min, p_sig_max = pedestal_values(ped_vals,
+                                                                                 lim_ped, ped_errs)
+        sd0[2:2]    = p_seed, p_sig_seed
+        bd0[0][2:2] = p_min, p_sig_min
+        bd0[1][2:2] = p_max, p_sig_max
 
-        sd0          = (norm_seed, mu_seed, ped_seed, ped_sig_seed, GSeed, GSSeed)
-        bd0          = [(0, 0, ped_min, ped_sig_min, 0, 0.001), (1e10, 10000, ped_max, ped_sig_max, 10000, 10000)]
-        return sd0, bd0
-
-    sd0 = (norm_seed, mu_seed, GSeed, GSSeed)
-    bd0 = [(0, 0, 0, 0.001), (1e10, 10000, 10000, 10000)]
+    sd0 = tuple(sd0)
+    bd0 = [tuple(bd0[0]), tuple(bd0[1])]
     return sd0, bd0

--- a/invisible_cities/calib/calib_functions.py
+++ b/invisible_cities/calib/calib_functions.py
@@ -127,6 +127,15 @@ def copy_sensor_table(h5in, h5out):
             datasipm.copy(newparent=group)
 
 
+def dark_scaler(dark_spectrum):
+    """
+    A function to scale dark spectrum with mu value.
+    """
+    def scaled_spectrum(x, mu):
+        return np.exp(-mu) * dark_spectrum
+    return scaled_spectrum
+
+
 def seeds_and_bounds(sensor_type, run_no, n_chann, scaler, bins, spec, ped_vals,
                      ped_errs, func='dfunc', use_db_gain_seeds=True):
 

--- a/invisible_cities/calib/calib_functions.py
+++ b/invisible_cities/calib/calib_functions.py
@@ -125,3 +125,114 @@ def copy_sensor_table(h5in, h5out):
         if 'DataSiPM' in dIn.root.Sensors:
             datasipm = dIn.root.Sensors.DataSiPM
             datasipm.copy(newparent=group)
+
+
+def seeds_and_bounds(sensor_type, run_no, n_chann, scaler, bins, spec, ped_vals,
+                     ped_errs, func='dfunc', use_db_gain_seeds=True):
+
+    """
+    Define the seeds and bounds to be used for calibration fits.
+
+    Parameters
+    ----------
+    sensor_type   : string
+    Input of type of sensor: sipm or pmt.
+    run_no        : int
+    Run number.
+    n_chann       : int
+    Channel number (sensor ID).
+    scaler        : callable
+    Scale function.
+    bins          : np.array
+    Number of divisions in the x axis.
+    spec          : np.array
+    Spectra, charge values of the signal.
+    ped_vals      : np.array
+    Values for the pedestal fit.
+    ped_errs      : np.array
+    Errors of the values for the pedestal fit.
+    func          : callable, optional
+    Function used for fitting. Defaults to dfunc.
+    use_db_gain_seeds : bool, optional
+    If True, seeds are taken from previous runs in database.
+    If False, peaks are found with find_peaks_cwt function.
+
+    Returns
+    -------
+    sd0 : sequence
+    Seeds for normalization, mu, gain and sigma.
+    bd0 : sequence
+    Minimum and maximum limits for the previous variables.
+    """
+
+    norm_seed = spec.sum()
+
+    GSeed  = 0
+    GSSeed = 0
+
+    if n_chann > 1000: #SiPMs
+        GainSeeds  = DB.DataSiPM(run_no).adc_to_pes.values
+        SigSeeds   = DB.DataSiPM(run_no).Sigma.values
+        spectra    = spec
+        peak_range = np.arange(4, 20)
+        min_bin    = 10
+        max_bin    = 22
+        hpw        = 5
+        mins       = 5
+        dscale     = spec[bins<5].sum() / fitf.gauss(bins[bins<5], *ped_vals).sum()
+        lim_ped    = 10000
+
+    else: #PMTs
+        GainSeeds  = DB.DataPMT(run_no).adc_to_pes.values
+        SigSeeds   = DB.DataPMT(run_no).Sigma.values
+        dscale     = spec[bins<0].sum() / fitf.gauss(bins[bins<0], *ped_vals).sum()
+        spectra    = spec - fitf.gauss(bins, *ped_vals) * dscale
+        peak_range = np.arange(10, 20)
+        min_bin    = 15
+        max_bin    = 50
+        hpw        = 10
+        mins       = 0
+        lim_ped    = 10000
+
+    if use_db_gain_seeds:
+        GSeed     = GainSeeds[n_chann]
+        GSSeed    = SigSeeds[n_chann]
+
+    else:
+        pDL  = find_peaks_cwt(spectra, peak_range, min_snr=1, noise_perc=5)
+        p1pe = pDL[(bins[pDL]>10) & (bins[pDL]<22)][0]
+        if not p1pe:
+            p1pe = np.argwhere(bins==(min_bin+max_bin)/2)[0][0]
+        else:
+            p1pe = p1pe[spec[p1pe].argmax()]
+
+        fgaus = fitf.fit(fitf.gauss, bins[p1pe-hpw:p1pe+hpw], spectra[p1pe-hpw:p1pe+hpw],
+                         seed=(spectra[p1pe], bins[p1pe], 7), sigma=np.sqrt(spectra[p1pe-hpw:p1pe+hpw]))
+
+        GSeed = fgaus.values[1] - ped_vals[1]
+        if fgaus.values[2] <= ped_vals[2]:
+            GSSeed = 0.5
+        else:
+            GSSeed = np.sqrt(fgaus.values[2]**2 - ped_vals[2]**2)
+
+    errs          = np.sqrt(spectra[bins<mins])
+    errs[errs==0] = 1
+    fscale        = fitf.fit(scaler, bins[bins<mins], spec[bins<mins], (dscale), sigma=errs)
+    mu_seed        = -np.log(fscale.values[0])
+    if mu_seed < 0: mu_seed = 0.001
+
+    if 'gau' in func:
+        ped_seed     = ped_vals[1]
+        ped_min      = ped_seed - lim_ped * ped_errs[1]
+        ped_max      = ped_seed + lim_ped * ped_errs[1]
+        ped_sig_seed = ped_vals[2]
+        ped_sig_min  = max(0.001, ped_sig_seed - lim_ped * ped_errs[2])
+        ped_sig_max  = ped_sig_seed + lim_ped * ped_errs[2]
+
+        sd0          = (norm_seed, mu_seed, ped_seed, ped_sig_seed, GSeed, GSSeed)
+        bd0          = [(0, 0, ped_min, ped_sig_min, 0, 0.001), (1e10, 10000, ped_max, ped_sig_max, 10000, 10000)]
+        return sd0, bd0
+
+    sd0 = (norm_seed, mu_seed, GSeed, GSSeed)
+    bd0 = [(0, 0, 0, 0.001), (1e10, 10000, 10000, 10000)]
+    return sd0, bd0

--- a/invisible_cities/calib/calib_functions_test.py
+++ b/invisible_cities/calib/calib_functions_test.py
@@ -7,9 +7,11 @@ from numpy.testing import assert_array_equal
 from numpy.testing import assert_approx_equal
 from pytest        import mark
 from pytest        import raises
+from scipy.signal  import find_peaks_cwt
 
 from .                         import calib_functions as cf
-from .. reco                   import tbl_functions as tbl
+from .. reco                   import tbl_functions   as tbl
+from .. core                   import fit_functions   as fitf
 from .. core.system_of_units_c import units
 from .. evm.nh5                import SensorTable
 
@@ -171,6 +173,76 @@ def test_copy_sensor_table3(config_tmpdir):
         assert out_file.root.Sensors.DataSiPM[0][1] == dummy_sipm[1]
 
 
+def test_seeds_db():
+    gain_seed_sipm, gain_sigma_seed_sipm = seeds_db('sipm', 6317, 13)
+    gain_seed_pmt, gain_sigma_seed_pmt   = seeds_db('pmt', 6317, 5)
+
+    assert gain_seed_sipm       == 16.5503
+    assert gain_sigma_seed_sipm == 1.65978
+    assert gain_seed_pmt        == 22.66
+    assert gain_sigma_seed_pmt  == 9.88
+
+
+def test_poisson_mu_seed():
+    bins     = np.array([-8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7])
+    spec     = np.array([28, 98, 28, 539, 1072, 1845, 2805, 3251, 3626, 3532, 3097, 2172, 1299, 665, 371, 174])
+    dark     = np.array([30, 107, 258, 612, 1142, 2054, 3037, 3593, 3769, 3777, 3319, 2321, 1298, 690, 415, 192])
+    ped_vals = np.array([2.65181178e+04, 1.23743445e-01, 2.63794236e+00])
+
+    scaler   = dark_scaler(dark[(bins>=-5) & (bins<=5)])
+    scaler2  = dark_scaler(dark[bins<0])
+    mu       = poisson_mu_seed('sipm', bins, spec, ped_vals, scaler)
+    mu2      = poisson_mu_seed('pmt', bins, spec, ped_vals, scaler2)
+
+    np.testing.assert_approx_equal(mu, 0.0698154)
+    np.testing.assert_approx_equal(mu2, 0.0950066)
+
+
+def test_sensor_values():
+    bins     = np.array([-6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7])
+    spec     = np.array([28, 539, 1072, 1845, 2805, 3251, 3626, 3532, 3097, 2172, 1299, 665, 371, 174])
+    dark     = np.array([258, 612, 1142, 2054, 3037, 3593, 3769, 3777, 3319, 2321, 1298, 690, 415, 192])
+    ped_vals = np.array([2.65181178e+04, 1.23743445e-01, 2.63794236e+00])
+    scaler   = dark_scaler(dark[(bins>=-5) & (bins<=5)])
+    scaler2  = dark_scaler(dark[bins<0])
+    spectra, p_range, min_bin, max_bin, hpw, lim_ped = sensor_values('sipm', 1023, scaler_func, spec, bins, ped_vals)
+    spectra2, p_range2, min_bin2, max_bin2, hpw2, lim_ped2 = sensor_values('pmt', 0, scaler_func, spec, bins, ped_vals)
+
+    expected_range = np.arange(4,20)
+    expected_spec2 = np.array([-215.61455106, -7.61389796, 9.69755144, 56.84252052, 197.9256732, -41.23729614, 25.03486623,
+                               120.56759537, 297.7306255, 182.5057727, 74.29711143, 12.00648349, 69.4376878, 53.375555])
+    expected_range2 = np.arange(10,20)
+
+    np.testing.assert_array_equal(spectra, spec)
+    np.testing.assert_array_equal(p_range, expected_range)
+    assert min_bin == 10
+    assert max_bin == 22
+    assert hpw == 5
+    assert lim_ped == lim_ped2
+    assert len(spectra2) == len(expected_spec2)
+
+    np.testing.assert_array_equal(p_range2, expected_range2)
+    assert min_bin2 == 15
+    assert max_bin2 == 50
+    assert hpw2 == 10
+
+
+def test_pedestal_values():
+    ped_vals = np.array([6.14871401e+04, -1.46181517e-01, 5.27614635e+00])
+    ped_errs = np.array([9.88752708e+02, 5.38541961e-02, 1.07169703e-01])
+    lim_ped  = 10000
+
+    p_seed, p_sig_seed, p_min, p_max, p_sig_min, p_sig_max = pedestal_values(ped_vals,
+                                                                             lim_ped, ped_errs)
+
+    assert_approx_equal(p_seed, -0.14618, 5)
+    assert_approx_equal(p_sig_seed, 5.27614, 5)
+    assert_approx_equal(p_min, -538.68814, 5)
+    assert_approx_equal(p_max, 538.39577, 5)
+    assert_approx_equal(p_sig_min, 0.001)
+    assert_approx_equal(p_sig_max, 1076.97317, 5)
+
+
 def test_seeds_and_bounds(file_name):
     sipmIn = tb.open_file(file_name, 'r')
     run_no = file_name[file_name.find('R')+1:file_name.find('R')+5]
@@ -195,7 +267,7 @@ def test_seeds_and_bounds(file_name):
         sd0     = (dar.sum(), 0, 2)
         errs    = poisson_sigma(dar[pD[0]-5:pD[0]+5], default=0.1)
         gfitRes = fitf.fit(fitf.gauss, bins[pD[0]-5:pD[0]+5], dar[pD[0]-5:pD[0]+5], sd0, sigma=errs, bounds=gb0)
-        
+
         ped_vals    = np.array([gfitRes.values[0], gfitRes.values[1], gfitRes.values[2]])
         scaler_func = dark_scaler(dar[b1:b2][(bins[b1:b2]>=-5) & (bins[b1:b2]<=5)])
 


### PR DESCRIPTION
This PR adds several functions to provide seeds and bounds for sensor calibration fits. For gain and sigma it provides either the option to take their values from previous runs in the database,  or it looks for the pedestal and 1 pe peaks. Corresponding tests are also added. 