### PR TITLE
Make neighbours available

### DIFF
--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -107,7 +107,7 @@ class Contiguity(Enum):
     CORNER = 1.8
 
 
-def neighbours(va : Voxel, vb : Voxel) -> bool:
+def neighbours(va : Voxel, vb : Voxel, contiguity : Contiguity = Contiguity.CORNER) -> bool:
     return np.linalg.norm((va.pos - vb.pos) / va.size) < contiguity.value
 
 
@@ -122,7 +122,7 @@ def make_track_graphs(voxels           : Voxel,
     voxel_graph = nx.Graph()
     voxel_graph.add_nodes_from(voxels)
     for va, vb in combinations(voxels, 2):
-        if neighbours(va, vb):
+        if neighbours(va, vb, contiguity):
             voxel_graph.add_edge(va, vb, distance = np.linalg.norm(va.pos - vb.pos))
 
     return tuple(connected_component_subgraphs(voxel_graph))

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -107,6 +107,10 @@ class Contiguity(Enum):
     CORNER = 1.8
 
 
+def neighbours(va : Voxel, vb : Voxel) -> bool:
+    return np.linalg.norm((va.pos - vb.pos) / va.size) < contiguity.value
+
+
 def make_track_graphs(voxels           : Voxel,
                       contiguity       : Contiguity = Contiguity.CORNER) -> Sequence[Graph]:
     """Create a graph where the voxels are the nodes and the edges are any
@@ -114,9 +118,6 @@ def make_track_graphs(voxels           : Voxel,
     neighbours if their distance normalized to their size is smaller
     than a contiguity factor.
     """
-
-    def neighbours(va : Voxel, vb : Voxel) -> bool:
-        return np.linalg.norm((va.pos - vb.pos) / va.size) < contiguity.value
 
     voxel_graph = nx.Graph()
     voxel_graph.add_nodes_from(voxels)
@@ -126,8 +127,10 @@ def make_track_graphs(voxels           : Voxel,
 
     return tuple(connected_component_subgraphs(voxel_graph))
 
+
 def connected_component_subgraphs(G):
     return (G.subgraph(c).copy() for c in nx.connected_components(G))
+
 
 def voxels_from_track_graph(track: Graph) -> List[Voxel]:
     """Create and return a list of voxels from a track graph."""


### PR DESCRIPTION
In the topology studies it turned out that the paolina `neighbours` function, which tells you if two voxels are neighbours or not, is useful for the users. Therefore, in this PR I extract it from the `make_track_graphs` function, where it lived.