### PR TITLE
Upload db pmt gains

### DIFF
--- a/invisible_cities/database/localdb.sqlite3
+++ b/invisible_cities/database/localdb.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:73280e7f09305f4de85d58b5a3f19d0cca53e5855b086e6b1abc00abf71d8e3c
+oid sha256:8e81bc4d9cd6ee082e1771eb6b291422413da09f7302742bfb09a1937ca8b6ec
 size 136785920


### PR DESCRIPTION
With this PR database is uploaded with the new values of pmt gains in order to try to reduce pmt saturation. For pmts 0, 1, 2, 5, 8, 9 gains have been decreased in 11-12%, while for pmts 4,7 gains have been decreased around 23-25%. 