### PR TITLE
Fix in configure.py to be able to run mypy.

### DIFF
--- a/invisible_cities/core/configure.py
+++ b/invisible_cities/core/configure.py
@@ -21,7 +21,9 @@ class EventRange(Enum):
     last = 2
 
 # to allow direct imports from other odules
-all, last = EventRange
+all  = EventRange.all
+last = EventRange.last
+
 
 def event_range(string):
     try:

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -111,7 +111,7 @@ def neighbours(va : Voxel, vb : Voxel, contiguity : Contiguity = Contiguity.CORN
     return np.linalg.norm((va.pos - vb.pos) / va.size) < contiguity.value
 
 
-def make_track_graphs(voxels           : Voxel,
+def make_track_graphs(voxels           : Sequence[Voxel],
                       contiguity       : Contiguity = Contiguity.CORNER) -> Sequence[Graph]:
     """Create a graph where the voxels are the nodes and the edges are any
     pair of neighbour voxel. Two voxels are considered to be


### PR DESCRIPTION
The baheviour of configure.py is the same than before but, by splitting the double assignment into two different lines, the error raised by mypy when checking types of fanal, is fixed.