### PR TITLE
Fix Z-related assignments in case of an XYRecoFail

### DIFF
--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -371,8 +371,10 @@ def build_pointlike_event(run_number, drift_v, reco):
             try:
                 clusters = reco(xys, qs)
             except XYRecoFail:
-                c = NNN()
-                Z, DT, Zrms = NN, NN, NN
+                c    = NNN()
+                Z    = tuple(NN for _ in evt.nS1)
+                DT   = tuple(NN for _ in evt.nS1)
+                Zrms = NN
             else:
                 c = clusters[0]
                 Z, DT = compute_z_and_dt(evt.S2t[-1], evt.S1t, drift_v)


### PR DESCRIPTION
The assignment of the variables related to the longitudinal coordinate was not properly done in #475 as they don't take into account the possibility of multiple S1s.