### PR TITLE
optimize  mc_info_writer last_row parameter update

### DIFF
--- a/invisible_cities/io/mcinfo_io.py
+++ b/invisible_cities/io/mcinfo_io.py
@@ -125,7 +125,7 @@ class mc_info_writer:
         self.extent_table.flush()
 
         hits, particles, generators = read_mcinfo_evt(mctables, evt_number, self.last_row)
-        self.last_row += 1
+        self.last_row = iext + 1
 
         for h in hits:
             new_row = self.hit_table.row


### PR DESCRIPTION
This  PR changes the update of last_row parameter in mc_info_writer, setting it to the value of the row number of the last written event, which speeds up writing of sparse filtered events