### PR TITLE
Eliminate not-used import.

### DIFF
--- a/invisible_cities/reco/wfm_functions.py
+++ b/invisible_cities/reco/wfm_functions.py
@@ -7,8 +7,6 @@ import math
 
 import numpy as np
 
-import matplotlib.pyplot as plt
-
 from .. core.core_functions import define_window
 from .. sierpe              import blr
 


### PR DESCRIPTION
I've eliminated a matplotlib import, which wasn't used, because it caused a segmentation fault with a particular IC environment in the majorana machine. 