### PR TITLE
Address tests failing due to hypothesis health checks

### DIFF
--- a/invisible_cities/reco/pmaps_functions_test.py
+++ b/invisible_cities/reco/pmaps_functions_test.py
@@ -1,6 +1,8 @@
 import numpy as np
 
 from hypothesis            import given
+from hypothesis            import settings
+from hypothesis            import HealthCheck
 from hypothesis.strategies import integers
 from hypothesis.strategies import floats
 from hypothesis.strategies import dictionaries
@@ -79,7 +81,11 @@ def test_rebin_peak(pk, fraction):
     assert_Peak_equality(rebinned_pk, expected_pk)
 
 
-@given(dictionaries(keys=integers(min_value=-1e5, max_value=1e5), values=pmaps(), max_size=5), lists(integers(min_value=-1e5, max_value=1e5)))
+@given(dictionaries(keys     = integers(min_value=-1e5, max_value=1e5),
+                    values   = pmaps(),
+                    max_size = 5),
+       lists(integers(min_value=-1e5, max_value=1e5)))
+@settings(suppress_health_check=(HealthCheck.too_slow,))
 def test_pmap_event_id_selection(pmaps, events):
     filtered_pmaps = pmf.pmap_event_id_selection(pmaps, events)
     assert set(filtered_pmaps) == set(pmaps) & set(events)


### PR DESCRIPTION
Some tests have been failing recurrently because hypothesis' data generation is too slow, [as pointed out in](https://github.com/nextic/IC/issues/551#issuecomment-434364870) #551. Since we don't know how to improve data generation at present, we will suppress this specific health check in these tests.

This PR is going to remain open until all the tests of this kind are identified and fixed. 


