### PR TITLE
Seeds and bounds for calibration fits

### DIFF
--- a/invisible_cities/database/test_data/pmtcalspectra_R6354.h5
+++ b/invisible_cities/database/test_data/pmtcalspectra_R6354.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb2ace6f9eb9241e5e05b24a7bd2bba6a879ce62caba7eea7fb288a20bd76bb0
+size 579357

--- a/invisible_cities/database/test_data/sipmcalspectra_R6358.h5
+++ b/invisible_cities/database/test_data/sipmcalspectra_R6358.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:daedad67de419ca13d45aa6faa66cf3b84c4b86dfd68de8b2066a40d24b1b278
+size 4458497

--- a/invisible_cities/evm/ic_containers.py
+++ b/invisible_cities/evm/ic_containers.py
@@ -42,7 +42,7 @@ for name, attrs in (
         ('TriggerParams'  , 'trigger_channels min_number_channels charge height width'),
         ('PeakData'       , 'charge height width'),
         ('Measurement'    , 'value uncertainty'),
-        ('SensorParams'   , 'spectra, peak_range, min_bin_peak, max_bin_peak, half_peak_width, p1pe_seed, lim_ped'),
+        ('SensorParams'   , 'spectra peak_range min_bin_peak max_bin_peak half_peak_width p1pe_seed lim_ped'),
         ('PedestalParams' , 'gain gain_min gain_max sigma sigma_min sigma_max')):
     _add_namedtuple_in_this_module(name, attrs)
 

--- a/invisible_cities/evm/ic_containers.py
+++ b/invisible_cities/evm/ic_containers.py
@@ -42,7 +42,7 @@ for name, attrs in (
         ('TriggerParams'  , 'trigger_channels min_number_channels charge height width'),
         ('PeakData'       , 'charge height width'),
         ('Measurement'    , 'value uncertainty'),
-        ('SensorParams'   , 'spectra, peak_range, min_bin_peak, max_bin_peak, half_peak_width, lim_ped'),
+        ('SensorParams'   , 'spectra, peak_range, min_bin_peak, max_bin_peak, half_peak_width, p1pe_seed, lim_ped'),
         ('PedestalParams' , 'gain gain_min gain_max sigma sigma_min sigma_max')):
     _add_namedtuple_in_this_module(name, attrs)
 

--- a/invisible_cities/evm/ic_containers.py
+++ b/invisible_cities/evm/ic_containers.py
@@ -41,7 +41,9 @@ for name, attrs in (
         ('FitFunction'    , 'fn values errors chi2 pvalue cov'),
         ('TriggerParams'  , 'trigger_channels min_number_channels charge height width'),
         ('PeakData'       , 'charge height width'),
-        ('Measurement'    , 'value uncertainty')):
+        ('Measurement'    , 'value uncertainty'),
+        ('SensorParams'   , 'spectra, peak_range, min_bin_peak, max_bin_peak, half_peak_width, lim_ped'),
+        ('PedestalParams' , 'gain gain_min gain_max sigma sigma_min sigma_max')):
     _add_namedtuple_in_this_module(name, attrs)
 
 # Leave nothing but the namedtuple types in the namespace of this module

--- a/invisible_cities/reco/calib_functions.py
+++ b/invisible_cities/reco/calib_functions.py
@@ -208,7 +208,8 @@ def sensor_values(sensor_type, n_chann, scaler, bins, spec, ped_vals):
         p1pe_seed       = 3
         lim_ped         = 10000
     elif sensor_type is SensorType.PMT:
-        scale           = spec[bins<0].sum() / fitf.gauss(bins[bins<0], *ped_vals).sum()
+        sel             = bins<0
+        scale           = spec[sel].sum() / fitf.gauss(bins[sel], *ped_vals).sum()
         spectra         = spec - fitf.gauss(bins, *ped_vals) * scale
         peak_range      = np.arange(10, 20)
         min_bin_peak    = 15

--- a/invisible_cities/reco/calib_functions.py
+++ b/invisible_cities/reco/calib_functions.py
@@ -245,7 +245,7 @@ def compute_seeds_from_spectrum(sens_values, bins, ped_vals):
     p_seed  = sens_values.p1pe_seed
 
     peaks_dark_led  = find_peaks_cwt(spectra, p_range, min_snr=1, noise_perc=5)
-    p1pe_samples    = peaks_dark_led[in_range(bins[peaks_dark_led], min_b, max_b)]
+    p1pe_samples    = peaks_dark_led[(bins[peaks_dark_led]>min_b) & (bins[peaks_dark_led]<max_b)]
     if len(p1pe_samples) == 0:
         try:
             p1pe_centroid = np.argwhere(bins==(min_b+max_b)/2)[0][0]

--- a/invisible_cities/reco/calib_functions.py
+++ b/invisible_cities/reco/calib_functions.py
@@ -199,6 +199,7 @@ def sensor_values(sensor_type, n_chann, scaler, spec, bins, ped_vals):
         min_bin_peak    = 10
         max_bin_peak    = 22
         half_peak_width = 5
+        p1pe_seed       = 3
         lim_ped         = 10000
     else:
         scale           = spec[bins<0].sum() / fitf.gauss(bins[bins<0], *ped_vals).sum()
@@ -207,8 +208,9 @@ def sensor_values(sensor_type, n_chann, scaler, spec, bins, ped_vals):
         min_bin_peak    = 15
         max_bin_peak    = 50
         half_peak_width = 10
+        p1pe_seed       = 7
         lim_ped         = 10000
-    return SensorParams(spectra, peak_range, min_bin_peak, max_bin_peak, half_peak_width, lim_ped)
+    return SensorParams(spectra, peak_range, min_bin_peak, max_bin_peak, half_peak_width, p1pe_seed, lim_ped)
 
 
 def pedestal_values(ped_vals, lim_ped, ped_errs):

--- a/invisible_cities/reco/calib_functions.py
+++ b/invisible_cities/reco/calib_functions.py
@@ -261,7 +261,7 @@ def compute_seeds_from_spectrum(sens_values, bins, ped_vals):
                      spectra[p1pe_centroid - hpw : p1pe_centroid + hpw],
                      seed   = fit_seed,
                      sigma  = fit_sigma,
-                     bounds = [(0, -100, 0), (1e99, 100, 10000)])
+                     bounds = [(0, -100, 0), (np.inf, 100, 10000)])
     gain_seed = fgaus.values[1] - ped_vals[1]
 
     if fgaus.values[2] <= ped_vals[2]: gain_sigma_seed = 0.5

--- a/invisible_cities/reco/calib_functions.py
+++ b/invisible_cities/reco/calib_functions.py
@@ -130,3 +130,114 @@ def copy_sensor_table(h5in, h5out):
         if 'DataSiPM' in dIn.root.Sensors:
             datasipm = dIn.root.Sensors.DataSiPM
             datasipm.copy(newparent=group)
+
+
+def seeds_and_bounds(sensor_type, run_no, n_chann, scaler, bins, spec, ped_vals,
+                     ped_errs, func='dfunc', use_db_gain_seeds=True):
+
+    """
+    Define the seeds and bounds to be used for calibration fits.
+
+    Parameters
+    ----------
+    sensor_type   : string
+    Input of type of sensor: sipm or pmt.
+    run_no        : int
+    Run number.
+    n_chann       : int
+    Channel number (sensor ID).
+    scaler        : callable
+    Scale function.
+    bins          : np.array
+    Number of divisions in the x axis.
+    spec          : np.array
+    Spectra, charge values of the signal.
+    ped_vals      : np.array
+    Values for the pedestal fit.
+    ped_errs      : np.array
+    Errors of the values for the pedestal fit.
+    func          : callable, optional
+    Function used for fitting. Defaults to dfunc.
+    use_db_gain_seeds : bool, optional
+    If True, seeds are taken from previous runs in database.
+    If False, peaks are found with find_peaks_cwt function.
+
+    Returns
+    -------
+    sd0 : sequence
+    Seeds for normalization, mu, gain and sigma.
+    bd0 : sequence
+    Minimum and maximum limits for the previous variables.
+    """
+
+    norm_seed = spec.sum()
+
+    GSeed  = 0
+    GSSeed = 0
+
+    if n_chann > 1000: #SiPMs
+        GainSeeds  = DB.DataSiPM(run_no).adc_to_pes.values
+        SigSeeds   = DB.DataSiPM(run_no).Sigma.values
+        spectra    = spec
+        peak_range = np.arange(4, 20)
+        min_bin    = 10
+        max_bin    = 22
+        hpw        = 5
+        mins       = 5
+        dscale     = spec[bins<5].sum() / fitf.gauss(bins[bins<5], *ped_vals).sum()
+        lim_ped    = 10000
+
+    else: #PMTs
+        GainSeeds  = DB.DataPMT(run_no).adc_to_pes.values
+        SigSeeds   = DB.DataPMT(run_no).Sigma.values
+        dscale     = spec[bins<0].sum() / fitf.gauss(bins[bins<0], *ped_vals).sum()
+        spectra    = spec - fitf.gauss(bins, *ped_vals) * dscale
+        peak_range = np.arange(10, 20)
+        min_bin    = 15
+        max_bin    = 50
+        hpw        = 10
+        mins       = 0
+        lim_ped    = 10000
+
+    if use_db_gain_seeds:
+        GSeed     = GainSeeds[n_chann]
+        GSSeed    = SigSeeds[n_chann]
+
+    else:
+        pDL  = find_peaks_cwt(spectra, peak_range, min_snr=1, noise_perc=5)
+        p1pe = pDL[(bins[pDL]>10) & (bins[pDL]<22)][0]
+        if not p1pe:
+            p1pe = np.argwhere(bins==(min_bin+max_bin)/2)[0][0]
+        else:
+            p1pe = p1pe[spec[p1pe].argmax()]
+
+        fgaus = fitf.fit(fitf.gauss, bins[p1pe-hpw:p1pe+hpw], spectra[p1pe-hpw:p1pe+hpw],
+                         seed=(spectra[p1pe], bins[p1pe], 7), sigma=np.sqrt(spectra[p1pe-hpw:p1pe+hpw]))
+
+        GSeed = fgaus.values[1] - ped_vals[1]
+        if fgaus.values[2] <= ped_vals[2]:
+            GSSeed = 0.5
+        else:
+            GSSeed = np.sqrt(fgaus.values[2]**2 - ped_vals[2]**2)
+
+    errs          = np.sqrt(spectra[bins<mins])
+    errs[errs==0] = 1
+    fscale        = fitf.fit(scaler, bins[bins<mins], spec[bins<mins], (dscale), sigma=errs)
+    mu_seed        = -np.log(fscale.values[0])
+    if mu_seed < 0: mu_seed = 0.001
+
+    if 'gau' in func:
+        ped_seed     = ped_vals[1]
+        ped_min      = ped_seed - lim_ped * ped_errs[1]
+        ped_max      = ped_seed + lim_ped * ped_errs[1]
+        ped_sig_seed = ped_vals[2]
+        ped_sig_min  = max(0.001, ped_sig_seed - lim_ped * ped_errs[2])
+        ped_sig_max  = ped_sig_seed + lim_ped * ped_errs[2]
+
+        sd0          = (norm_seed, mu_seed, ped_seed, ped_sig_seed, GSeed, GSSeed)
+        bd0          = [(0, 0, ped_min, ped_sig_min, 0, 0.001), (1e10, 10000, ped_max, ped_sig_max, 10000, 10000)]
+        return sd0, bd0
+
+    sd0 = (norm_seed, mu_seed, GSeed, GSSeed)
+    bd0 = [(0, 0, 0, 0.001), (1e10, 10000, 10000, 10000)]
+    return sd0, bd0

--- a/invisible_cities/reco/calib_functions.py
+++ b/invisible_cities/reco/calib_functions.py
@@ -261,7 +261,8 @@ def compute_seeds_from_spectrum(sens_values, bins, ped_vals):
                      spectra[p1pe_centroid - hpw : p1pe_centroid + hpw],
                      seed   = fit_seed,
                      sigma  = fit_sigma,
-                     bounds = [(0, -100, 0), (np.inf, 100, 10000)])
+                     bounds = [(0, -100, 0), (np.inf, 100, 10000)],
+                     maxfev = 2000)
     gain_seed = fgaus.values[1] - ped_vals[1]
 
     if fgaus.values[2] <= ped_vals[2]: gain_sigma_seed = 0.5

--- a/invisible_cities/reco/calib_functions.py
+++ b/invisible_cities/reco/calib_functions.py
@@ -156,7 +156,7 @@ def seeds_db(sensor_type, run_no, n_chann):
     Take gain and sigma values of previous runs in the database
     to use them as seeds.
     """
-    if sensor_type == 'sipm':
+    if sensor_type == SensorType.SIPM:
         gain_seed       = DB.DataSiPM(run_no).adc_to_pes.iloc[n_chann]
         gain_sigma_seed = DB.DataSiPM(run_no).Sigma.iloc[n_chann]
     else:
@@ -169,7 +169,7 @@ def poisson_mu_seed(sensor_type, bins, spec, ped_vals, scaler):
     """
     Calculate poisson mu using the scaler function.
     """
-    if sensor_type == 'sipm':
+    if sensor_type == SensorType.SIPM:
         sel    = (bins>=-5) & (bins<=5)
         gdist  = fitf.gauss(bins[sel], *ped_vals)
         dscale = spec[sel].sum() / gdist.sum()
@@ -189,7 +189,7 @@ def sensor_values(sensor_type, n_chann, scaler, spec, bins, ped_vals):
     """
     Define different values and ranges of the spectra depending on the sensor type.
     """
-    if sensor_type == 'sipm':
+    if sensor_type == SensorType.SIPM:
         spectra         = spec
         peak_range      = np.arange(4, 20)
         min_bin_peak    = 10

--- a/invisible_cities/reco/calib_functions.py
+++ b/invisible_cities/reco/calib_functions.py
@@ -272,18 +272,20 @@ def seeds_and_bounds(sensor_type, run_no, n_chann, scaler, bins, spec, ped_vals,
     """
 
     norm_seed = spec.sum()
-    gain_seed, gain_sigma_seed = seeds_db(sensor_type, run_no, n_chann)
-    sens_values = sensor_values(sensor_type, n_chann, scaler, bins, spec, ped_vals)
+    if use_db_gain_seeds:
+        gain_seed, gain_sigma_seed = seeds_db(sensor_type, run_no, n_chann)
 
-    spectra = sens_values.spectra
-    p_range = sens_values.peak_range
-    min_b   = sens_values.min_bin_peak
-    max_b   = sens_values.max_bin_peak
-    hpw     = sens_values.half_peak_width
-    p_seed  = sens_values.p1pe_seed
-    lim_ped = sens_values.lim_ped
+    else:
+        sens_values = sensor_values(sensor_type, n_chann, scaler, bins, spec, ped_vals)
 
-    if not use_db_gain_seeds:
+        spectra = sens_values.spectra
+        p_range = sens_values.peak_range
+        min_b   = sens_values.min_bin_peak
+        max_b   = sens_values.max_bin_peak
+        hpw     = sens_values.half_peak_width
+        p_seed  = sens_values.p1pe_seed
+        lim_ped = sens_values.lim_ped
+
         pDL  = find_peaks_cwt(spectra, p_range, min_snr=1, noise_perc=5)
         p1pe = pDL[(bins[pDL]>min_b) & (bins[pDL]<max_b)]
         if len(p1pe) == 0:

--- a/invisible_cities/reco/calib_functions.py
+++ b/invisible_cities/reco/calib_functions.py
@@ -186,10 +186,11 @@ def poisson_mu_seed(sensor_type, scaler, bins, spectrum, ped_vals):
                         spectrum[sel],
                         dscale, sigma=errs).values[0]
     elif sensor_type is SensorType.PMT:
-        dscale = spectrum[bins<0].sum() / fitf.gauss(bins[bins<0], *ped_vals).sum()
+        sel   = bins<0
+        dscale = spectrum[sel].sum() / fitf.gauss(bins[sel], *ped_vals).sum()
         return fitf.fit(scaler,
-                        bins    [bins<0],
-                        spectrum[bins<0],
+                        bins    [sel],
+                        spectrum[sel],
                         dscale).values[0]
     else:
         raise ValueError("SensorType.SIPM or SensorType.PMT must be given for sensor_type")

--- a/invisible_cities/reco/calib_functions.py
+++ b/invisible_cities/reco/calib_functions.py
@@ -10,8 +10,9 @@ from scipy.signal import find_peaks_cwt
 from .. core.system_of_units_c import units
 from .. core.core_functions    import in_range
 from .. core.stat_functions    import poisson_sigma
-from .. core                   import fit_functions as fitf
-from .. database               import load_db       as DB
+from .. core                   import fit_functions    as fitf
+from .. database               import load_db          as DB
+from .. types.ic_types         import AutoNameEnumBase
 
 
 def bin_waveforms(waveforms, bins):
@@ -145,6 +146,10 @@ def dark_scaler(dark_spectrum):
         return np.exp(-mu) * dark_spectrum
     return scaled_spectrum
 
+
+class SensorType(AutoNameEnumBase):
+    SIPM = auto()
+    PMT  = auto()
 
 def seeds_db(sensor_type, run_no, n_chann):
     """

--- a/invisible_cities/reco/calib_functions.py
+++ b/invisible_cities/reco/calib_functions.py
@@ -6,6 +6,7 @@ import numpy  as np
 import tables as tb
 
 from scipy.signal import find_peaks_cwt
+from enum         import auto
 
 from .. core.system_of_units_c import units
 from .. core.core_functions    import in_range
@@ -161,10 +162,10 @@ def seeds_db(sensor_type, run_no, n_chann):
     """
     if sensor_type == SensorType.SIPM:
         gain_seed       = DB.DataSiPM(run_no).adc_to_pes.iloc[n_chann]
-        gain_sigma_seed = DB.DataSiPM(run_no).Sigma.iloc[n_chann]
+        gain_sigma_seed = DB.DataSiPM(run_no).     Sigma.iloc[n_chann]
     else:
         gain_seed       = DB.DataPMT(run_no).adc_to_pes.iloc[n_chann]
-        gain_sigma_seed = DB.DataPMT(run_no).Sigma.iloc[n_chann]
+        gain_sigma_seed = DB.DataPMT(run_no).     Sigma.iloc[n_chann]
     return gain_seed, gain_sigma_seed
 
 
@@ -211,8 +212,7 @@ def sensor_values(sensor_type, n_chann, scaler, spec, bins, ped_vals):
 
 
 def pedestal_values(ped_vals, lim_ped, ped_errs):
-    """
-    Define pedestal values for 'gau' functions.
+    """Define pedestal values for 'gau' functions.
     """
     ped_seed     = ped_vals[1]
     ped_min      = ped_seed - lim_ped * ped_errs[1]
@@ -226,41 +226,40 @@ def pedestal_values(ped_vals, lim_ped, ped_errs):
 
 def seeds_and_bounds(sensor_type, run_no, n_chann, scaler, bins, spec, ped_vals,
                      ped_errs, func='dfunc', use_db_gain_seeds=True):
+    """ Define the seeds and bounds to be used for calibration fits.
+
+        Parameters
+        ----------
+        sensor_type   : string
+        Input of type of sensor: sipm or pmt.
+        run_no        : int
+        Run number.
+        n_chann       : int
+        Channel number (sensor ID).
+        scaler        : callable
+        Scale function.
+        bins          : np.array
+        Number of divisions in the x axis.
+        spec          : np.array
+        Spectra, charge values of the signal.
+        ped_vals      : np.array
+        Values for the pedestal fit.
+        ped_errs      : np.array
+        Errors of the values for the pedestal fit.
+        func          : callable, optional
+        Function used for fitting. Defaults to dfunc.
+        use_db_gain_seeds : bool, optional
+        If True, seeds are taken from previous runs in database.
+        If False, peaks are found with find_peaks_cwt function.
+
+        Returns
+        -------
+        sd0 : sequence
+        Seeds for normalization, mu, gain and sigma.
+        bd0 : sequence
+        Minimum and maximum limits for the previous variables.
     """
-    Define the seeds and bounds to be used for calibration fits.
-
-    Parameters
-    ----------
-    sensor_type   : string
-    Input of type of sensor: sipm or pmt.
-    run_no        : int
-    Run number.
-    n_chann       : int
-    Channel number (sensor ID).
-    scaler        : callable
-    Scale function.
-    bins          : np.array
-    Number of divisions in the x axis.
-    spec          : np.array
-    Spectra, charge values of the signal.
-    ped_vals      : np.array
-    Values for the pedestal fit.
-    ped_errs      : np.array
-    Errors of the values for the pedestal fit.
-    func          : callable, optional
-    Function used for fitting. Defaults to dfunc.
-    use_db_gain_seeds : bool, optional
-    If True, seeds are taken from previous runs in database.
-    If False, peaks are found with find_peaks_cwt function.
-
-    Returns
-    -------
-    sd0 : sequence
-    Seeds for normalization, mu, gain and sigma.
-    bd0 : sequence
-    Minimum and maximum limits for the previous variables.
-    """
-
+    
     norm_seed = spec.sum()
     gain_seed, gain_sigma_seed = seeds_db(sensor_type, run_no, n_chann)
     sens_values = sensor_values(sensor_type, n_chann, scaler, spec, bins, ped_vals)

--- a/invisible_cities/reco/calib_functions.py
+++ b/invisible_cities/reco/calib_functions.py
@@ -310,17 +310,17 @@ def seeds_and_bounds(sensor_type, run_no, n_chann, scaler, bins, spec, ped_vals,
     mu_seed = poisson_mu_seed(sensor_type, scaler, bins, spec, ped_vals)
     if mu_seed < 0: mu_seed = 0.001
 
-    sd0middle  = ()
-    bd00middle = ()
-    bd01middle = ()
+    ped_seed      = ()
+    ped_bound_low = ()
+    ped_bound_upp = ()
 
     if 'gau' in func:
-        ped_values = pedestal_values(ped_vals, lim_ped             , ped_errs)
-        sd0middle  = (ped_values.gain        , ped_values.sigma    )
-        bd00middle = (ped_values.gain_min    , ped_values.gain_max )
-        bd01middle = (ped_values.sigma_min   , ped_values.sigma_max)
+        ped_values    = pedestal_values(ped_vals, lim_ped             , ped_errs)
+        ped_seed      = (ped_values.gain        , ped_values.sigma    )
+        ped_bound_low = (ped_values.gain_min    , ped_values.gain_max )
+        ped_bound_upp = (ped_values.sigma_min   , ped_values.sigma_max)
 
-    seed   = (norm_seed, mu_seed) + sd0middle  + (gain_seed, gain_sigma_seed)
-    bound1 = (0       ,       0)  + bd00middle + (0        ,           0.001)
-    bound2 = (1e10    ,   10000)  + bd01middle + (10000    ,           10000)
+    seed   = (norm_seed, mu_seed) + ped_seed      + (gain_seed, gain_sigma_seed)
+    bound1 = (0       ,       0)  + ped_bound_low + (0        ,           0.001)
+    bound2 = (1e10    ,   10000)  + ped_bound_upp + (10000    ,           10000)
     return seed, (bound1, bound2)

--- a/invisible_cities/reco/calib_functions.py
+++ b/invisible_cities/reco/calib_functions.py
@@ -331,5 +331,5 @@ def seeds_and_bounds(sensor_type, run_no, n_chann, scaler, bins, spectrum, ped_v
 
     seed   = (norm_seed, mu_seed) + ped_seed      + (gain_seed, gain_sigma_seed)
     bound1 = (0       ,       0)  + ped_bound_low + (0        ,           0.001)
-    bound2 = (1e10    ,   10000)  + ped_bound_upp + (10000    ,           10000)
+    bound2 = (np.inf  ,   10000)  + ped_bound_upp + (10000    ,           10000)
     return seed, (bound1, bound2)

--- a/invisible_cities/reco/calib_functions.py
+++ b/invisible_cities/reco/calib_functions.py
@@ -195,7 +195,7 @@ def poisson_mu_seed(sensor_type, scaler, bins, spec, ped_vals):
         raise ValueError("SensorType.SIPM or SensorType.PMT must be given for sensor_type")
 
 
-def sensor_values(sensor_type, n_chann, scaler, bins, spec, ped_vals):
+def sensor_values(sensor_type, scaler, bins, spectrum, ped_vals):
     """
     Define different values and ranges of the spectra depending on the sensor type.
     """
@@ -306,8 +306,8 @@ def seeds_and_bounds(sensor_type, run_no, n_chann, scaler, bins, spec, ped_vals,
         Minimum and maximum limits for the previous variables.
     """
 
-    norm_seed = spec.sum()
-    sens_values = sensor_values(sensor_type, n_chann, scaler, bins, spec, ped_vals)
+    norm_seed = spectrum.sum()
+    sens_values = sensor_values(sensor_type, scaler, bins, spectrum, ped_vals)
     if use_db_gain_seeds:
         gain_seed, gain_sigma_seed = seeds_db(sensor_type, run_no, n_chann)
 

--- a/invisible_cities/reco/calib_functions.py
+++ b/invisible_cities/reco/calib_functions.py
@@ -273,7 +273,7 @@ def seeds_and_bounds(sensor_type, run_no, n_chann, scaler, bins, spec, ped_vals,
                         spectra[p1pe-hpw:p1pe+hpw],
                         seed=(spectra[p1pe], bins[p1pe], 7),
                         sigma=np.sqrt(spectra[p1pe-hpw:p1pe+hpw]),
-                        bounds=[(0, -100, 0), (1e99, 100, 10000)]))
+                        bounds=[(0, -100, 0), (1e99, 100, 10000)])
         gain_seed = fgaus.values[1] - ped_vals[1]
 
         if fgaus.values[2] <= ped_vals[2]:

--- a/invisible_cities/reco/calib_functions.py
+++ b/invisible_cities/reco/calib_functions.py
@@ -184,13 +184,13 @@ def poisson_mu_seed(sensor_type, scaler, bins, spectrum, ped_vals):
         return fitf.fit(scaler,
                         bins    [sel],
                         spectrum[sel],
-                        (dscale), sigma=errs).values[0]
+                        dscale, sigma=errs).values[0]
     elif sensor_type is SensorType.PMT:
         dscale = spectrum[bins<0].sum() / fitf.gauss(bins[bins<0], *ped_vals).sum()
         return fitf.fit(scaler,
                         bins    [bins<0],
                         spectrum[bins<0],
-                        (dscale)).values[0]
+                        dscale).values[0]
     else:
         raise ValueError("SensorType.SIPM or SensorType.PMT must be given for sensor_type")
 

--- a/invisible_cities/reco/calib_functions.py
+++ b/invisible_cities/reco/calib_functions.py
@@ -132,6 +132,15 @@ def copy_sensor_table(h5in, h5out):
             datasipm.copy(newparent=group)
 
 
+def dark_scaler(dark_spectrum):
+    """
+    A function to scale dark spectrum with mu value.
+    """
+    def scaled_spectrum(x, mu):
+        return np.exp(-mu) * dark_spectrum
+    return scaled_spectrum
+
+
 def seeds_and_bounds(sensor_type, run_no, n_chann, scaler, bins, spec, ped_vals,
                      ped_errs, func='dfunc', use_db_gain_seeds=True):
 

--- a/invisible_cities/reco/calib_functions_test.py
+++ b/invisible_cities/reco/calib_functions_test.py
@@ -259,13 +259,12 @@ def test_seeds_without_using_db(ICDATADIR):
     for ich, (led, dar) in enumerate(zip(specsL, specsD)):
         b1 = 0
         b2 = len(dar)
-        if min_stat != 0:
-            try:
-                valid_bins = np.argwhere(led>=min_stat)
-                b1 = valid_bins[ 0][0]
-                b2 = valid_bins[-1][0]
-            except IndexError:
-                continue
+        try:
+            valid_bins = np.argwhere(led>=min_stat)
+            b1 = valid_bins[ 0][0]
+            b2 = valid_bins[-1][0]
+        except IndexError:
+            continue
 
         pD = find_peaks_cwt(dar, np.arange(2, 20), min_snr=2)
         if len(pD) == 0:

--- a/invisible_cities/reco/calib_functions_test.py
+++ b/invisible_cities/reco/calib_functions_test.py
@@ -7,9 +7,11 @@ from numpy.testing import assert_array_equal
 from numpy.testing import assert_approx_equal
 from pytest        import mark
 from pytest        import raises
+from scipy.signal  import find_peaks_cwt
 
 from .                         import calib_functions as cf
-from .. reco                   import tbl_functions as tbl
+from .. reco                   import tbl_functions   as tbl
+from .. core                   import fit_functions   as fitf
 from .. core.system_of_units_c import units
 from .. evm.nh5                import SensorTable
 
@@ -171,6 +173,76 @@ def test_copy_sensor_table3(config_tmpdir):
         assert out_file.root.Sensors.DataSiPM[0][1] == dummy_sipm[1]
 
 
+def test_seeds_db():
+    gain_seed_sipm, gain_sigma_seed_sipm = seeds_db('sipm', 6317, 13)
+    gain_seed_pmt, gain_sigma_seed_pmt   = seeds_db('pmt', 6317, 5)
+
+    assert gain_seed_sipm       == 16.5503
+    assert gain_sigma_seed_sipm == 1.65978
+    assert gain_seed_pmt        == 22.66
+    assert gain_sigma_seed_pmt  == 9.88
+
+
+def test_poisson_mu_seed():
+    bins     = np.array([-8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7])
+    spec     = np.array([28, 98, 28, 539, 1072, 1845, 2805, 3251, 3626, 3532, 3097, 2172, 1299, 665, 371, 174])
+    dark     = np.array([30, 107, 258, 612, 1142, 2054, 3037, 3593, 3769, 3777, 3319, 2321, 1298, 690, 415, 192])
+    ped_vals = np.array([2.65181178e+04, 1.23743445e-01, 2.63794236e+00])
+
+    scaler   = dark_scaler(dark[(bins>=-5) & (bins<=5)])
+    scaler2  = dark_scaler(dark[bins<0])
+    mu       = poisson_mu_seed('sipm', bins, spec, ped_vals, scaler)
+    mu2      = poisson_mu_seed('pmt', bins, spec, ped_vals, scaler2)
+
+    np.testing.assert_approx_equal(mu, 0.0698154)
+    np.testing.assert_approx_equal(mu2, 0.0950066)
+
+
+def test_sensor_values():
+    bins     = np.array([-6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7])
+    spec     = np.array([28, 539, 1072, 1845, 2805, 3251, 3626, 3532, 3097, 2172, 1299, 665, 371, 174])
+    dark     = np.array([258, 612, 1142, 2054, 3037, 3593, 3769, 3777, 3319, 2321, 1298, 690, 415, 192])
+    ped_vals = np.array([2.65181178e+04, 1.23743445e-01, 2.63794236e+00])
+    scaler   = dark_scaler(dark[(bins>=-5) & (bins<=5)])
+    scaler2  = dark_scaler(dark[bins<0])
+    spectra, p_range, min_bin, max_bin, hpw, lim_ped = sensor_values('sipm', 1023, scaler_func, spec, bins, ped_vals)
+    spectra2, p_range2, min_bin2, max_bin2, hpw2, lim_ped2 = sensor_values('pmt', 0, scaler_func, spec, bins, ped_vals)
+
+    expected_range = np.arange(4,20)
+    expected_spec2 = np.array([-215.61455106, -7.61389796, 9.69755144, 56.84252052, 197.9256732, -41.23729614, 25.03486623,
+                               120.56759537, 297.7306255, 182.5057727, 74.29711143, 12.00648349, 69.4376878, 53.375555])
+    expected_range2 = np.arange(10,20)
+
+    np.testing.assert_array_equal(spectra, spec)
+    np.testing.assert_array_equal(p_range, expected_range)
+    assert min_bin == 10
+    assert max_bin == 22
+    assert hpw == 5
+    assert lim_ped == lim_ped2
+    assert len(spectra2) == len(expected_spec2)
+
+    np.testing.assert_array_equal(p_range2, expected_range2)
+    assert min_bin2 == 15
+    assert max_bin2 == 50
+    assert hpw2 == 10
+
+
+def test_pedestal_values():
+    ped_vals = np.array([6.14871401e+04, -1.46181517e-01, 5.27614635e+00])
+    ped_errs = np.array([9.88752708e+02, 5.38541961e-02, 1.07169703e-01])
+    lim_ped  = 10000
+
+    p_seed, p_sig_seed, p_min, p_max, p_sig_min, p_sig_max = pedestal_values(ped_vals,
+                                                                             lim_ped, ped_errs)
+
+    assert_approx_equal(p_seed, -0.14618, 5)
+    assert_approx_equal(p_sig_seed, 5.27614, 5)
+    assert_approx_equal(p_min, -538.68814, 5)
+    assert_approx_equal(p_max, 538.39577, 5)
+    assert_approx_equal(p_sig_min, 0.001)
+    assert_approx_equal(p_sig_max, 1076.97317, 5)
+
+
 def test_seeds_and_bounds(file_name):
     sipmIn = tb.open_file(file_name, 'r')
     run_no = file_name[file_name.find('R')+1:file_name.find('R')+5]
@@ -195,7 +267,7 @@ def test_seeds_and_bounds(file_name):
         sd0     = (dar.sum(), 0, 2)
         errs    = poisson_sigma(dar[pD[0]-5:pD[0]+5], default=0.1)
         gfitRes = fitf.fit(fitf.gauss, bins[pD[0]-5:pD[0]+5], dar[pD[0]-5:pD[0]+5], sd0, sigma=errs, bounds=gb0)
-        
+
         ped_vals    = np.array([gfitRes.values[0], gfitRes.values[1], gfitRes.values[2]])
         scaler_func = dark_scaler(dar[b1:b2][(bins[b1:b2]>=-5) & (bins[b1:b2]<=5)])
 

--- a/invisible_cities/reco/calib_functions_test.py
+++ b/invisible_cities/reco/calib_functions_test.py
@@ -176,10 +176,11 @@ def test_copy_sensor_table3(config_tmpdir):
         assert out_file.root.Sensors.DataSiPM[0][1] == dummy_sipm[1]
 
 
-@mark.parametrize('sensor_type     , run_number, n_channel, gain_seed, gain_sigma_seed',
-                  ((SensorType.SIPM,       6217,         1,   16.5622,         2.5),
-                   (SensorType.PMT ,       6217,         5,   24.9557,         9.55162)))
-def test_seeds_db(sensor_type, run_number, n_channel, gain_seed, gain_sigma_seed):
+@mark.parametrize('sensor_type     , n_channel, gain_seed, gain_sigma_seed',
+                  ((SensorType.SIPM,         1,   16.5622,         2.5),
+                   (SensorType.PMT ,         5,   24.9557,         9.55162)))
+def test_seeds_db(sensor_type, n_channel, gain_seed, gain_sigma_seed):
+    run_number = 6217
     result = cf.seeds_db(sensor_type, run_number, n_channel)
     assert result == (gain_seed, gain_sigma_seed)
 

--- a/invisible_cities/reco/calib_functions_test.py
+++ b/invisible_cities/reco/calib_functions_test.py
@@ -266,13 +266,13 @@ def test_seeds_without_using_db(ICDATADIR):
         except IndexError:
             continue
 
-        pD = find_peaks_cwt(dar, np.arange(2, 20), min_snr=2)
-        if len(pD) == 0:
+        peaks_dark = find_peaks_cwt(dar, np.arange(2, 20), min_snr=2)
+        if len(peaks_dark) == 0:
             continue
 
         gb0     = [(0, -100, 0), (np.inf, 100, 10000)]
         sd0     = (dar.sum(), 0, 2)
-        sel     = np.arange(pD[0]-5, pD[0]+5)
+        sel     = np.arange(peaks_dark[0]-5, peaks_dark[0]+5)
         errs    = poisson_sigma(dar[sel], default=0.1)
         gfitRes = fitf.fit(fitf.gauss, bins[sel], dar[sel], sd0, sigma=errs, bounds=gb0)
 

--- a/invisible_cities/reco/calib_functions_test.py
+++ b/invisible_cities/reco/calib_functions_test.py
@@ -174,8 +174,8 @@ def test_copy_sensor_table3(config_tmpdir):
 
 
 def test_seeds_db():
-    gain_seed_sipm, gain_sigma_seed_sipm = seeds_db('sipm', 6317, 13)
-    gain_seed_pmt, gain_sigma_seed_pmt   = seeds_db('pmt', 6317, 5)
+    gain_seed_sipm, gain_sigma_seed_sipm = cf.seeds_db('sipm', 6317, 13)
+    gain_seed_pmt, gain_sigma_seed_pmt   = cf.seeds_db('pmt', 6317, 5)
 
     assert gain_seed_sipm       == 16.5503
     assert gain_sigma_seed_sipm == 1.65978
@@ -189,10 +189,10 @@ def test_poisson_mu_seed():
     dark     = np.array([30, 107, 258, 612, 1142, 2054, 3037, 3593, 3769, 3777, 3319, 2321, 1298, 690, 415, 192])
     ped_vals = np.array([2.65181178e+04, 1.23743445e-01, 2.63794236e+00])
 
-    scaler   = dark_scaler(dark[(bins>=-5) & (bins<=5)])
-    scaler2  = dark_scaler(dark[bins<0])
-    mu       = poisson_mu_seed('sipm', bins, spec, ped_vals, scaler)
-    mu2      = poisson_mu_seed('pmt', bins, spec, ped_vals, scaler2)
+    scaler   = cf.dark_scaler(dark[(bins>=-5) & (bins<=5)])
+    scaler2  = cf.dark_scaler(dark[bins<0])
+    mu       = cf.poisson_mu_seed('sipm', bins, spec, ped_vals, scaler)
+    mu2      = cf.poisson_mu_seed('pmt', bins, spec, ped_vals, scaler2)
 
     np.testing.assert_approx_equal(mu, 0.0698154)
     np.testing.assert_approx_equal(mu2, 0.0950066)
@@ -203,10 +203,10 @@ def test_sensor_values():
     spec     = np.array([28, 539, 1072, 1845, 2805, 3251, 3626, 3532, 3097, 2172, 1299, 665, 371, 174])
     dark     = np.array([258, 612, 1142, 2054, 3037, 3593, 3769, 3777, 3319, 2321, 1298, 690, 415, 192])
     ped_vals = np.array([2.65181178e+04, 1.23743445e-01, 2.63794236e+00])
-    scaler   = dark_scaler(dark[(bins>=-5) & (bins<=5)])
-    scaler2  = dark_scaler(dark[bins<0])
-    spectra, p_range, min_bin, max_bin, hpw, lim_ped = sensor_values('sipm', 1023, scaler_func, spec, bins, ped_vals)
-    spectra2, p_range2, min_bin2, max_bin2, hpw2, lim_ped2 = sensor_values('pmt', 0, scaler_func, spec, bins, ped_vals)
+    scaler   = cf.dark_scaler(dark[(bins>=-5) & (bins<=5)])
+    scaler2  = cf.dark_scaler(dark[bins<0])
+    spectra, p_range, min_bin, max_bin, hpw, lim_ped = cf.sensor_values('sipm', 1023, scaler_func, spec, bins, ped_vals)
+    spectra2, p_range2, min_bin2, max_bin2, hpw2, lim_ped2 = cf.sensor_values('pmt', 0, scaler_func, spec, bins, ped_vals)
 
     expected_range = np.arange(4,20)
     expected_spec2 = np.array([-215.61455106, -7.61389796, 9.69755144, 56.84252052, 197.9256732, -41.23729614, 25.03486623,
@@ -232,7 +232,7 @@ def test_pedestal_values():
     ped_errs = np.array([9.88752708e+02, 5.38541961e-02, 1.07169703e-01])
     lim_ped  = 10000
 
-    p_seed, p_sig_seed, p_min, p_max, p_sig_min, p_sig_max = pedestal_values(ped_vals,
+    p_seed, p_sig_seed, p_min, p_max, p_sig_min, p_sig_max = cf.pedestal_values(ped_vals,
                                                                              lim_ped, ped_errs)
 
     assert_approx_equal(p_seed, -0.14618, 5)
@@ -270,7 +270,7 @@ def test_seeds_and_bounds(file_name):
         ped_vals    = np.array([gfitRes.values[0], gfitRes.values[1], gfitRes.values[2]])
         scaler_func = dark_scaler(dar[b1:b2][(bins[b1:b2]>=-5) & (bins[b1:b2]<=5)])
 
-        seeds, bounds = seeds_and_bounds('sipm', run_no, ich, scaler_func, bins[b1:b2], led[b1:b2],
+        seeds, bounds = cf.seeds_and_bounds('sipm', run_no, ich, scaler_func, bins[b1:b2], led[b1:b2],
                                          ped_vals, gfitRes.errors, use_db_gain_seeds=False)
 
         assert all(i > 0 for i in seeds)

--- a/invisible_cities/reco/calib_functions_test.py
+++ b/invisible_cities/reco/calib_functions_test.py
@@ -197,28 +197,29 @@ def test_poisson_mu_seed(sensor_type, scaler, mu):
     np.testing.assert_approx_equal(result, mu)
 
 
-@mark.parametrize('     sensor_type, n_chann,                    scaler,    expected_range, min_b, max_b, half_width, lim_p',
-                  ((SensorType.SIPM,    1023, cf.dark_scaler(dark_sipm),  np.arange(4 ,20),    10,    22,          5, 10000),
-                   (SensorType.PMT ,       0, cf.dark_scaler(dark_pmt) ,  np.arange(10,20),    15,    50,         10, 10000)))
-def test_sensor_values(sensor_type, n_chann, scaler, expected_range, min_b, max_b, half_width, lim_p):
+@mark.parametrize('     sensor_type, n_chann,                    scaler,    expected_range, min_b, max_b, half_width, p1pe_seed, lim_p',
+                  ((SensorType.SIPM,    1023, cf.dark_scaler(dark_sipm),  np.arange(4 ,20),    10,    22,          5,         3, 10000),
+                   (SensorType.PMT ,       0, cf.dark_scaler(dark_pmt) ,  np.arange(10,20),    15,    50,         10,         7, 10000)))
+def test_sensor_values(sensor_type, n_chann, scaler, expected_range, min_b, max_b, half_width, p1pe_seed, lim_p):
     bins     = np.array([ -6,  -5,   -4,   -3,   -2,   -1,    0,    1,    2,    3,    4,   5,   6,   7])
     spec     = np.array([ 28, 539, 1072, 1845, 2805, 3251, 3626, 3532, 3097, 2172, 1299, 665, 371, 174])
     ped_vals = np.array([2.65181178e+04, 1.23743445e-01, 2.63794236e+00])
-    spectra, p_range, min_bin, max_bin, hpw, lim_ped = cf.sensor_values(sensor_type, n_chann, scaler, spec, bins, ped_vals)
+    spectra, p_range, min_bin, max_bin, hpw, seed, lim_ped = cf.sensor_values(sensor_type, n_chann, scaler, spec, bins, ped_vals)
 
     np.testing.assert_array_equal(p_range, expected_range)
     assert len(spectra) == len(spec)
-    assert min_bin == min_b
-    assert max_bin == max_b
-    assert hpw     == half_width
-    assert lim_ped == lim_p
+    assert min_bin      == min_b
+    assert max_bin      == max_b
+    assert hpw          == half_width
+    assert seed         == p1pe_seed
+    assert lim_ped      == lim_p
 
 
 def test_pedestal_values():
     ped_vals   = np.array([6.14871401e+04, -1.46181517e-01, 5.27614635e+00])
     ped_errs   = np.array([9.88752708e+02,  5.38541961e-02, 1.07169703e-01])
     ped_values = cf.pedestal_values(ped_vals, 10000, ped_errs)
-    
+
     assert_approx_equal(ped_values.gain     ,   -0.14618, 5)
     assert_approx_equal(ped_values.sigma    ,    5.27614, 5)
     assert_approx_equal(ped_values.gain_min , -538.68814, 5)

--- a/invisible_cities/reco/calib_functions_test.py
+++ b/invisible_cities/reco/calib_functions_test.py
@@ -205,8 +205,8 @@ def test_sensor_values():
     ped_vals = np.array([2.65181178e+04, 1.23743445e-01, 2.63794236e+00])
     scaler   = cf.dark_scaler(dark[(bins>=-5) & (bins<=5)])
     scaler2  = cf.dark_scaler(dark[bins<0])
-    spectra, p_range, min_bin, max_bin, hpw, lim_ped = cf.sensor_values('sipm', 1023, scaler_func, spec, bins, ped_vals)
-    spectra2, p_range2, min_bin2, max_bin2, hpw2, lim_ped2 = cf.sensor_values('pmt', 0, scaler_func, spec, bins, ped_vals)
+    spectra, p_range, min_bin, max_bin, hpw, lim_ped = cf.sensor_values('sipm', 1023, scaler, spec, bins, ped_vals)
+    spectra2, p_range2, min_bin2, max_bin2, hpw2, lim_ped2 = cf.sensor_values('pmt', 0, scaler2, spec, bins, ped_vals)
 
     expected_range = np.arange(4,20)
     expected_spec2 = np.array([-215.61455106, -7.61389796, 9.69755144, 56.84252052, 197.9256732, -41.23729614, 25.03486623,

--- a/invisible_cities/reco/calib_functions_test.py
+++ b/invisible_cities/reco/calib_functions_test.py
@@ -185,12 +185,12 @@ def test_seeds_db(sensor_type, n_channel, gain_seed, gain_sigma_seed):
     assert result == (gain_seed, gain_sigma_seed)
 
 
-dark_sipm = np.array([612, 1142, 2054, 3037, 3593, 3769, 3777, 3319, 2321, 1298, 690])
-dark_pmt  = np.array([ 30,  107,  258,  612, 1142, 2054, 3037, 3593                 ])
+_dark_sipm_scaler = cf.dark_scaler(np.array([612, 1142, 2054, 3037, 3593, 3769, 3777, 3319, 2321, 1298, 690]))
+_dark_pmt_scaler  = cf.dark_scaler(np.array([ 30,  107,  258,  612, 1142, 2054, 3037, 3593                 ]))
 
-@mark.parametrize('     sensor_type,                    scaler,        mu',
-                  ((SensorType.SIPM, cf.dark_scaler(dark_sipm), 0.0698154),
-                   (SensorType.PMT , cf.dark_scaler(dark_pmt) , 0.0950066)))
+@mark.parametrize('     sensor_type,            scaler,        mu',
+                  ((SensorType.SIPM, _dark_sipm_scaler, 0.0698154),
+                   (SensorType.PMT ,  _dark_pmt_scaler, 0.0950066)))
 def test_poisson_mu_seed(sensor_type, scaler, mu):
     bins     = np.array([-8,  -7,  -6,  -5,  -4,    -3,   -2,   -1,    0,    1,    2,    3,    4,   5,   6,   7])
     spec     = np.array([28,  98,  28, 539, 1072, 1845, 2805, 3251, 3626, 3532, 3097, 2172, 1299, 665, 371, 174])

--- a/invisible_cities/reco/calib_functions_test.py
+++ b/invisible_cities/reco/calib_functions_test.py
@@ -260,7 +260,6 @@ def test_seeds_and_bounds(file_name):
         b2 = valid_bins[-1][0]
         pD = find_peaks_cwt(dar, np.arange(2, 20), min_snr=2)
         if len(pD) == 0:
-            print('no peaks in dark spectrum, spec ', ich)
             continue
 
         gb0     = [(0, -100, 0), (1e99, 100, 10000)]

--- a/invisible_cities/reco/calib_functions_test.py
+++ b/invisible_cities/reco/calib_functions_test.py
@@ -16,7 +16,7 @@ from .. core.stat_functions      import poisson_sigma
 from .. core.system_of_units_c   import units
 from .. evm.nh5                  import SensorTable
 from .  calib_functions          import SensorType
-from .. liquid_cities.components import get_run_number
+from .. cities.components        import get_run_number
 
 
 def test_bin_waveforms():

--- a/invisible_cities/reco/calib_functions_test.py
+++ b/invisible_cities/reco/calib_functions_test.py
@@ -209,13 +209,13 @@ def test_sensor_values(sensor_type, scaler, expected_range, min_b, max_b, half_w
     ped_vals    = np.array([2.65181178e+04, 1.23743445e-01, 2.63794236e+00])
     sens_values = cf.sensor_values(sensor_type, scaler, bins, spec, ped_vals)
 
-    assert_array_equal(p_range, expected_range)
-    assert len(sens_values.spectra) == len(spec)
-    assert     sens_values.min_bin  == min_b
-    assert     sens_values.max_bin  == max_b
-    assert     sens_values.hpw      == half_width
-    assert     sens_values.seed     == p1pe_seed
-    assert     sens_values.lim_ped  == lim_p
+    assert_array_equal(sens_values.peak_range, expected_range)
+    assert len(sens_values.spectra)        == len(spec)
+    assert     sens_values.min_bin_peak    == min_b
+    assert     sens_values.max_bin_peak    == max_b
+    assert     sens_values.half_peak_width == half_width
+    assert     sens_values.p1pe_seed       == p1pe_seed
+    assert     sens_values.lim_ped         == lim_p
 
 
 @mark.parametrize('sensor_type, run_number, n_chann,            scaler',

--- a/invisible_cities/reco/calib_functions_test.py
+++ b/invisible_cities/reco/calib_functions_test.py
@@ -329,4 +329,4 @@ def test_seeds_without_using_db(ICDATADIR):
                                             ped_vals, gfitRes.errors,
                                             use_db_gain_seeds=False)
         assert all(seeds)
-        assert bounds == ((0, 0, 0, 0.001), (1e10, 10000, 10000, 10000))
+        assert bounds == ((0, 0, 0, 0.001), (np.inf, 10000, 10000, 10000))

--- a/invisible_cities/reco/calib_functions_test.py
+++ b/invisible_cities/reco/calib_functions_test.py
@@ -277,8 +277,12 @@ def test_seeds_without_using_db(ICDATADIR):
         gfitRes = fitf.fit(fitf.gauss, bins[sel], dar[sel], sd0, sigma=errs, bounds=gb0)
 
         ped_vals      = np.array([gfitRes.values[0], gfitRes.values[1], gfitRes.values[2]])
-        scaler_func   = cf.dark_scaler(dar[b1:b2][(bins[b1:b2]>=-5) & (bins[b1:b2]<=5)])
-        seeds, bounds = cf.seeds_and_bounds(SensorType.SIPM, run_no, ich, scaler_func, bins[b1:b2],
-                                            led[b1:b2], ped_vals, gfitRes.errors, use_db_gain_seeds=False)
+        p_range       = slice(b1, b2)
+        p_bins        = (bins[p_range] >= -5) & (bins[p_range] <= 5)
+        scaler_func   = cf.dark_scaler(dar[p_range][p_bins])
+        seeds, bounds = cf.seeds_and_bounds(SensorType.SIPM, run_no, ich,
+                                            scaler_func, bins[p_range], led[p_range],
+                                            ped_vals, gfitRes.errors,
+                                            use_db_gain_seeds=False)
         assert not (all(seeds) == 0)
         assert bounds == ((0, 0, 0, 0.001), (1e10, 10000, 10000, 10000))

--- a/invisible_cities/reco/calib_functions_test.py
+++ b/invisible_cities/reco/calib_functions_test.py
@@ -185,12 +185,12 @@ def test_seeds_db(sensor_type, n_channel, gain_seed, gain_sigma_seed):
     assert result == (gain_seed, gain_sigma_seed)
 
 
-_dark_sipm_scaler = cf.dark_scaler(np.array([612, 1142, 2054, 3037, 3593, 3769, 3777, 3319, 2321, 1298, 690]))
-_dark_pmt_scaler  = cf.dark_scaler(np.array([ 30,  107,  258,  612, 1142, 2054, 3037, 3593                 ]))
+_dark_scaler_sipm = cf.dark_scaler(np.array([612, 1142, 2054, 3037, 3593, 3769, 3777, 3319, 2321, 1298, 690]))
+_dark_scaler_pmt  = cf.dark_scaler(np.array([ 30,  107,  258,  612, 1142, 2054, 3037, 3593                 ]))
 
 @mark.parametrize('     sensor_type,            scaler,        mu',
-                  ((SensorType.SIPM, _dark_sipm_scaler, 0.0698154),
-                   (SensorType.PMT ,  _dark_pmt_scaler, 0.0950066)))
+                  ((SensorType.SIPM, _dark_scaler_sipm, 0.0698154),
+                   (SensorType.PMT , _dark_scaler_pmt , 0.0950066)))
 def test_poisson_mu_seed(sensor_type, scaler, mu):
     bins     = np.array([-8,  -7,  -6,  -5,  -4,    -3,   -2,   -1,    0,    1,    2,    3,    4,   5,   6,   7])
     spec     = np.array([28,  98,  28, 539, 1072, 1845, 2805, 3251, 3626, 3532, 3097, 2172, 1299, 665, 371, 174])
@@ -218,9 +218,9 @@ def test_sensor_values(sensor_type, scaler, expected_range, min_b, max_b, half_w
     assert     sens_values.lim_ped  == lim_p
 
 
-@mark.parametrize('sensor_type, run_number, n_chann,                    scaler',
-                  ((      None,       6217,    1023, cf.dark_scaler(dark_sipm)),
-                   (      None,       6217,       0, cf.dark_scaler(dark_pmt))))
+@mark.parametrize('sensor_type, run_number, n_chann,            scaler',
+                  ((      None,       6217,    1023, _dark_scaler_sipm),
+                   (      None,       6217,       0, _dark_scaler_pmt)))
 def test_incorrect_sensor_type_raises_ValueError(sensor_type, run_number, n_chann, scaler):
     bins     = np.array([ -6,  -5,   -4,   -3,   -2,   -1,    0,    1,    2,    3,    4,   5,   6,   7])
     spec     = np.array([ 28, 539, 1072, 1845, 2805, 3251, 3626, 3532, 3097, 2172, 1299, 665, 371, 174])

--- a/invisible_cities/reco/calib_functions_test.py
+++ b/invisible_cities/reco/calib_functions_test.py
@@ -204,18 +204,18 @@ def test_poisson_mu_seed(sensor_type, scaler, mu):
                   ((SensorType.SIPM,    1023, cf.dark_scaler(dark_sipm),  np.arange(4 ,20),    10,    22,          5,         3, 10000),
                    (SensorType.PMT ,       0, cf.dark_scaler(dark_pmt) ,  np.arange(10,20),    15,    50,         10,         7, 10000)))
 def test_sensor_values(sensor_type, n_chann, scaler, expected_range, min_b, max_b, half_width, p1pe_seed, lim_p):
-    bins     = np.array([ -6,  -5,   -4,   -3,   -2,   -1,    0,    1,    2,    3,    4,   5,   6,   7])
-    spec     = np.array([ 28, 539, 1072, 1845, 2805, 3251, 3626, 3532, 3097, 2172, 1299, 665, 371, 174])
-    ped_vals = np.array([2.65181178e+04, 1.23743445e-01, 2.63794236e+00])
-    spectra, p_range, min_bin, max_bin, hpw, seed, lim_ped = cf.sensor_values(sensor_type, n_chann, scaler, bins, spec, ped_vals)
+    bins        = np.array([ -6,  -5,   -4,   -3,   -2,   -1,    0,    1,    2,    3,    4,   5,   6,   7])
+    spec        = np.array([ 28, 539, 1072, 1845, 2805, 3251, 3626, 3532, 3097, 2172, 1299, 665, 371, 174])
+    ped_vals    = np.array([2.65181178e+04, 1.23743445e-01, 2.63794236e+00])
+    sens_values = cf.sensor_values(sensor_type, n_chann, scaler, bins, spec, ped_vals)
 
     assert_array_equal(p_range, expected_range)
-    assert len(spectra) == len(spec)
-    assert min_bin      == min_b
-    assert max_bin      == max_b
-    assert hpw          == half_width
-    assert seed         == p1pe_seed
-    assert lim_ped      == lim_p
+    assert len(sens_values.spectra) == len(spec)
+    assert     sens_values.min_bin  == min_b
+    assert     sens_values.max_bin  == max_b
+    assert     sens_values.hpw      == half_width
+    assert     sens_values.seed     == p1pe_seed
+    assert     sens_values.lim_ped  == lim_p
 
 
 @mark.parametrize('sensor_type, run_number, n_chann,                    scaler',

--- a/invisible_cities/reco/calib_functions_test.py
+++ b/invisible_cities/reco/calib_functions_test.py
@@ -200,14 +200,14 @@ def test_poisson_mu_seed(sensor_type, scaler, mu):
     assert_approx_equal(result, mu)
 
 
-@mark.parametrize('     sensor_type, n_chann,                    scaler,    expected_range, min_b, max_b, half_width, p1pe_seed, lim_p',
-                  ((SensorType.SIPM,    1023, cf.dark_scaler(dark_sipm),  np.arange(4 ,20),    10,    22,          5,         3, 10000),
-                   (SensorType.PMT ,       0, cf.dark_scaler(dark_pmt) ,  np.arange(10,20),    15,    50,         10,         7, 10000)))
-def test_sensor_values(sensor_type, n_chann, scaler, expected_range, min_b, max_b, half_width, p1pe_seed, lim_p):
+@mark.parametrize('     sensor_type,            scaler,    expected_range, min_b, max_b, half_width, p1pe_seed, lim_p',
+                  ((SensorType.SIPM, _dark_scaler_sipm,  np.arange(4 ,20),    10,    22,          5,         3, 10000),
+                   (SensorType.PMT ,  _dark_scaler_pmt,  np.arange(10,20),    15,    50,         10,         7, 10000)))
+def test_sensor_values(sensor_type, scaler, expected_range, min_b, max_b, half_width, p1pe_seed, lim_p):
     bins        = np.array([ -6,  -5,   -4,   -3,   -2,   -1,    0,    1,    2,    3,    4,   5,   6,   7])
     spec        = np.array([ 28, 539, 1072, 1845, 2805, 3251, 3626, 3532, 3097, 2172, 1299, 665, 371, 174])
     ped_vals    = np.array([2.65181178e+04, 1.23743445e-01, 2.63794236e+00])
-    sens_values = cf.sensor_values(sensor_type, n_chann, scaler, bins, spec, ped_vals)
+    sens_values = cf.sensor_values(sensor_type, scaler, bins, spec, ped_vals)
 
     assert_array_equal(p_range, expected_range)
     assert len(sens_values.spectra) == len(spec)
@@ -229,7 +229,7 @@ def test_incorrect_sensor_type_raises_ValueError(sensor_type, run_number, n_chan
     with raises(ValueError):
         cf.       seeds_db(sensor_type, run_number, n_chann)
         cf.poisson_mu_seed(sensor_type, scaler, bins, spec, ped_vals)
-        cf.  sensor_values(sensor_type, n_chann, scaler, bins, spec, ped_vals)
+        cf.  sensor_values(sensor_type, scaler, bins, spec, ped_vals)
 
 
 def test_pedestal_values():

--- a/invisible_cities/reco/calib_functions_test.py
+++ b/invisible_cities/reco/calib_functions_test.py
@@ -270,7 +270,7 @@ def test_seeds_without_using_db(ICDATADIR):
         if len(pD) == 0:
             continue
 
-        gb0     = [(0, -100, 0), (1e99, 100, 10000)]
+        gb0     = [(0, -100, 0), (np.inf, 100, 10000)]
         sd0     = (dar.sum(), 0, 2)
         sel     = np.arange(pD[0]-5, pD[0]+5)
         errs    = poisson_sigma(dar[sel], default=0.1)

--- a/invisible_cities/reco/calib_functions_test.py
+++ b/invisible_cities/reco/calib_functions_test.py
@@ -197,7 +197,7 @@ def test_poisson_mu_seed(sensor_type, scaler, mu):
     ped_vals = np.array([2.65181178e+04, 1.23743445e-01, 2.63794236e+00])
 
     result   = cf.poisson_mu_seed(sensor_type, scaler, bins, spec, ped_vals)
-    np.testing.assert_approx_equal(result, mu)
+    assert_approx_equal(result, mu)
 
 
 @mark.parametrize('     sensor_type, n_chann,                    scaler,    expected_range, min_b, max_b, half_width, p1pe_seed, lim_p',
@@ -209,7 +209,7 @@ def test_sensor_values(sensor_type, n_chann, scaler, expected_range, min_b, max_
     ped_vals = np.array([2.65181178e+04, 1.23743445e-01, 2.63794236e+00])
     spectra, p_range, min_bin, max_bin, hpw, seed, lim_ped = cf.sensor_values(sensor_type, n_chann, scaler, bins, spec, ped_vals)
 
-    np.testing.assert_array_equal(p_range, expected_range)
+    assert_array_equal(p_range, expected_range)
     assert len(spectra) == len(spec)
     assert min_bin      == min_b
     assert max_bin      == max_b

--- a/invisible_cities/reco/calib_functions_test.py
+++ b/invisible_cities/reco/calib_functions_test.py
@@ -284,5 +284,5 @@ def test_seeds_without_using_db(ICDATADIR):
                                             scaler_func, bins[p_range], led[p_range],
                                             ped_vals, gfitRes.errors,
                                             use_db_gain_seeds=False)
-        assert not (all(seeds) == 0)
+        assert all(seeds)
         assert bounds == ((0, 0, 0, 0.001), (1e10, 10000, 10000, 10000))

--- a/invisible_cities/types/ic_types.py
+++ b/invisible_cities/types/ic_types.py
@@ -1,4 +1,5 @@
 from argparse import Namespace
+from enum     import Enum, auto
 
 import numpy as np
 
@@ -102,3 +103,20 @@ class minmax:
         if n == 0: return self.min
         if n == 1: return self.max
         raise IndexError
+
+
+class AutoNameEnumBase(Enum):
+    """Automatically generate Enum values from their names.
+
+        Use this as a base class to make Enums with values which automatically
+        match the member names:
+
+        class Direction(AutoNameEnumBase):
+        ...     LEFT  = auto()
+        ...     RIGHT = auto()
+        ...
+        >>> list(Direction)
+        [<Direction.LEFT: 'LEFT'>, <Direction.RIGHT: 'RIGHT'>]
+    """
+    def _generate_next_value_(name, start, count, last_values):
+        return name

--- a/invisible_cities/types/ic_types.py
+++ b/invisible_cities/types/ic_types.py
@@ -1,5 +1,5 @@
 from argparse import Namespace
-from enum     import Enum, auto
+from enum     import Enum
 
 import numpy as np
 


### PR DESCRIPTION
This PR adds several functions to provide seeds and bounds for sensor calibration fits. For gain and sigma it provides either the option to take their values from previous runs in the database, or it looks for the pedestal and 1 pe peaks. Corresponding tests are also added.

This is an LFS version of #540.