### PR TITLE
Add hits to voxels

### DIFF
--- a/invisible_cities/evm/event_model.py
+++ b/invisible_cities/evm/event_model.py
@@ -181,7 +181,7 @@ class MCHit(BHit):
 
 class Voxel(BHit):
     """Represents a Voxel"""
-    def __init__(self, x,y,z, E, size, hits):
+    def __init__(self, x,y,z, E, size, hits=[]):
         super().__init__(x,y,z, E)
         self._size = size
         self.hits = hits

--- a/invisible_cities/evm/event_model.py
+++ b/invisible_cities/evm/event_model.py
@@ -1,4 +1,4 @@
-# Clsses defining the event model
+# Classes defining the event model
 
 import tables as tb
 import numpy  as np
@@ -181,9 +181,10 @@ class MCHit(BHit):
 
 class Voxel(BHit):
     """Represents a Voxel"""
-    def __init__(self, x,y,z, E, size):
+    def __init__(self, x,y,z, E, size, hits):
         super().__init__(x,y,z, E)
         self._size = size
+        self.hits = hits
 
     @property
     def size(self): return self._size

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -83,8 +83,8 @@ def voxelize_hits(hits             : Sequence[BHit],
         # find the bins where hits fall into
         # numpy.histogramdd() uses [,) intervals...
         index = np.digitize(hit_coordinates[i], edges[i], right=False) - 1
-        # ...except for the last one, which is [,]: hits on the last edge
-        # must fall into the last bin
+        # ...except for the last one, which is [,]: hits on the last edge,
+        # if any, must fall into the last bin
         index[index == number_of_voxels[i]] = number_of_voxels[i] - 1
         indx_coordinates.append(index)
 

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -74,37 +74,32 @@ def voxelize_hits(hits             : Sequence[BHit],
     true_dimensions = np.array([size_x[0], size_y[0], size_z[0]])
 
     hit_x = np.array([h.X for h in hits])
-    # find the bins where hits fall into; numpy.histogramdd()
-    # uses [,) intervals, except for the last one, which is [,]
-    indices_x = np.digitize(hit_x, edges[0], right=False) - 1
-    # hits on the last edge must fall inside the last bin
-    indices_x[indices_x == number_of_voxels[0]] = number_of_voxels[0] - 1
-
     hit_y = np.array([h.Y for h in hits])
-    indices_y = np.digitize(hit_y, edges[1], right=False) - 1
-    indices_y[indices_y == number_of_voxels[1]] = number_of_voxels[1] - 1
-
     hit_z = np.array([h.Z for h in hits])
-    indices_z = np.digitize(hit_z, edges[2], right=False) - 1
-    indices_z[indices_z == number_of_voxels[2]] = number_of_voxels[2] - 1
+    hit_coordinates = [hit_x, hit_y, hit_z]
 
-    h_indices = [(i, j, k) for i, j, k in zip(indices_x, indices_y, indices_z)]
-    #print(h_indices)
+    indx_coordinates = []
+    for i in range(3):
+        # find the bins where hits fall into
+        # numpy.histogramdd() uses [,) intervals...
+        index = np.digitize(hit_coordinates[i], edges[i], right=False) - 1
+        # ...except for the last one, which is [,]: hits on the last edge
+        # must fall into the last bin
+        index[index == number_of_voxels[i]] = number_of_voxels[i] - 1
+        indx_coordinates.append(index)
+
+    h_indices = np.array([(i, j, k) for i, j, k in zip(indx_coordinates[0], indx_coordinates[1], indx_coordinates[2])])
+
     voxels = []
     for (x,y,z) in np.stack(nz).T:
-        #print(type((x, y, z)))
-        indx_comp = np.array(h_indices) == (x, y, z)
+
+        indx_comp = (h_indices == (x, y, z))
         ok = [i[0] & i[1] & i[2] for i in indx_comp]
-        #print((x, y, z))
-        #print(ok)
         hits = np.array(hits)
         hits_in_bin = hits[ok]
-        #print(hits_in_bin)
+
         voxels.append(Voxel(cx[x], cy[y], cz[z], E[x,y,z], true_dimensions, hits_in_bin))  
-    
-   # voxels = [Voxel(cx[x], cy[y], cz[z], E[x,y,z], true_dimensions) for (x,y,z) in np.stack(nz).T]
-   # for v in voxels:
-   #     print(v, v.hits)
+
     return voxels
 
 

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -94,9 +94,7 @@ def voxelize_hits(hits             : Sequence[BHit],
     for (x,y,z) in np.stack(nz).T:
 
         indx_comp = (h_indices == (x, y, z))
-        ok = [i[0] & i[1] & i[2] for i in indx_comp]
-        hits = np.array(hits)
-        hits_in_bin = hits[ok]
+        hits_in_bin = list(h for i, h in zip(indx_comp, hits) if all(i))
 
         voxels.append(Voxel(cx[x], cy[y], cz[z], E[x,y,z], true_dimensions, hits_in_bin))  
 

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -172,6 +172,24 @@ def test_hits_energy_in_voxel_is_equal_to_voxel_energy(hits, requested_voxel_dim
     for v in voxels:
         assert sum([h.E for h in v.hits]) == v.energy
 
+def test_hits_assigned_to_correct_voxel():
+    z = 10.
+    energy = 1.
+    hits = [BHit( 5., 15., z, energy),
+            BHit(15.,  5., z, energy),
+            BHit(15., 15., z, energy),
+            BHit(15., 25., z, energy),
+            BHit(25., 15., z, energy)]
+
+    vox_size = np.array([15,15,15], dtype=np.int16)
+    voxels = voxelize_hits(hits, vox_size)
+
+    assert len(voxels) == 3
+
+    n_expected_hits = [1, 1, 3]
+    for v, nhits in zip(voxels, n_expected_hits):
+        assert len(v.hits) == nhits
+
 
 @given(bunch_of_hits, box_sizes)
 def test_make_voxel_graph_keeps_all_voxels(hits, voxel_dimensions):

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -172,6 +172,7 @@ def test_hits_energy_in_voxel_is_equal_to_voxel_energy(hits, requested_voxel_dim
     for v in voxels:
         assert sum([h.E for h in v.hits]) == v.energy
 
+
 def test_hits_assigned_to_correct_voxel():
     z = 10.
     energy = 1.
@@ -186,13 +187,13 @@ def test_hits_assigned_to_correct_voxel():
 
     assert len(voxels) == 3
 
-    expected_hits = [(BHit( 5., 15., z, energy)),
-                     (BHit(15.,  5., z, energy)),
-                     (BHit(15., 15., z, energy),
+    expected_hits = [[BHit( 5., 15., z, energy)],
+                     [BHit(15.,  5., z, energy)],
+                     [BHit(15., 15., z, energy),
                       BHit(15., 25., z, energy),
-                      BHit(25., 15., z, energy))]
+                      BHit(25., 15., z, energy)]]
     for v, hits in zip(voxels, expected_hits):
-        assert all(v.hits == hits)
+        assert v.hits == hits
 
 
 @given(bunch_of_hits, box_sizes)

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -193,7 +193,7 @@ def test_voxel_hits_are_same_as_original_ones(hits, requested_voxel_dimensions):
     assert  hits_read_from_voxels_s_all == hits_s_all
 
 
-def test_hits_assigned_to_correct_voxel():
+def test_hits_on_border_are_assigned_to_correct_voxel():
     z = 10.
     energy = 1.
     hits = [BHit( 5., 15., z, energy),

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -167,6 +167,13 @@ def test_voxelize_hits_flexible_gives_correct_voxels_size(hits, requested_voxel_
 
 
 @given(bunch_of_hits, box_sizes)
+def test_hits_energy_in_voxel_is_equal_to_voxel_energy(hits, requested_voxel_dimensions):
+    voxels = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False)
+    for v in voxels:
+        assert sum([h.E for h in v.hits]) == v.energy
+
+
+@given(bunch_of_hits, box_sizes)
 def test_make_voxel_graph_keeps_all_voxels(hits, voxel_dimensions):
     voxels = voxelize_hits    (hits  , voxel_dimensions)
     tracks = make_track_graphs(voxels)

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -186,9 +186,13 @@ def test_hits_assigned_to_correct_voxel():
 
     assert len(voxels) == 3
 
-    n_expected_hits = [1, 1, 3]
-    for v, nhits in zip(voxels, n_expected_hits):
-        assert len(v.hits) == nhits
+    expected_hits = [(BHit( 5., 15., z, energy)),
+                     (BHit(15.,  5., z, energy)),
+                     (BHit(15., 15., z, energy),
+                      BHit(15., 25., z, energy),
+                      BHit(25., 15., z, energy))]
+    for v, hits in zip(voxels, expected_hits):
+        assert all(v.hits == hits)
 
 
 @given(bunch_of_hits, box_sizes)

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -173,6 +173,26 @@ def test_hits_energy_in_voxel_is_equal_to_voxel_energy(hits, requested_voxel_dim
         assert sum([h.E for h in v.hits]) == v.energy
 
 
+@given(bunch_of_hits, box_sizes)
+def test_voxel_hits_are_same_as_original_ones(hits, requested_voxel_dimensions):
+    voxels = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False)
+    hits_read_from_voxels = []
+    for v in voxels:
+        hits_read_from_voxels += v.hits
+
+    hits_s_x   = sorted(hits,       key=lambda h: h.X)
+    hits_s_xy  = sorted(hits_s_x,   key=lambda h: h.Y)
+    hits_s_xyz = sorted(hits_s_xy,  key=lambda h: h.Z)
+    hits_s_all = sorted(hits_s_xyz, key=lambda h: h.E)
+
+    hits_read_from_voxels_s_x   = sorted(hits_read_from_voxels,       key=lambda h: h.X)
+    hits_read_from_voxels_s_xy  = sorted(hits_read_from_voxels_s_x,   key=lambda h: h.Y)
+    hits_read_from_voxels_s_xyz = sorted(hits_read_from_voxels_s_xy,  key=lambda h: h.Z)
+    hits_read_from_voxels_s_all = sorted(hits_read_from_voxels_s_xyz, key=lambda h: h.E)
+
+    assert  hits_read_from_voxels_s_all == hits_s_all
+
+
 def test_hits_assigned_to_correct_voxel():
     z = 10.
     energy = 1.


### PR DESCRIPTION
This PR adds to the `Voxel` class the `hits` attribute, which contains the list of the hits that belong to a certain voxel. In the initialization of the class, this list is empty by default, since we can use voxels that are not related to any hits (for instance, voxels coming from RESET).
In the `voxelize_hits()` function of paolina, the calculation of which hits fall in which voxel has been added, and voxels are created with their hits.
Two tests have been added: the first one checks that the energy of the voxel is equal to the sum of the energies of the hits that fall inside the voxel. Another option would have been to calculate the energy of the voxels from the energy of the hits directly in the code, but I preferred to have it this way, to keep the check that the hits are assigned correctly.
The second test takes a specific case, where the hits fall on voxel boundaries, to check that they are assigned correctly.