### PR TITLE
Fix random sampling tests

### DIFF
--- a/invisible_cities/core/random_sampling_test.py
+++ b/invisible_cities/core/random_sampling_test.py
@@ -3,6 +3,7 @@ import numpy as np
 from flaky  import flaky
 from pytest import mark
 from pytest import fixture
+from pytest import approx
 
 from hypothesis            import given
 from hypothesis.strategies import composite
@@ -146,7 +147,7 @@ def test_inverse_cdf_hypothesis_generated(distribution, percentile):
             true_value = d
             break
     icdf = inverse_cdf(domain, cdf, percentile)
-    assert true_value == icdf
+    assert icdf == approx(true_value)
 
 
 @fixture(scope="module")


### PR DESCRIPTION
As pointed out in #551, the test `test_inverse_cdf_hypothesis_generated` failed from time to time.
The origin of the failure was the exact (`==`) comparison between floats. This has been replaced with an approximate comparison (`pytest.approx`). I also took the chance to improve the data generation algorithm for `hypothesis`.