### PR TITLE
New wrapper to fix parameters for fitting

### DIFF
--- a/invisible_cities/core/fit_functions.py
+++ b/invisible_cities/core/fit_functions.py
@@ -4,14 +4,53 @@ A set of functions for data fitting.
 GML November 2016
 """
 
-import numpy  as np
-import pandas as pd
+import numpy   as np
+import pandas  as pd
+import inspect as insp
 import scipy.optimize
 import scipy.stats
+
+from functools import wraps
 
 from .                    import core_functions as coref
 from .  stat_functions    import poisson_sigma
 from .. evm.ic_containers import FitFunction
+
+
+def fixed_parameters(fn, **kwargs):
+    """
+    Wrapper to fix parameters of a function
+    which can then be used in curve_fit.
+    """
+    fn_sig    = insp.signature(fn)
+    fn_pars   = np.array(list(fn_sig.parameters))[1:]
+    par_gen   = (kwargs[k] if k in kwargs.keys() else np.nan for k in fn_pars)
+    all_args  = np.fromiter(par_gen, np.float)
+    free_pars = np.isnan(all_args)
+    
+    if np.all(free_pars):
+        raise ValueError(kwargs.keys() + " not parameters of " + fn.__name__)
+    elif np.count_nonzero(free_pars) > len(fn_pars) - len(kwargs):
+        raise ValueError("Some parameters not found in " + fn.__name__)
+    
+    @wraps(fn)
+    def fixed_fn(x, *pars):
+        all_args[free_pars] = pars
+        func_value = fn(x, *all_args)
+        ## hack to maintain spe_functions underlying decorator
+        try:
+            fixed_fn.n_gaussians = fn.n_gaussians
+        except AttributeError: pass
+        return func_value
+    
+    ## Correct the doc string and signature for the new wrapped function
+    fixed_fn.__doc__  = fixed_fn.__name__ + str(fixed_fn.__doc__) + "\n"
+    fixed_fn.__doc__ += " fixed" + str(fn_pars[np.invert(free_pars)])
+    
+    new_pars               = np.array(tuple(fn_sig.parameters.values()))
+    new_pars               = np.insert(new_pars[1:][free_pars], 0, new_pars[0])
+    fixed_fn.__signature__ = fn_sig.replace(parameters=tuple(new_pars))
+    return fixed_fn
 
 
 def get_errors(cov):

--- a/invisible_cities/core/fit_functions_test.py
+++ b/invisible_cities/core/fit_functions_test.py
@@ -2,7 +2,8 @@
 Tests for fit_functions
 """
 
-import numpy as np
+import numpy   as np
+import inspect as insp
 
 from pytest        import mark
 from pytest        import approx
@@ -289,6 +290,17 @@ def test_fit_with_errors(reduced):
     assert_allclose(f.values, pars)
 
 
+@mark.parametrize(["func", "known_pars"],
+                  ((fitf.gauss, {'mu' : 10, 'sigma' : 2}),
+                  (fitf.expo, {'const' : 22})))
+def test_number_fixed_parameters(func, known_pars):
+    fixed_p        = fitf.fixed_parameters(func, **known_pars)
+    npars_original = len(insp.signature(func).parameters)
+    npars_new      = len(insp.signature(fixed_p).parameters)
+
+    assert npars_new == npars_original - len(known_pars)
+
+
 def test_fixed_parameters():
     pars = [3.0,  2.0, 0.50]
     x = np.arange(10.)
@@ -299,6 +311,15 @@ def test_fixed_parameters():
     seeds = np.array(pars[::2])
     f = fitf.fit(fixed_mu, x, y, seeds * 1.2, sigma=e)
     assert_allclose(f.values, seeds)
+
+
+@mark.parametrize("pars",
+                  ({'amp' : 2, 'mu' : 0, 'sigma' : 2},
+                   {'fake1' : 2},
+                   {'fake1' : 1, 'mu' : 0}))
+def test_fix_wrong_parameters_raises_error(pars):
+    with raises(ValueError):
+        fixed_mu = fitf.fixed_parameters(fitf.gauss, **pars)
 
 
 @mark.parametrize(["func"],

--- a/invisible_cities/core/fit_functions_test.py
+++ b/invisible_cities/core/fit_functions_test.py
@@ -289,6 +289,18 @@ def test_fit_with_errors(reduced):
     assert_allclose(f.values, pars)
 
 
+def test_fixed_parameters():
+    pars = [3.0,  2.0, 0.50]
+    x = np.arange(10.)
+    y = fitf.gauss(x, *pars)
+    e = 0.1 * y
+
+    fixed_mu = fitf.fixed_parameters(fitf.gauss, mu = pars[1])
+    seeds = np.array(pars[::2])
+    f = fitf.fit(fixed_mu, x, y, seeds * 1.2, sigma=e)
+    assert_allclose(f.values, seeds)
+
+
 @mark.parametrize(["func"],
                   ((fitf.profileX,),
                    (fitf.profileY,)))


### PR DESCRIPTION
Adds a wrapper so that functions can have
parameters fixed to known values and
still work as expected with scipy.curve_fit.

Slightly updated from old PR to clarify some
arguments.

This is an LFS version of #512.