### PR TITLE
Remove annoying print that adds noise to dorothea's output

### DIFF
--- a/invisible_cities/evm/event_model.py
+++ b/invisible_cities/evm/event_model.py
@@ -451,7 +451,6 @@ class KrEvent(Event):
         s2_peaks = range(int(self.nS2)) if self.nS2 else [-1]
         self.fill_defaults()
 
-        print(self)
         for i in s1_peaks:
             for j in s2_peaks:
                 row["event"  ] = self.event


### PR DESCRIPTION
A leftover `print` call introduces a lot of noise to dorothea's output. Remove it.