### PR TITLE
Added rebin_method option to penthesilea

### DIFF
--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -410,7 +410,7 @@ def split_energy(total_e, clusters):
     return total_e * qs / np.sum(qs)
 
 
-def hit_builder(dbfile, run_number, drift_v, reco, rebin_slices):
+def hit_builder(dbfile, run_number, drift_v, reco, rebin_slices, rebin_method):
     datasipm = load_db.DataSiPM(dbfile, run_number)
     sipm_xs  = datasipm.X.values
     sipm_ys  = datasipm.Y.values
@@ -446,7 +446,7 @@ def hit_builder(dbfile, run_number, drift_v, reco, rebin_slices):
                                                      pmap.s2s)):
             if not passed: continue
 
-            peak = pmf.rebin_peak(peak, rebin_slices)
+            peak = pmf.rebin_peak(peak, rebin_slices, rebin_method)
 
             xys     = sipm_xys[peak.sipms.ids           ]
             qs      =          peak.sipms.sum_over_times

--- a/invisible_cities/cities/penthesilea.py
+++ b/invisible_cities/cities/penthesilea.py
@@ -27,9 +27,10 @@ from operator import attrgetter
 
 import tables as tb
 
-from .. database       import load_db
-from .. core.system_of_units_c import units
-from .. reco                   import tbl_functions        as tbl
+from .. database               import              load_db
+from .. core.system_of_units_c import                units
+from .. reco                   import        tbl_functions as tbl
+from .. reco. pmaps_functions  import          RebinMethod
 from .. io  .         hits_io  import          hits_writer
 from .. io  .       mcinfo_io  import       mc_info_writer
 from .. io  .run_and_event_io  import run_and_event_writer
@@ -54,7 +55,8 @@ def penthesilea(files_in, file_out, compression, event_range, print_mod, detecto
                 s1_nmin, s1_nmax, s1_emin, s1_emax, s1_wmin, s1_wmax, s1_hmin, s1_hmax, s1_ethr,
                 s2_nmin, s2_nmax, s2_emin, s2_emax, s2_wmin, s2_wmax, s2_hmin, s2_hmax, s2_ethr, s2_nsipmmin, s2_nsipmmax,
                 slice_reco_params  = dict(),
-                global_reco_params = dict()):
+                global_reco_params = dict(),
+                rebin_method       = 'stride'):
     #  slice_reco_params are qth, qlm, lm_radius, new_lm_radius, msipm used for hits reconstruction
     # global_reco_params are qth, qlm, lm_radius, new_lm_radius, msipm used for overall global (pointlike event) reconstruction
 
@@ -67,7 +69,7 @@ def penthesilea(files_in, file_out, compression, event_range, print_mod, detecto
     pmap_select           = df.count_filter(bool, args="pmap_passed")
 
     reco_algo_slice       = compute_xy_position(detector_db, **slice_reco_params)
-    build_hits            = df.map(hit_builder(detector_db, run_number, drift_v, reco_algo_slice, rebin),
+    build_hits            = df.map(hit_builder(detector_db, run_number, drift_v, reco_algo_slice, rebin, RebinMethod[rebin_method]),
                                    args = ("pmap", "selector_output", "event_number", "timestamp"),
                                    out  = "hits"                                                 )
     reco_algo_global      = compute_xy_position(detector_db, **global_reco_params)

--- a/invisible_cities/cities/penthesilea_test.py
+++ b/invisible_cities/cities/penthesilea_test.py
@@ -44,6 +44,7 @@ def test_penthesilea_KrMC(KrMC_pmaps_filename, KrMC_hdst, KrMC_kdst, config_tmpd
     assert_dataframes_close(df_penthesilea_dst , DF_TRUE_DST ,
                             check_types=False, rtol=1e-4)
 
+
 def test_penthesilea_filter_events(config_tmpdir, Kr_pmaps_run4628_filename):
     PATH_IN =  Kr_pmaps_run4628_filename
 
@@ -109,6 +110,30 @@ def test_penthesilea_filter_events(config_tmpdir, Kr_pmaps_run4628_filename):
     assert np.all(df_penthesilea_dst.event  .values ==  events_pass_dst)
     assert np.all(df_penthesilea_dst.s1_peak.values == s1_peak_pass_dst)
     assert np.all(df_penthesilea_dst.s2_peak.values == s2_peak_pass_dst)
+
+
+def test_penthesilea_threshold_rebin(ICDATADIR, output_tmpdir):
+    file_in     = os.path.join(ICDATADIR    ,            "Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts.PMP.h5")
+    file_out    = os.path.join(output_tmpdir,                   "exact_result_penthesilea_rebin4000.h5")
+    true_output = os.path.join(ICDATADIR    , "Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts_rebin4000.HDST.h5")
+
+    conf        = configure('dummy invisible_cities/config/penthesilea.conf'.split())
+    rebin_thresh = 4000
+    
+    conf.update(dict(run_number      =        -6340,
+                     files_in        =      file_in,
+                     file_out        =     file_out,
+                     event_range     =   all_events,
+                     rebin           = rebin_thresh,
+                     rebin_method    =  'threshold'))
+
+    cnt = penthesilea(**conf)
+
+    output_dst   = dio.load_dst(file_out   , 'RECO', 'Events')
+    expected_dst = dio.load_dst(true_output, 'RECO', 'Events')
+
+    assert len(set(output_dst.event)) == len(set(expected_dst.event))
+    assert_dataframes_close(output_dst, expected_dst, check_types=False)
 
 
 @mark.serial

--- a/invisible_cities/database/test_data/Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts_rebin4000.HDST.h5
+++ b/invisible_cities/database/test_data/Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts_rebin4000.HDST.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c7c188b99154dc7a024acd05bd8b5d0030e9fdc72f6ac7e3f52421848dd33b6
+size 79956


### PR DESCRIPTION
Adds the possibility to rebin PMaps
using the new threshold method using
a configuration option.

stride option as default for backwards
compatibility.