### PR TITLE
Fix Matplotlib version to 3.0.1

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -72,7 +72,7 @@ function install_conda {
     fi
 }
 
-CONDA_ENV_TAG=2018-10-20
+CONDA_ENV_TAG=2018-11-07
 CONDA_ENV_NAME=IC-${PYTHON_VERSION}-${CONDA_ENV_TAG}
 
 function make_environment {
@@ -87,7 +87,7 @@ dependencies:
 # *REMEMBER TO CHANGE CONDA_ENV_TAG WHEN CHANGING VERSION NUMBERS*
 - cython       = 0.29
 - jupyter      = 1.0.0
-- matplotlib   = 3.0.0
+- matplotlib   = 3.0.1
 - networkx     = 2.2
 - notebook     = 5.7.0
 - numpy        = 1.15.2


### PR DESCRIPTION
There is a bug in matplotlib that makes it incompatible with python 3.7.1. https://github.com/matplotlib/matplotlib/issues/12601

Some Mac users got python 3.7.1 after running `source manage.sh install_and_check 3.7` and many test failed. So until the bug is fixed and we have a better way of controlling the exact python version we are using, we should fix it in the environment specification, which is what this PR does.