### PR TITLE
Drop voxels

### DIFF
--- a/invisible_cities/core/exceptions.py
+++ b/invisible_cities/core/exceptions.py
@@ -73,3 +73,6 @@ class SensorBinningNotFound(ICException):
 
 class NoParticleInfoInFile(ICException):
     pass
+
+class VoxelNotInList(ICException):
+    pass

--- a/invisible_cities/database/test_data/tracks_0000_6803_trigger2_v0.9.9_20190111_krth1600.h5
+++ b/invisible_cities/database/test_data/tracks_0000_6803_trigger2_v0.9.9_20190111_krth1600.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a14c705481b439961659f79811f837ef6f26a60b691eac6ca99412b14e046910
+size 35584

--- a/invisible_cities/evm/event_model.py
+++ b/invisible_cities/evm/event_model.py
@@ -189,6 +189,9 @@ class Voxel(BHit):
     @property
     def size(self): return self._size
 
+    @property
+    def Ehits(self): return sum(h.E for h in hits)
+
 
 class Cluster(BHit):
     """Represents a reconstructed cluster in the tracking plane"""

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -254,7 +254,7 @@ def drop_end_point_voxels(voxels: Sequence[Voxel], energy_threshold: float, min_
 
         ### add voxel energy to hit and to voxel, separately
         min_hit.energy += the_vox.E
-        min_v.energy += the_vox.E
+        min_v.energy   += the_vox.E
 
 
     mod_voxels = copy.deepcopy(voxels)

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -258,7 +258,8 @@ def drop_voxel(voxels: Sequence, the_vox: Voxel):
 
 
 def drop_end_point_voxels(voxels: Sequence[Voxel], energy_threshold: float, min_vxls: int):
-    """Eliminate voxels at the end-points of a track, if their energy is lower than a threshold"""
+    """Eliminate voxels at the end-points of a track, recursively,
+       if their energy is lower than a threshold"""
     while True:
         modified_voxels = 0
         trks = make_track_graphs(voxels)

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -236,7 +236,7 @@ def drop_end_point_voxels(voxels: Sequence[Voxel], energy_threshold: float, min_
         voxels.remove(the_vox)
 
         pos = [h.pos for h in the_vox.hits]
-        qs = [h.E for h in the_vox.hits]
+        qs  = [h.E for h in the_vox.hits]
         bary_pos = np.average(pos, weights=qs, axis=0)
 
         ### find hit with minimum distance, only among neighbours

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -236,7 +236,7 @@ def drop_end_point_voxels(voxels: Sequence[Voxel], energy_threshold: float, min_
         voxels.remove(the_vox)
 
         pos = [h.pos for h in the_vox.hits]
-        qs  = [h.E for h in the_vox.hits]
+        qs  = [h.E   for h in the_vox.hits]
         bary_pos = np.average(pos, weights=qs, axis=0)
 
         ### find hit with minimum distance, only among neighbours

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -2,6 +2,8 @@ from functools   import reduce
 from itertools   import combinations
 from enum        import Enum
 
+import copy
+
 import numpy    as np
 import networkx as nx
 
@@ -9,7 +11,6 @@ from networkx                   import Graph
 from .. evm.event_model         import Voxel
 from .. core.exceptions         import NoHits
 from .. core.exceptions         import NoVoxels
-from .. core.exceptions         import VoxelNotInList
 from .. evm.event_model         import BHit
 from .. evm.event_model         import Voxel
 from .. evm.event_model         import Track
@@ -222,60 +223,60 @@ def make_tracks(evt_number       : float,
     return tc
 
 
-def drop_voxel(voxels: Sequence, the_vox: Voxel):
-    """Eliminate an individual voxel from a set of voxels and give its energy to the hit
-       that is closest to the barycenter of the eliminated voxel hits, provided that it
-       belongs to a neighbour voxel."""
-    ### remove voxel from list of voxels
-    try:
-        voxels.remove(the_vox)
-    except ValueError:
-        raise VoxelNotInList
-
-    if len(voxels) == 0:
-        return
-
-    pos = [h.pos for h in the_vox.hits]
-    qs = [h.E for h in the_vox.hits]
-    bary_pos = np.average(pos, weights=qs, axis=0)
-
-    ### find hit with minimum distance, only among neighbours
-    min_dist = 1e+06
-    min_hit = voxels[0].hits[0]
-    min_v = voxels[0]
-    for v in voxels:
-        if neighbours(the_vox, v):
-            for hh in v.hits:
-                dist = np.linalg.norm(bary_pos - hh.pos)
-                if dist < min_dist:
-                    min_dist = dist
-                    min_hit = hh
-                    min_v = v
-
-    ### add voxel energy to hit and to voxel, separately
-    min_hit.energy += the_vox.E
-    min_v.energy += the_vox.E
-
-
-def drop_end_point_voxels(voxels: Sequence[Voxel], energy_threshold: float, min_vxls: int):
+def drop_end_point_voxels(voxels: Sequence[Voxel], energy_threshold: float, min_vxls: int = 3) -> Sequence[Voxel]:
     """Eliminate voxels at the end-points of a track, recursively,
        if their energy is lower than a threshold"""
+
+    def drop_voxel(voxels: Sequence[Voxel], the_vox: Voxel):
+        """Eliminate an individual voxel from a set of voxels and give its energy to the hit
+           that is closest to the barycenter of the eliminated voxel hits, provided that it
+           belongs to a neighbour voxel."""
+
+        ### remove voxel from list of voxels
+        voxels.remove(the_vox)
+
+        pos = [h.pos for h in the_vox.hits]
+        qs = [h.E for h in the_vox.hits]
+        bary_pos = np.average(pos, weights=qs, axis=0)
+
+        ### find hit with minimum distance, only among neighbours
+        min_dist = 1e+06
+        min_hit = voxels[0].hits[0]
+        min_v = voxels[0]
+        for v in voxels:
+            if neighbours(the_vox, v):
+                for hh in v.hits:
+                    dist = np.linalg.norm(bary_pos - hh.pos)
+                    if dist < min_dist:
+                        min_dist = dist
+                        min_hit = hh
+                        min_v = v
+
+        ### add voxel energy to hit and to voxel, separately
+        min_hit.energy += the_vox.E
+        min_v.energy += the_vox.E
+
+
+    mod_voxels = copy.deepcopy(voxels)
+
     while True:
-        modified_voxels = 0
-        trks = make_track_graphs(voxels)
-        vxl_size = voxels[0].size
+        n_modified_voxels = 0
+        trks = make_track_graphs(mod_voxels)
+        vxl_size = mod_voxels[0].size
 
         for t in trks:
             if len(t.nodes()) < min_vxls:
                 continue
 
             extr1, extr2 = find_extrema(t)
-            if extr1.E < energy_threshold:
-                modified_voxels += 1
-                drop_voxel(voxels, extr1)
-            if extr2.E < energy_threshold:
-                modified_voxels += 1
-                drop_voxel(voxels, extr2)
+            if extr1.E < energy_threshold and len(t.nodes()) > 1:
+                n_modified_voxels += 1
+                drop_voxel(mod_voxels, extr1)
+            if extr2.E < energy_threshold and len(t.nodes()) > 1:
+                n_modified_voxels += 1
+                drop_voxel(mod_voxels, extr2)
 
-        if modified_voxels == 0:
+        if n_modified_voxels == 0:
             break
+
+    return mod_voxels

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -265,8 +265,6 @@ def drop_end_point_voxels(voxels: Sequence[Voxel], energy_threshold: float, min_
 
         return 1
 
-
-
     mod_voxels = copy.deepcopy(voxels)
 
     while True:

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -486,10 +486,15 @@ def test_initial_voxels_are_the_same_after_dropping_voxels(ICDATADIR):
 
     # This is the core of the test: collect data before/after ...
     ante_energies  = [v.E   for v in voxels]
-    ante_positions = [v.pos for v in voxels]
+    ante_positions = [v.XYZ for v in voxels]
     mod_voxels = drop_end_point_voxels(voxels, e_thr, min_voxels)
     post_energies  = [v.E   for v in voxels]
-    post_positions = [v.pos for v in voxels]
+    post_positions = [v.XYZ for v in voxels]
+
+    ante_energies.sort()
+    post_energies.sort()
+    ante_positions.sort()
+    post_positions.sort()
 
     # ... and make sure that nothing has changed
     assert len(ante_energies)  == len(post_energies)
@@ -522,6 +527,9 @@ def test_tracks_with_dropped_voxels(ICDATADIR):
     n_voxels = np.array([len(t.nodes()) for t in trks])
 
     expected_diff_n_voxels = np.array([0, 0, 2])
+
+    ini_energies.sort()
+    energies.sort()
 
     assert initial_n_of_tracks == n_of_tracks
     assert np.allclose(ini_energies, energies)

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -2,7 +2,6 @@ import os
 
 from math      import sqrt
 from functools import partial
-import random
 
 import tables as tb
 import numpy    as np
@@ -70,8 +69,10 @@ box_sizes = builds(np.array, lists(box_dimension,
 
 eps = 3e-12 # value that works for margin
 
+fraction_zero_one = floats(min_value = 0,
+                           max_value = 1)
 min_n_of_voxels = integers(min_value = 3,
-                       max_value = 10)
+                           max_value = 10)
 
 
 def test_voxelize_hits_should_detect_no_hits():
@@ -467,7 +468,7 @@ def test_energy_is_conserved_if_voxel_is_dropped(hits, requested_voxel_dimension
         return
 
 
-@given(bunch_of_hits, box_sizes)
+@given(bunch_of_hits, box_sizes, min_n_of_voxels, fraction_zero_one)
 def test_voxel_is_dropped(hits, requested_voxel_dimensions):
     voxels = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False)
     n_starting_voxels = len(voxels)
@@ -477,13 +478,13 @@ def test_voxel_is_dropped(hits, requested_voxel_dimensions):
     assert len(voxels) == n_starting_voxels - 1
 
 
-@given(bunch_of_hits, box_sizes, min_n_of_voxels)
-def test_total_energy_is_conserved(hits, requested_voxel_dimensions, min_voxels):
+@given(bunch_of_hits, box_sizes, min_n_of_voxels, fraction_zero_one)
+def test_total_energy_is_conserved(hits, requested_voxel_dimensions, min_voxels, fraction_zero_one):
 
     tot_initial_energy = sum(h.E for h in hits)
     voxels = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False)
     energies = [v.E for v in voxels]
-    e_thr = random.uniform(min(energies), max(energies))
+    e_thr = min(energies) + fraction_zero_one * (max(energies) - min(energies))
     drop_end_point_voxels(voxels, e_thr, min_voxels)
     tot_final_energy = sum(v.E for v in voxels)
 

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -472,27 +472,30 @@ def test_energy_is_conserved_with_dropped_voxels(hits, requested_voxel_dimension
 
 
 def test_initial_voxels_are_the_same_after_dropping_voxels(ICDATADIR):
+
+    # Get some test data: nothing interesting to see here
     hit_file = os.path.join(ICDATADIR, 'tracks_0000_6803_trigger2_v0.9.9_20190111_krth1600.h5')
     evt_number = 19
     e_thr = 5867.92
     min_voxels = 3
     size = 15.
-    vox_size = np.array([size,size,size],dtype=np.float16)
-
+    vox_size = np.array([size,size,size], dtype=np.float16)
     all_hits = load_hits(hit_file)
     hits = all_hits[evt_number].hits
     voxels = voxelize_hits(hits, vox_size, strict_voxel_size=False)
-    ini_energies = [v.E for v in voxels]
-    ini_pos      = [v.pos for v in voxels]
+
+    # This is the core of the test: collect data before/after ...
+    ante_energies  = [v.E   for v in voxels]
+    ante_positions = [v.pos for v in voxels]
     mod_voxels = drop_end_point_voxels(voxels, e_thr, min_voxels)
+    post_energies  = [v.E   for v in voxels]
+    post_positions = [v.pos for v in voxels]
 
-    final_energies = [v.E for v in voxels]
-    final_pos      = [v.pos for v in voxels]
-
-    assert len(ini_energies) == len(final_energies)
-    assert np.allclose(ini_energies, final_energies)
-    assert len(ini_pos) == len(final_pos)
-    assert np.allclose(ini_pos, final_pos)
+    # ... and make sure that nothing has changed
+    assert len(ante_energies)  == len(post_energies)
+    assert len(ante_positions) == len(post_positions)
+    assert np.allclose(ante_energies,  post_energies)
+    assert np.allclose(ante_positions, post_positions)
 
 
 def test_tracks_with_dropped_voxels(ICDATADIR):

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -2,6 +2,7 @@ import os
 
 from math      import sqrt
 from functools import partial
+import random
 
 import tables as tb
 import numpy    as np
@@ -39,6 +40,7 @@ from . paolina_functions import make_track_graphs
 from . paolina_functions import voxels_from_track_graph
 from . paolina_functions import length
 from . paolina_functions import Contiguity
+from . paolina_functions import drop_voxel
 
 from .. core.exceptions import NoHits
 from .. core.exceptions import NoVoxels
@@ -443,4 +445,28 @@ def test_contiguity(proximity, contiguity, are_neighbours):
     tracks = make_track_graphs(voxels, contiguity=contiguity)
 
     assert len(tracks) == expected_number_of_tracks
+
+
+@given(bunch_of_hits, box_sizes)
+def test_energy_is_conserved_if_voxel_is_dropped(hits, requested_voxel_dimensions):
+    voxels = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False)
+    tot_energy = sum(v.E for v in voxels)
+    voxel_to_drop = random.choice(voxels)
+    drop_voxel(voxels, voxel_to_drop)
+    tot_energy_drop = sum(v.E for v in voxels)
+
+    if len(voxels) > 0:
+        assert tot_energy == approx(tot_energy_drop)
+    else:
+        return
+
+
+@given(bunch_of_hits, box_sizes)
+def test_voxel_is_dropped(hits, requested_voxel_dimensions):
+    voxels = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False)
+    n_starting_voxels = len(voxels)
+    voxel_to_drop = random.choice(voxels)
+    drop_voxel(voxels, voxel_to_drop)
+
+    assert len(voxels) == n_starting_voxels - 1
     

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -454,7 +454,7 @@ def test_contiguity(proximity, contiguity, are_neighbours):
 
 
 @given(bunch_of_hits, box_sizes, min_n_of_voxels, fraction_zero_one)
-def test_energy_is_conserved(hits, requested_voxel_dimensions, min_voxels, fraction_zero_one):
+def test_energy_is_conserved_with_dropped_voxels(hits, requested_voxel_dimensions, min_voxels, fraction_zero_one):
     tot_initial_energy = sum(h.E for h in hits)
     voxels = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False)
     ini_trks = make_track_graphs(voxels)

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -471,6 +471,30 @@ def test_energy_is_conserved_with_dropped_voxels(hits, requested_voxel_dimension
     assert np.allclose(ini_trk_energies, final_trk_energies)
 
 
+def test_initial_voxels_are_the_same_after_dropping_voxels(ICDATADIR):
+    hit_file = os.path.join(ICDATADIR, 'tracks_0000_6803_trigger2_v0.9.9_20190111_krth1600.h5')
+    evt_number = 19
+    e_thr = 5867.92
+    min_voxels = 3
+    size = 15.
+    vox_size = np.array([size,size,size],dtype=np.float16)
+
+    all_hits = load_hits(hit_file)
+    hits = all_hits[evt_number].hits
+    voxels = voxelize_hits(hits, vox_size, strict_voxel_size=False)
+    ini_energies = [v.E for v in voxels]
+    ini_pos      = [v.pos for v in voxels]
+    mod_voxels = drop_end_point_voxels(voxels, e_thr, min_voxels)
+
+    final_energies = [v.E for v in voxels]
+    final_pos      = [v.pos for v in voxels]
+
+    assert len(ini_energies) == len(final_energies)
+    assert np.allclose(ini_energies, final_energies)
+    assert len(ini_pos) == len(final_pos)
+    assert np.allclose(ini_pos, final_pos)
+
+
 def test_tracks_with_dropped_voxels(ICDATADIR):
     hit_file = os.path.join(ICDATADIR, 'tracks_0000_6803_trigger2_v0.9.9_20190111_krth1600.h5')
     evt_number = 19

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -526,4 +526,14 @@ def test_tracks_with_dropped_voxels(ICDATADIR):
     assert initial_n_of_tracks == n_of_tracks
     assert np.allclose(ini_energies, energies)
     assert np.all(ini_n_voxels - n_voxels == expected_diff_n_voxels)
-    
+
+
+def test_voxel_drop_in_short_tracks():
+    hits = [BHit(10, 10, 10, 1), BHit(26, 10, 10, 1)]
+    voxels = voxelize_hits(hits, [15,15,15], strict_voxel_size=True)
+    e_thr = sum(v.E for v in voxels) + 1.
+    min_voxels = 0
+
+    mod_voxels = drop_end_point_voxels(voxels, e_thr, min_voxels)
+
+    assert len(mod_voxels) >= 1


### PR DESCRIPTION
In this PR a couple of functions are added to paolina, which allow one to eliminate voxels from a track, with energy lower than a threshold, and redistribute their energy among the closest voxels.
The function `drop_end_point_voxels` modifies the `voxels` argument.
I would require a review from @ausonandres, because he knows the algorithm, but he hasn't taken part in this particular implementation, and @mmkekic for an outsider view.