### PR TITLE
Calculate SiPM signal to noise

### DIFF
--- a/invisible_cities/core/random_sampling.py
+++ b/invisible_cities/core/random_sampling.py
@@ -199,6 +199,8 @@ class NoiseSampler:
         pad_xbins = pad_pdfs(self.xbins)
 
         if dark_model == DarkModel.threshold:
+            pdfs = np.apply_along_axis(normalize_distribution, 1,
+                                       self.mask(pdfs))
             dark_pes = general_thresholds(pad_xbins, pdfs, 0.99)
             dark_pes[self.active.flatten() == 0] = 0
             return dark_pes

--- a/invisible_cities/core/random_sampling.py
+++ b/invisible_cities/core/random_sampling.py
@@ -2,12 +2,12 @@ from enum import Enum
 
 import numpy as np
 
-from typing import Tuple
+from typing      import Tuple
 
-from functools import partial
-from functools import lru_cache
+from functools   import   partial
+from functools   import lru_cache
 
-from .. database import load_db as DB
+from .. database import   load_db as DB
 
 
 class DarkModel(Enum):
@@ -15,34 +15,42 @@ class DarkModel(Enum):
     threshold = 1
 
 
-def normalize_distribution(y):
-    ysum = np.sum(y)
-    return y / ysum if ysum else y
+def normalize_distribution(bin_weights : np.array):
+    weight_sum = np.sum(bin_weights)
+    return bin_weights / weight_sum if weight_sum else bin_weights
 
 
-def sample_discrete_distribution(x, y, size=1):
-    if not y.any():
+def sample_discrete_distribution(bin_centres : np.array,
+                                 bin_weights : np.array,
+                                 size : int = 1) -> np.array:
+    if not bin_weights.any():
         return np.zeros(size)
-    return np.random.choice(x, p=y, size=size)
+    return np.random.choice(bin_centres,
+                            p = bin_weights,
+                            size = size)
 
 
-def uniform_smearing(max_deviation, size=1):
+def uniform_smearing(max_deviation : np.array,
+                     size : Tuple = 1) -> np.array:
     return np.random.uniform(-max_deviation,
                              +max_deviation,
                              size = size)
 
 
-def inverse_cdf_index(y, percentile):
+def inverse_cdf_index(y : np.array,
+                      percentile : float) -> int:
     return np.argwhere(y >= percentile)[0,0]
 
 
-def inverse_cdf(x, y, percentile):
+def inverse_cdf(x : np.array,
+                y : np.array,
+                percentile : float) -> float:
     if not y.any():
         return np.inf
     return x[inverse_cdf_index(y, percentile)]
 
 
-def pad_pdfs(bins : np.array,
+def pad_pdfs(bins    : np.array,
              spectra : np.array) -> Tuple[np.array]:
     """
     Pads the spectra to a range of
@@ -97,7 +105,11 @@ def general_thresholds(xbins : np.array,
 
 
 class NoiseSampler:
-    def __init__(self, detector, run_number, sample_size=1, smear=True):
+    def __init__(self,
+                 detector    : str,
+                 run_number  : int,
+                 sample_size : int = 1,
+                 smear       : bool = True):
         """Sample a histogram as if it was a PDF.
 
         Parameters
@@ -158,8 +170,8 @@ class NoiseSampler:
         sample = self.adc_to_pes * sample + self.baselines
         return self.mask(sample)
 
-    def compute_thresholds(self, noise_cut : float=0.99,
-                           pes_to_adc : float=1) -> np.array:
+    def compute_thresholds(self, noise_cut : float = 0.99,
+                           pes_to_adc : float = 1) -> np.array:
         """Find the energy threshold that reduces the noise population by a
         fraction of *noise_cut*.
 

--- a/invisible_cities/core/random_sampling_test.py
+++ b/invisible_cities/core/random_sampling_test.py
@@ -132,15 +132,15 @@ def test_inverse_cdf_index_hypothesis_generated(distribution, percentile):
 
 
 @mark.parametrize("bins           expected_length ".split(),
-                  ((np.linspace(-1, 1, 20),    20 ),
-                   (np.linspace(-2, 1, 30),    40 ),
-                   (np.linspace(-1, 2, 30),    40 ),
-                   (np.linspace(-1, 0, 10),    20 ),
-                   (np.linspace( 0, 1, 10),    18 )))
+                  ((np.linspace(-1, 1, 20),    1900 ),
+                   (np.linspace(-2, 1, 30),    1933 ),
+                   (np.linspace(-1, 2, 30),    1933 ),
+                   (np.linspace(-1, 0, 10),    1801 ),
+                   (np.linspace( 0, 1, 10),    1801 )))
 def test_pad_pdfs(bins, expected_length):
     ## Dummy spectra for 2 'sensors'
-    spectra        = np.full((2, len(bins)), 0.1)
-    padded_spectra = pad_pdfs(bins, spectra)
+    spectra           = np.full((2, len(bins)), 0.1)
+    _, padded_spectra = pad_pdfs(bins, spectra)
     assert padded_spectra.shape[1] == expected_length
     
 
@@ -276,7 +276,8 @@ def test_noise_sampler_multi_sample_distributions(noise_sampler):
     noise_sampler, *_ = noise_sampler
 
     active       = noise_sampler.active.flatten() != 0
-    padded_xbins = pad_pdfs(noise_sampler.xbins)
+    padded_xbins, _ = pad_pdfs(noise_sampler.xbins,
+                               noise_sampler.probs)
 
     nsipm = np.count_nonzero(active)
     PDF_means = np.average(np.repeat(noise_sampler.xbins[None, :], nsipm, 0),

--- a/invisible_cities/core/random_sampling_test.py
+++ b/invisible_cities/core/random_sampling_test.py
@@ -20,6 +20,7 @@ from . random_sampling  import uniform_smearing
 from . random_sampling  import inverse_cdf_index
 from . random_sampling  import inverse_cdf
 from . random_sampling  import pad_pdfs
+from . random_sampling  import DarkModel
 from . random_sampling  import NoiseSampler
 
 sensible_sizes    =                  integers(min_value =    2,
@@ -290,26 +291,31 @@ def test_noise_sampler_multi_sample_distributions(noise_sampler):
     assert np.all(twomu_means > PDF_means)
 
 
-@mark.parametrize("sample_width", (2, 3, 5))
-def test_noise_sampler_dark_expectation(noise_sampler, sample_width):
+@mark.parametrize("sample_width dark_model".split(),
+                  ((2, DarkModel.mean),
+                   (3, DarkModel.threshold),
+                   (5, DarkModel.threshold)))
+def test_noise_sampler_dark_expectation(noise_sampler,
+                                        sample_width ,
+                                        dark_model   ):
     noise_sampler, *_ = noise_sampler
 
-    dark_mean = noise_sampler.dark_expectation(sample_width)
+    dark_mean = noise_sampler.dark_expectation(sample_width, dark_model)
 
     assert len(dark_mean) == noise_sampler.nsensors
     assert np.any(dark_mean)
     assert np.count_nonzero(dark_mean) == np.count_nonzero(noise_sampler.active)
 
 
-@mark.parametrize(" ids qs width expected".split(),
-                  (([  0,   1,   2], np.array([ 6, 10,  4]), 2, [2.42, 3.13, 1.96]),
-                   ([700, 701, 702], np.array([22,  4, 19]), 4, [4.63, 1.90, 4.30]),
-                   ([658, 666, 674], np.array([ 5, 15,  5]), 5, [2.16, 3.81, 2.16])))
+@mark.parametrize(" ids qs width model expected".split(),
+                  (([  0,   1,   2], np.array([ 6, 10,  4]), 2, DarkModel.mean, [2.42, 3.13, 1.96]),
+                   ([700, 701, 702], np.array([22,  4, 19]), 4, DarkModel.mean, [4.63, 1.90, 4.30]),
+                   ([658, 666, 674], np.array([ 5, 15,  5]), 5, DarkModel.threshold, [1.90, 3.60, 1.88])))
 def test_noise_sampler_signal_to_noise(noise_sampler,
-                                       ids, qs, width, expected):
+                                       ids, qs, width, model, expected):
     noise_sampler, *_ = noise_sampler
 
-    signal_to_noise = noise_sampler.signal_to_noise(ids, qs, width)
+    signal_to_noise = noise_sampler.signal_to_noise(ids, qs, width, model)
 
     assert len(signal_to_noise) == len(ids)
     assert np.allclose(np.round(signal_to_noise, 2), expected)


### PR DESCRIPTION
First version with the functions added to calculate
signal to noise for the sipms.

Currently only uses the mean of the appropriate
distribution as an estimator for dark current but
will be generalised to use other definitions.

Addition as an option in reconstruction cities
to be added.

One new test failing (commented out at moment)
because of float accuracy but passes in interactive.