### PR TITLE
Remove unnecessary raw data type parameter

### DIFF
--- a/invisible_cities/cities/irene.py
+++ b/invisible_cities/cities/irene.py
@@ -47,8 +47,7 @@ from .  components import wf_from_files
 
 @city
 def irene(files_in, file_out, compression, event_range, print_mod, run_number,
-          n_baseline, raw_data_type,
-          n_mau, thr_mau, thr_sipm, thr_sipm_type,
+          n_baseline, n_mau, thr_mau, thr_sipm, thr_sipm_type,
           s1_lmin, s1_lmax, s1_tmin, s1_tmax, s1_rebin_stride, s1_stride, thr_csum_s1,
           s2_lmin, s2_lmax, s2_tmin, s2_tmax, s2_rebin_stride, s2_stride, thr_csum_s2, thr_sipm_s2):
     if   thr_sipm_type.lower() == "common":

--- a/invisible_cities/cities/isidora.py
+++ b/invisible_cities/cities/isidora.py
@@ -36,7 +36,7 @@ from .  components import deconv_pmt
 
 @city
 def isidora(files_in, file_out, compression, event_range, print_mod, run_number,
-            n_baseline, raw_data_type):
+            n_baseline):
     """
     The city of ISIDORA performs a fast processing from raw data
     (pmtrwf and sipmrwf) to BLR wavefunctions.

--- a/invisible_cities/cities/moriana.py
+++ b/invisible_cities/cities/moriana.py
@@ -56,18 +56,16 @@ from .  components import waveform_integrator
 
 @city
 def moriana(files_in, file_out, compression, event_range, print_mod, run_number,
-            raw_data_type, proc_mode,
+            proc_mode,
             min_bin, max_bin, bin_width,
             number_integrals, integral_start, integral_width, integrals_period,
             n_mau = 100):
-    raw_data_type_ = getattr(WfType, raw_data_type.lower())
-
     if proc_mode not in ("subtract_mode", "subtract_median"):
         raise ValueError(f"Unrecognized processing mode: {proc_mode}")
 
     bin_edges   = np.arange(min_bin, max_bin, bin_width)
     bin_centres = shift_to_bin_centers(bin_edges)
-    sd          = sensor_data(files_in[0], raw_data_type_)
+    sd          = sensor_data(files_in[0], WfType.rwf)
     nsipm       = sd.NSIPM
     wf_length   = sd.SIPMWL
     shape       = nsipm, len(bin_centres)
@@ -100,7 +98,7 @@ def moriana(files_in, file_out, compression, event_range, print_mod, run_number,
                                       bin_centres = bin_centres)
 
         out = fl.push(
-            source = wf_from_files(files_in, raw_data_type_),
+            source = wf_from_files(files_in, WfType.rwf),
             pipe   = fl.pipe(fl.slice(*event_range, close_all=True),
                              event_count.spy,
                              print_every(print_mod),

--- a/invisible_cities/cities/phyllis.py
+++ b/invisible_cities/cities/phyllis.py
@@ -62,13 +62,10 @@ from .  components import waveform_integrator
 
 @city
 def phyllis(files_in, file_out, compression, event_range, print_mod, run_number,
-            raw_data_type, proc_mode,
-            n_baseline,
+            proc_mode, n_baseline,
             min_bin, max_bin, bin_width,
             number_integrals, integral_start, integral_width, integrals_period,
             n_mau = 100):
-    raw_data_type_ = getattr(WfType, raw_data_type.lower())
-
     if   proc_mode == "gain"         : proc = pmt_deconvolver    (run_number, n_baseline       )
     elif proc_mode == "gain_mau"     : proc = pmt_deconvolver_mau(run_number, n_baseline, n_mau)
     elif proc_mode == "gain_nodeconv": proc = mode_subtractor    (run_number)
@@ -76,7 +73,7 @@ def phyllis(files_in, file_out, compression, event_range, print_mod, run_number,
 
     bin_edges   = np.arange(min_bin, max_bin, bin_width)
     bin_centres = shift_to_bin_centers(bin_edges)
-    sd          = sensor_data(files_in[0], raw_data_type_)
+    sd          = sensor_data(files_in[0], WfType.rwf)
     npmt        = np.count_nonzero(load_db.DataPMT(run_number).Active.values)
     wf_length   = sd.PMTWL
     shape       = npmt, len(bin_centres)
@@ -109,7 +106,7 @@ def phyllis(files_in, file_out, compression, event_range, print_mod, run_number,
                                       bin_centres = bin_centres)
 
         out = fl.push(
-            source = wf_from_files(files_in, raw_data_type_),
+            source = wf_from_files(files_in, WfType.rwf),
             pipe   = fl.pipe(fl.slice(*event_range, close_all=True),
                              event_count.spy,
                              print_every(print_mod),

--- a/invisible_cities/cities/zemrude.py
+++ b/invisible_cities/cities/zemrude.py
@@ -47,13 +47,10 @@ from .  components import waveform_binner
 
 @city
 def zemrude(files_in, file_out, compression, event_range, print_mod, run_number,
-            raw_data_type,
             min_bin, max_bin, bin_width):
-    raw_data_type_ = getattr(WfType, raw_data_type.lower())
-
     bin_edges   = np.arange(min_bin, max_bin, bin_width)
     bin_centres = shift_to_bin_centers(bin_edges)
-    nsipm       = sensor_data(files_in[0], raw_data_type_).NSIPM
+    nsipm       = sensor_data(files_in[0], WfType.rwf).NSIPM
     shape       = nsipm, len(bin_centres)
 
     subtract_mode         = fl.map(csf.subtract_mode            )
@@ -80,7 +77,7 @@ def zemrude(files_in, file_out, compression, event_range, print_mod, run_number,
                              bin_centres = bin_centres)
 
         out = fl.push(
-            source = wf_from_files(files_in, raw_data_type_),
+            source = wf_from_files(files_in, WfType.rwf),
             pipe   = fl.pipe(fl.slice(*event_range, close_all=True),
                              event_count.spy,
                              print_every(print_mod),

--- a/invisible_cities/config/irene.conf
+++ b/invisible_cities/config/irene.conf
@@ -15,9 +15,7 @@ print_mod = 1
 # max number of events to run
 event_range =  1
 
-raw_data_type =   'RWF'   # The default raw waveform
-
-n_baseline            =   28000           # for a window of 800 mus
+n_baseline =   28000 # for a window of 800 mus
 
 # Set MAU for calibrated sum
 n_mau   = 100

--- a/invisible_cities/config/isidora.conf
+++ b/invisible_cities/config/isidora.conf
@@ -16,6 +16,4 @@ print_mod = 1
 # max number of events to run
 event_range =  1
 
-raw_data_type =   'RWF'   # The default raw waveform
-
-n_baseline =   28000           # for a window of 800 mus
+n_baseline = 28000 # for a window of 800 mus

--- a/invisible_cities/config/moriana.conf
+++ b/invisible_cities/config/moriana.conf
@@ -5,8 +5,6 @@ print_mod   = 1
 event_range = 1
 
 run_number    = 4821
-raw_data_type = 'RWF'
-
 
 # Histogram bins
 min_bin   = - 49.5

--- a/invisible_cities/config/phyllis.conf
+++ b/invisible_cities/config/phyllis.conf
@@ -5,8 +5,6 @@ print_mod   = 1
 event_range = 1
 
 run_number    = 4819
-raw_data_type = 'RWF' # The default raw waveform
-
 
 # Histogram bins
 min_bin   = - 49.5

--- a/invisible_cities/config/zemrude.conf
+++ b/invisible_cities/config/zemrude.conf
@@ -5,7 +5,6 @@ print_mod   = 1
 event_range = 1
 
 run_number    = 4821
-raw_data_type = 'RWF'
 
 # Histogram bins
 min_bin   = -10


### PR DESCRIPTION
The parameter `raw_data_type` is not needed, as each city reads always from the same type of data. It has been removed from all cities.