### PR TITLE
Store filters results in output file

### DIFF
--- a/invisible_cities/cities/diomira_test.py
+++ b/invisible_cities/cities/diomira_test.py
@@ -208,9 +208,10 @@ def test_diomira_exact_result(ICDATADIR, output_tmpdir):
     np.random.set_state(original_random_state)
 
 
-    tables = ( "MC/extents",  "MC/hits"   , "MC/particles", "MC/generators",
-               "RD/pmtrwf" ,  "RD/pmtblr" , "RD/sipmrwf"  ,
-              "Run/events" , "Run/runInfo")
+    tables = (     "MC/extents",  "MC/hits"   , "MC/particles", "MC/generators",
+                   "RD/pmtrwf" ,  "RD/pmtblr" , "RD/sipmrwf"  ,
+                  "Run/events" , "Run/runInfo",
+              "Filters/trigger")
     with tb.open_file(true_output)  as true_output_file:
         with tb.open_file(file_out) as      output_file:
             for table in tables:

--- a/invisible_cities/cities/dorothea_test.py
+++ b/invisible_cities/cities/dorothea_test.py
@@ -151,7 +151,8 @@ def test_dorothea_exact_result(ICDATADIR, output_tmpdir):
 
     dorothea(**conf)
 
-    tables = ("DST/Events",)
+    tables = (    "DST/Events",
+              "Filters/s12_selector")
     with tb.open_file(true_output)  as true_output_file:
         with tb.open_file(file_out) as      output_file:
             for table in tables:

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -400,11 +400,12 @@ def test_irene_exact_result(ICDATADIR, output_tmpdir):
 
     irene(**conf)
 
-    tables = (     "MC/extents",      "MC/hits"   ,    "MC/particles", "MC/generators",
-                "PMAPS/S1"     ,   "PMAPS/S2"     , "PMAPS/S2Si"     ,
-                "PMAPS/S1Pmt"  ,   "PMAPS/S2Pmt"  ,
-                  "Run/events" ,     "Run/runInfo",
-              "Trigger/events" , "Trigger/trigger")
+    tables = (     "MC/extents"    ,      "MC/hits"      ,    "MC/particles", "MC/generators",
+                "PMAPS/S1"         ,   "PMAPS/S2"        , "PMAPS/S2Si"     ,
+                "PMAPS/S1Pmt"      ,   "PMAPS/S2Pmt"     ,
+                  "Run/events"     ,     "Run/runInfo"   ,
+              "Trigger/events"     , "Trigger/trigger"   ,
+              "Filters/s12_indices", "Filters/empty_pmap")
     with tb.open_file(true_output)  as true_output_file:
         with tb.open_file(file_out) as      output_file:
             for table in tables:

--- a/invisible_cities/cities/penthesilea_test.py
+++ b/invisible_cities/cities/penthesilea_test.py
@@ -206,8 +206,9 @@ def test_penthesilea_exact_result(ICDATADIR, output_tmpdir):
 
     penthesilea(**conf)
 
-    tables = (  "MC/extents",  "MC/hits", "MC/particles", "MC/generators",
-              "RECO/Events" , "DST/Events")
+    tables = (     "MC/extents"     ,  "MC/hits", "MC/particles", "MC/generators",
+                 "RECO/Events"      , "DST/Events",
+              "Filters/s12_selector")
     with tb.open_file(true_output)  as true_output_file:
         with tb.open_file(file_out) as      output_file:
             print(true_output_file)

--- a/invisible_cities/database/test_data/Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts.HDST.h5
+++ b/invisible_cities/database/test_data/Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts.HDST.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aa5e1da11f6ffc1adb9e466fa5af9d357ced5d5f20267a5edd28fd4880bc8110
-size 76199
+oid sha256:293599fedc5d490f07dc5380dc28f190f733c567a13df2edf032ef26dff472af
+size 80428

--- a/invisible_cities/database/test_data/Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts.KDST.h5
+++ b/invisible_cities/database/test_data/Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts.KDST.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:825677f7bfc8ae045fafc4c3cfb2d69db801f97653ebbb8df6ec39366d7c90f4
-size 10362
+oid sha256:4569925b137feac080e5a54b2a8f0cfe424a3a95178fdeb503f7d63b5381d736
+size 33772

--- a/invisible_cities/database/test_data/Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts.PMP.h5
+++ b/invisible_cities/database/test_data/Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts.PMP.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d771df409aabc5a2217705349e78a7479534cc7ff607a488ee832a21ad16e74a
-size 52063
+oid sha256:12c5d03549ea9de3dd4799b90122803ada0a51960a20d9b6aa1ed4ace4c90ec4
+size 130063

--- a/invisible_cities/database/test_data/Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts.RWF.h5
+++ b/invisible_cities/database/test_data/Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts.RWF.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:33db2c5f7bd0fe9737da428e726d0b68715f6d3c65f9b8e91f0020e49bd68f7e
-size 2638083
+oid sha256:3868b26499cd8fee5ad467c496734bf0b1785af3997c12bb5e5ab42139e31a4e
+size 2581649

--- a/invisible_cities/database/test_data/multiple_filter_tables_file_different_lengths.h5
+++ b/invisible_cities/database/test_data/multiple_filter_tables_file_different_lengths.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d5422d76ffc712cc71170185646fb3a5718ba48a76725c566fb5cdc3c385a2b
+size 14388

--- a/invisible_cities/database/test_data/multiple_filter_tables_file_same_length.h5
+++ b/invisible_cities/database/test_data/multiple_filter_tables_file_same_length.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:febfaa8caf0e48bedc04d41e39765e461c9d4267e82124666696bf4c481fa49b
+size 14397

--- a/invisible_cities/database/test_data/one_filter_table_file.h5
+++ b/invisible_cities/database/test_data/one_filter_table_file.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f35a29a88fe43f2074a8a0c6a27e9c6671ef334d47297fa23d441869cc49f88
+size 5554

--- a/invisible_cities/evm/nh5.py
+++ b/invisible_cities/evm/nh5.py
@@ -233,6 +233,7 @@ class HitsTable(tb.IsDescription):
     Ec       = tb.Float64Col(pos=16)
     Zc       = tb.Float64Col(pos=17)
 
+
 class VoxelsTable(tb.IsDescription):
     event    = tb.  Int32Col(pos=0)
     X        = tb.Float64Col(pos=1)
@@ -240,3 +241,8 @@ class VoxelsTable(tb.IsDescription):
     Z        = tb.Float64Col(pos=3)
     E        = tb.Float64Col(pos=4)
     size     = tb.Float64Col(pos=5, shape=3)
+
+
+class EventPassedFilter(tb.IsDescription):
+    event  = tb.Int32Col(pos=0)
+    passed = tb. BoolCol(pos=1)

--- a/invisible_cities/io/event_filter_io.py
+++ b/invisible_cities/io/event_filter_io.py
@@ -1,0 +1,18 @@
+from .. evm      import nh5        as table_formats
+from .  table_io import make_table
+
+
+def event_filter_writer(file, filter_name, *, compression='ZLIB4'):
+    table = make_table(file,
+                       group       = "Filters",
+                        name        = filter_name,
+                       fformat     = table_formats.EventPassedFilter,
+                       description = "Event has passed filter flag",
+                       compression = compression)
+
+    def write_event_passed(event_number, passed_filter):
+        table.row["event" ] = event_number
+        table.row["passed"] = passed_filter
+        table.row.append()
+
+    return write_event_passed

--- a/invisible_cities/io/event_filter_io.py
+++ b/invisible_cities/io/event_filter_io.py
@@ -1,3 +1,6 @@
+import tables as tb
+import pandas as pd
+
 from .. evm      import nh5        as table_formats
 from .  table_io import make_table
 
@@ -16,3 +19,15 @@ def event_filter_writer(file, filter_name, *, compression='ZLIB4'):
         table.row.append()
 
     return write_event_passed
+
+
+def event_filter_reader(filename):
+    def read_as_df(table):
+        df = pd.DataFrame.from_records(table.read(), index="event")
+        df.rename(columns=dict(passed = table.name), inplace=True)
+        return df
+
+    with tb.open_file(filename) as file:
+        tables  = map(read_as_df, file.root.Filters)
+        full_df = pd.concat(list(tables), axis=1)
+        return full_df.fillna(False)

--- a/invisible_cities/io/event_filter_io_test.py
+++ b/invisible_cities/io/event_filter_io_test.py
@@ -1,0 +1,46 @@
+import os
+
+from pytest import mark
+
+import numpy  as np
+import tables as tb
+
+from . event_filter_io import event_filter_writer
+
+
+@mark.parametrize("table_names",
+                  (("a_filter",),
+                   ("a_filter", "b_filter"),
+                   ("a_filter", "b_filter", "c_filter")))
+def test_event_filter_writer_creates_group_and_tables(config_tmpdir, table_names):
+    filename = os.path.join(config_tmpdir, f"test_event_filter_writer_creates_group_and_table.h5")
+
+    with tb.open_file(filename, "w") as file:
+        # do nothing but create the tables
+        for table_name in table_names:
+            event_filter_writer(file, table_name)
+
+    with tb.open_file(filename, "r") as file:
+        assert "Filters"  in file.root
+        for table_name in table_names:
+            assert table_name in file.root.Filters
+
+
+def test_event_filter_writer_writes_data_correctly(config_tmpdir):
+    filename = os.path.join(config_tmpdir, f"test_event_filter_writer_writes_data_correctly.h5")
+    n_evt    = 10
+    evt_nos  = np.random.randint(0, 10000, size=n_evt)
+    passed   = np.random.randint(0,     2, size=n_evt).astype(bool)
+
+    with tb.open_file(filename, "w") as file:
+        write = event_filter_writer(file, "a_filter")
+
+        for evt, value in zip(evt_nos, passed):
+            write(evt, value)
+
+    with tb.open_file(filename, "r") as file:
+        data = file.root.Filters.a_filter
+        assert data.nrows == n_evt
+        for i, (evt_no, pss) in enumerate(data.read()):
+            assert evt_no == evt_nos[i]
+            assert pss    == passed [i]

--- a/invisible_cities/io/event_filter_io_test.py
+++ b/invisible_cities/io/event_filter_io_test.py
@@ -1,11 +1,64 @@
 import os
 
+from collections import namedtuple
+
+from pytest import fixture
 from pytest import mark
 
 import numpy  as np
 import tables as tb
 
 from . event_filter_io import event_filter_writer
+from . event_filter_io import event_filter_reader
+
+
+filter_data = namedtuple("filter_data", "filename nevt tables evt passed")
+
+
+@fixture(scope="session")
+def one_filter_table_file(ICDATADIR):
+    filename = os.path.join(ICDATADIR, "one_filter_table_file.h5")
+    nevt     = 20
+    tables   = "a_filter",
+    evts     = np.arange(0, 40, 2)
+    passed   = [True] * 3 + [False] * 4 + [True] * 3 + [False] * 5 + [True] * 5
+
+    return filter_data(filename, nevt, tables, evts, np.array(passed))
+
+
+@fixture(scope="session")
+def multiple_filter_tables_file_same_length(ICDATADIR):
+    filename = os.path.join(ICDATADIR, "multiple_filter_tables_file_same_length.h5")
+    nevt     = 5
+    tables   = "a_filter", "b_filter", "c_filter", "d_filter"
+    evts     = np.arange(0, 15, 3)
+    passed   = np.array([[ True, True , True , True ],
+                         [ True, True , True , False],
+                         [ True, True , False, False],
+                         [ True, False, False, False],
+                         [False, False, False, False]])
+
+    return filter_data(filename, nevt, tables, evts, np.array(passed))
+
+
+@fixture(scope="session")
+def multiple_filter_tables_file_different_lengths(ICDATADIR):
+    filename = os.path.join(ICDATADIR, "multiple_filter_tables_file_different_lengths.h5")
+    nevt     = 5
+    tables   = "a_filter", "b_filter", "c_filter", "d_filter"
+    evts     = np.arange(0, 20, 4)
+    passed   = np.array([[ True, True , True , True ],
+                         [ True, True , True , False],
+                         [ True, True , False, False],
+                         [ True, False, False, False],
+                         [False, False, False, False]])
+
+    return filter_data(filename, nevt, tables, evts, np.array(passed))
+
+
+@fixture(scope="session")
+def multiple_filter_tables(request):
+    return request.getfuncargvalue(request.param)
 
 
 @mark.parametrize("table_names",
@@ -44,3 +97,40 @@ def test_event_filter_writer_writes_data_correctly(config_tmpdir):
         for i, (evt_no, pss) in enumerate(data.read()):
             assert evt_no == evt_nos[i]
             assert pss    == passed [i]
+
+
+@mark.parametrize("multiple_filter_tables",
+                  ("multiple_filter_tables_file_same_length"      ,
+                   "multiple_filter_tables_file_different_lengths"),
+                  indirect=True)
+def test_event_filter_reader_column_names(multiple_filter_tables):
+    data = multiple_filter_tables
+    df   = event_filter_reader(data.filename)
+    assert sorted(df.columns.values) == sorted(data.tables)
+
+
+def test_event_filter_reader_one_filter(one_filter_table_file):
+    data = one_filter_table_file
+    df   = event_filter_reader(data.filename)
+    assert np.all(df.index   .values == data.evt   )
+    assert np.all(df.a_filter.values == data.passed)
+
+
+def test_event_filter_reader_multiple_filters_same_length(multiple_filter_tables_file_same_length):
+    data = multiple_filter_tables_file_same_length
+    df   = event_filter_reader(data.filename)
+
+    assert np.all(df.index.values == data.evt)
+
+    for column, expected in zip(data.tables, data.passed.T):
+        assert np.all(getattr(df, column).values == expected)
+
+
+def test_event_filter_reader_multiple_filters_different_lengths(multiple_filter_tables_file_different_lengths):
+    data = multiple_filter_tables_file_different_lengths
+    df   = event_filter_reader(data.filename)
+
+    assert np.all(df.index.values == data.evt)
+
+    for column, expected in zip(data.tables, data.passed.T):
+        assert np.all(getattr(df, column).values == expected)


### PR DESCRIPTION
Following #581, we implement the addition of the result of data filters to file in such a way that we can always know where a given event has been rejected.