### PR TITLE
Fix `test_mean_for_pmts_fee_is_unbiased`

### DIFF
--- a/invisible_cities/reco/calib_sensors_functions_test.py
+++ b/invisible_cities/reco/calib_sensors_functions_test.py
@@ -256,6 +256,17 @@ def test_subtract_mean_diff_minmax_remains_constant(square_pmt_and_sipm_waveform
     assert np.allclose(wf_diff_bls, wf_diff_original)
 
 
+@flaky(max_runs=10, min_passes=10)
+def test_subtract_mean_mean_is_zero(square_pmt_and_sipm_waveforms):
+    _, _, pmts_fee, _, _, _, _ = square_pmt_and_sipm_waveforms
+    pmts_bls = csf.subtract_mean(pmts_fee)
+
+    # By definition, if we subtract the mean, the mean
+    # of the resulting object must be zero
+    wf_mean_bls = np.mean(pmts_bls, axis=1)
+    assert np.allclose(wf_mean_bls, 0, atol=1e-10)
+
+
 @flaky(max_runs=3)
 def test_mean_for_pmts_fee_is_unbiased(square_pmt_and_sipm_waveforms):
     _, _, pmts_fee, _, _, _, _ = square_pmt_and_sipm_waveforms

--- a/invisible_cities/reco/calib_sensors_functions_test.py
+++ b/invisible_cities/reco/calib_sensors_functions_test.py
@@ -281,7 +281,7 @@ def test_subtract_mean_difference_is_mean(square_pmt_and_sipm_waveforms):
         assert np.allclose(diff, mean)
 
 
-@flaky(max_runs=3)
+@flaky(max_runs=10, min_passes=10)
 def test_mean_for_pmts_fee_is_unbiased(square_pmt_and_sipm_waveforms):
     _, _, pmts_fee, _, _, _, _ = square_pmt_and_sipm_waveforms
     pmts_bls = csf.subtract_mean(pmts_fee) # ped subtracted near zero

--- a/invisible_cities/reco/calib_sensors_functions_test.py
+++ b/invisible_cities/reco/calib_sensors_functions_test.py
@@ -96,7 +96,7 @@ def oscillating_waveform_with_baseline(oscillating_waveform_wo_baseline):
 
 @fixture
 def square_pmt_and_sipm_waveforms():
-    pedestal = 5000
+    pedestal = 25000
     nsensors =    5
     fee      = FE.FEE(noise_FEEPMB_rms = 1 * FE.NOISE_I  ,
                       noise_DAQ_rms    = 1 * FE.NOISE_DAQ)

--- a/invisible_cities/reco/calib_sensors_functions_test.py
+++ b/invisible_cities/reco/calib_sensors_functions_test.py
@@ -244,6 +244,18 @@ def test_wf_baseline_subtracted_is_close_to_zero(gaussian_sipm_signal):
     np.testing.assert_allclose(np.mean(bls_wf, axis=1), 0, atol=1e-10)
 
 
+@flaky(max_runs=10, min_passes=10)
+def test_subtract_mean_diff_minmax_remains_constant(square_pmt_and_sipm_waveforms):
+    _, _, pmts_fee, _, _, _, _ = square_pmt_and_sipm_waveforms
+    pmts_bls = csf.subtract_mean(pmts_fee)
+
+    # Baseline subtraction is only an overall shift,
+    # the differences between min and max must remain constant
+    wf_diff_original = np.max(pmts_fee, axis=1) - np.min(pmts_fee, axis=1)
+    wf_diff_bls      = np.max(pmts_bls, axis=1) - np.min(pmts_bls, axis=1)
+    assert np.allclose(wf_diff_bls, wf_diff_original)
+
+
 @flaky(max_runs=3)
 def test_mean_for_pmts_fee_is_unbiased(square_pmt_and_sipm_waveforms):
     _, _, pmts_fee, _, _, _, _ = square_pmt_and_sipm_waveforms

--- a/invisible_cities/reco/calib_sensors_functions_test.py
+++ b/invisible_cities/reco/calib_sensors_functions_test.py
@@ -267,6 +267,20 @@ def test_subtract_mean_mean_is_zero(square_pmt_and_sipm_waveforms):
     assert np.allclose(wf_mean_bls, 0, atol=1e-10)
 
 
+@flaky(max_runs=10, min_passes=10)
+def test_subtract_mean_difference_is_mean(square_pmt_and_sipm_waveforms):
+    _, _, pmts_fee, _, _, _, _ = square_pmt_and_sipm_waveforms
+    pmts_bls = csf.subtract_mean(pmts_fee)
+    means    = np.mean(pmts_fee, axis=1)
+
+    # If the mean is subtracted, the difference between
+    # the original wf and the bls one should be exactly the mean
+    # at all points
+    diffs = pmts_fee - pmts_bls
+    for mean, diff in zip(means, diffs):
+        assert np.allclose(diff, mean)
+
+
 @flaky(max_runs=3)
 def test_mean_for_pmts_fee_is_unbiased(square_pmt_and_sipm_waveforms):
     _, _, pmts_fee, _, _, _, _ = square_pmt_and_sipm_waveforms


### PR DESCRIPTION
While trying to fix this test I realized that we have a fishy trick in the code.
It was introduced in #489 and essentially ignores zeros in the waveforms passed to baseline-subtraction functions so the baseline calculation works for both full waveforms and zero-suppressed ones. That is fine for waveforms that are symmetric wrt zero, but not arbitrary waveforms.

I will push a couple of commits that show it a bit better.