### PR TITLE
Fix arguments in sensor functions

### DIFF
--- a/invisible_cities/cities/diomira.py
+++ b/invisible_cities/cities/diomira.py
@@ -147,7 +147,7 @@ def simulate_sipm_response(run_number, wf_length, noise_cut, filter_padding):
     def simulate_sipm_response(sipmrd):
         wfs = sf.simulate_sipm_response(0, sipmrd[np.newaxis],
                                         noise_sampler, adc_to_pes,
-                                        pe_resolution, run_number)
+                                        pe_resolution)
         return wfm.noise_suppression(wfs, thresholds, filter_padding)
     return simulate_sipm_response
 

--- a/invisible_cities/reco/sensor_functions.py
+++ b/invisible_cities/reco/sensor_functions.py
@@ -77,8 +77,7 @@ def simulate_pmt_response(event, pmtrd, adc_to_pes, pe_resolution, run_number = 
     return np.array(RWF), np.array(BLRX)
 
 
-def simulate_sipm_response(event, sipmrd, sipms_noise_sampler, sipm_adc_to_pes,
-                           pe_resolution, run_number = 0):
+def simulate_sipm_response(event, sipmrd, sipms_noise_sampler, sipm_adc_to_pes, pe_resolution):
     """Add noise to the sipms with the NoiseSampler class and return
     the noisy waveform (in adc)."""
 

--- a/invisible_cities/reco/wfm_functions.py
+++ b/invisible_cities/reco/wfm_functions.py
@@ -18,7 +18,7 @@ def to_adc(wfs, adc_to_pes):
     ----------
     wfs : 2-dim np.ndarray
         The waveform (axis 1) for each sensor (axis 0).
-    sensdf : a vector of constants
+    adc_to_pes : a vector of constants
         Contains the sensor-related information.
 
     Returns
@@ -37,7 +37,7 @@ def to_pes(wfs, adc_to_pes):
     ----------
     wfs : 2-dim np.ndarray
         The waveform (axis 1) for each sensor (axis 0).
-    sensdf : a vector of constants
+    adc_to_pes : a vector of constants
         Contains the sensor-related information.
 
     Returns


### PR DESCRIPTION
While using `sensor_functions` I realized that there were two minor argument hints and bugs that nevertheless confused me. The first one refers to the hint of an argument and the second one is an unused argument. This PR fixes both.