### PR TITLE
Updates on database code for different detectors

### DIFF
--- a/invisible_cities/conftest.py
+++ b/invisible_cities/conftest.py
@@ -23,6 +23,7 @@ dst_data = namedtuple('dst_data', 'file_info config read true')
 pmp_dfs  = namedtuple('pmp_dfs' , 's1 s2 si, s1pmt, s2pmt')
 pmp_data = namedtuple('pmp_data', 's1 s2 si')
 mcs_data = namedtuple('mcs_data', 'pmap hdst')
+db_data  = namedtuple('db_data', 'detector npmts nsipms feboxes nfreqs')
 
 
 @pytest.fixture(scope = 'session')
@@ -659,9 +660,21 @@ def voxels_toy_data(ICDATADIR):
 
 
 @pytest.fixture(scope='session')
+def dbdemopp():
+    return 'demopp'
+
+@pytest.fixture(scope='session')
 def dbnew():
     return 'new'
 
 @pytest.fixture(scope='session')
-def dbdemopp():
-    return 'demo'
+def dbnext100():
+    return 'next100'
+
+@pytest.fixture(scope='session',
+                params=[db_data('demopp' ,  3,  256, 3, 79),
+                        db_data('new'    , 12, 1792, 3, 79),
+                        db_data('next100', 60, 6848, 8, 79)],
+               ids=["demo", "new", "next100"])
+def db(request):
+    return request.param

--- a/invisible_cities/database/download.py
+++ b/invisible_cities/database/download.py
@@ -1,140 +1,82 @@
 import sqlite3
 import sys
 import pymysql
-import pymysql as MySQLdb
 pymysql.install_as_MySQLdb()
 import os
+import re
 from os import path
 
+
+tables = ['DetectorGeo','PmtBlr','ChannelGain','ChannelMapping','ChannelMask',
+          'PmtNoiseRms','ChannelPosition','SipmBaseline', 'SipmNoisePDF',
+          'PMTFEMapping', 'PMTFELowFrequencyNoise']
+
+
+def create_table_sqlite(cursorSqlite, cursorMySql, table):
+    cursorMySql.execute('show create table {}'.format(table))
+    data = cursorMySql.fetchone()
+    sql  = data[1]
+
+    # show create table will include comments for each row
+    # Example: `MinRun` int(11) NOT NULL COMMENT 'Minimum run number for which valid'
+    # that is not compatible with sqlite3, so we remove it.
+    sql = re.sub(r" COMMENT\s+\'.*\'", "", sql)
+
+    # it will also include: ENGINE=MyISAM DEFAULT CHARSET=latin1
+    # this is not compatible either, so we remove it.
+    sql = re.sub(r"\s*ENGINE.*", "", sql)
+
+    # some tables may have KEYs defined: KEY `ElecID` (`SensorID`)
+    # this syntax is different, so we remove it too.
+    # This happens for instance in table ChannelGain
+    sql = re.sub(r",\s*\n\s*KEY.*[\n,]", "", sql)
+
+    cursorSqlite.execute(sql)
+
+
+def copy_all_rows(connSqlite, cursorSqlite, cursorMySql, table):
+    # Get all data
+    cursorMySql.execute('SELECT * from {0}'.format(table))
+    data = cursorMySql.fetchall()
+
+    # Insert all rows
+    fields = '?'
+    try:
+        nfields = len(data[0])
+        fields += (nfields-1) * ',?'
+        cursorSqlite.executemany('INSERT INTO {0} VALUES({1})'.format(table,fields),data)
+        connSqlite.commit()
+    except IndexError:
+        print('Table ' +table+' is empty.')
+
+
 def loadDB(dbname : str):
+    print("Cloning database {}".format(dbname))
     dbfile = path.join(os.environ['ICDIR'], 'database/localdb.'+dbname+'.sqlite3')
     try:
         os.remove(dbfile)
     except:
         pass
 
-    connSql3 = sqlite3.connect(dbfile)
-    cursorSql3 = connSql3.cursor()
+    connSqlite = sqlite3.connect(dbfile)
+    connMySql  = pymysql.connect(host="neutrinos1.ific.uv.es",
+                                user='nextreader',passwd='readonly', db=dbname)
 
+    cursorMySql  = connMySql .cursor()
+    cursorSqlite = connSqlite.cursor()
 
-    connMySql = MySQLdb.connect(host="neutrinos1.ific.uv.es", user='nextreader',passwd='readonly', db=dbname)
-    cursorMySql = connMySql.cursor()
-
-    # Create tables
-    cursorSql3.execute('''CREATE TABLE IF NOT EXISTS `DetectorGeo` (
-  `XMIN` float NOT NULL
-,  `XMAX` float NOT NULL
-,  `YMIN` float NOT NULL
-,  `YMAX` float NOT NULL
-,  `ZMIN` float NOT NULL
-,  `ZMAX` float NOT NULL
-,  `RMAX` float NOT NULL
-);''')
-
-    cursorSql3.execute('''CREATE TABLE IF NOT EXISTS `ChannelGain` (
-  `MinRun` integer NOT NULL
-,  `MaxRun` integer NOT NULL
-,  `SensorID` integer NOT NULL
-,  `Centroid` float NOT NULL
-,  `ErrorCentroid` float NOT NULL
-,  `Sigma` float NOT NULL
-,  `ErrorSigma` float NOT NULL
-);''')
-
-    cursorSql3.execute('''CREATE TABLE IF NOT EXISTS `ChannelMask` (
-  `MinRun` integer NOT NULL
-,  `MaxRun` integer NOT NULL
-,  `SensorID` integer NOT NULL
-);''')
-
-    cursorSql3.execute('''CREATE TABLE IF NOT EXISTS `ChannelMapping` (
-  `MinRun` integer NOT NULL
-,  `MaxRun` integer NOT NULL
-,  `ElecID` integer NOT NULL
-,  `SensorID` integer NOT NULL
-);''')
-
-    cursorSql3.execute('''CREATE TABLE IF NOT EXISTS `ChannelPosition` (
-  `MinRun` integer NOT NULL
-,  `MaxRun` integer NOT NULL
-,  `SensorID` integer NOT NULL
-,  `Label` varchar(20) NOT NULL
-,  `Type` varchar(20) NOT NULL
-,  `X` float NOT NULL
-,  `Y` float NOT NULL
-);''')
-
-    cursorSql3.execute('''CREATE TABLE IF NOT EXISTS `PmtBlr` (
-  `MinRun` integer NOT NULL
-,  `MaxRun` integer DEFAULT NULL
-,  `ElecID` integer NOT NULL
-,  `coeff_c` double NOT NULL
-,  `coeff_blr` double NOT NULL
-);''')
-
-    cursorSql3.execute('''CREATE TABLE IF NOT EXISTS `PmtNoiseRms` (
-  `MinRun` integer NOT NULL
-,  `MaxRun` integer DEFAULT NULL
-,  `ElecID` integer NOT NULL
-,  `noise_rms` double NOT NULL
-);''')
-
-
-    cursorSql3.execute('''CREATE TABLE IF NOT EXISTS `SipmBaseline` (
-  `MinRun` integer NOT NULL
-,  `MaxRun` integer DEFAULT NULL
-,  `SensorID` integer NOT NULL
-,  `Energy` float NOT NULL
-);''')
-
-    cursorSql3.execute('''CREATE TABLE IF NOT EXISTS `SipmNoisePDF` (
-  `MinRun` integer NOT NULL
-,  `MaxRun` integer DEFAULT NULL
-,  `SensorID` integer NOT NULL
-,  `BinEnergyPes` float NOT NULL
-,  `Probability` float NOT NULL
-);''')
-
-    cursorSql3.execute('''CREATE TABLE IF NOT EXISTS `PMTFEMapping` (
-    `MinRun` integer NOT NULL
-,  `MaxRun` integer NOT NULL
-,  `SensorID` integer NOT NULL
-,  `FEBox` integer NOT NULL
-);''')
-
-    cursorSql3.execute('''CREATE TABLE IF NOT EXISTS `PMTFELowFrequencyNoise` (
-    `MinRun` integer NOT NULL
-,  `MaxRun` integer NOT NULL
-,  `Frequency` float NOT NULL
-,  `FE0Magnitude` float NOT NULL
-,  `FE1Magnitude` float NOT NULL
-,  `FE2Magnitude` float NOT NULL
-);''')
-
-
-    tables = ['DetectorGeo','PmtBlr','ChannelGain','ChannelMapping','ChannelMask',
-              'PmtNoiseRms','ChannelPosition','SipmBaseline', 'SipmNoisePDF',
-              'PMTFEMapping', 'PMTFELowFrequencyNoise']
-
-
-    # Copy all tables
     for table in tables:
-        # Get all data
-        cursorMySql.execute('SELECT * from {0}'.format(table))
-        data = cursorMySql.fetchall()
+        print("Downloading table {}".format(table))
 
-        # Insert all rows
-        fields = '?'
-        try:
-            nfields = len(data[0])
-            fields += (nfields-1) * ',?'
-            cursorSql3.executemany('INSERT INTO {0} VALUES({1})'.format(table,fields),data)
-            connSql3.commit()
-        except IndexError:
-            print('Table ' +table+' is empty.')
+        # Create table
+        create_table_sqlite(cursorSqlite, cursorMySql, table)
+
+        # Copy data
+        copy_all_rows(connSqlite, cursorSqlite, cursorMySql, table)
+
 
 if __name__ == '__main__':
-    dbname = ['NEWDB','DEMOPPDB']
+    dbname = ['NEWDB', 'DEMOPPDB', 'NEXT100DB']
     if len(sys.argv) > 1:
         dbname = sys.argv[1]
         loadDB(dbname)

--- a/invisible_cities/database/download_test.py
+++ b/invisible_cities/database/download_test.py
@@ -1,0 +1,29 @@
+import os
+
+import sqlite3
+import pymysql
+pymysql.install_as_MySQLdb()
+
+from pytest import mark
+
+from . import download as db
+
+@mark.parametrize('dbname', 'DEMOPPDB NEWDB NEXT100DB'.split())
+def test_create_table_sqlite(dbname, output_tmpdir):
+    dbfile = os.path.join(output_tmpdir, 'db.sqlite3')
+
+    if os.path.isfile(dbfile):
+        os.remove(dbfile)
+
+    dbname = 'NEXT100DB'
+    table = 'PmtBlr'
+
+    connSqlite = sqlite3.connect(dbfile)
+    connMySql  = pymysql.connect(host="neutrinos1.ific.uv.es",
+                                user='nextreader',passwd='readonly', db=dbname)
+
+    cursorMySql  = connMySql .cursor()
+    cursorSqlite = connSqlite.cursor()
+
+    for table in db.tables:
+        db.create_table_sqlite(cursorSqlite, cursorMySql, table)

--- a/invisible_cities/database/load_db.py
+++ b/invisible_cities/database/load_db.py
@@ -129,9 +129,16 @@ def PMTLowFrequencyNoise(db_file, run_number=1e5):
     mapping = pd.read_sql_query(sqlmapping, conn)
 
     ## Now get the frequencies and magnitudes (and ?) for each box
-    sqlmagnitudes = '''select Frequency, FE0Magnitude, FE1Magnitude, FE2Magnitude
-    from PMTFELowFrequencyNoise where MinRun <= {0}
-    and (MaxRun >= {0} or MaxRun is NULL)'''.format(abs(run_number))
+    ## Number of boxes can be different for different detectors, so we need to
+    ## find out how many columns are there in the table
+    sql = '''PRAGMA table_info('PMTFELowFrequencyNoise');'''
+    schema = pd.read_sql_query(sql, conn)
+    colnames = schema.name[schema.name.str.contains("FE")].values
+    colnames = ', '.join(colnames)
+
+    sqlmagnitudes = '''select Frequency, {0}
+    from PMTFELowFrequencyNoise where MinRun <= {1}
+    and (MaxRun >= {1} or MaxRun is NULL)'''.format(colnames, abs(run_number))
     frequencies = pd.read_sql_query(sqlmagnitudes, conn)
 
     return mapping, frequencies.values

--- a/invisible_cities/database/load_db.py
+++ b/invisible_cities/database/load_db.py
@@ -7,8 +7,9 @@ from functools import lru_cache
 
 
 class DetDB:
-    new    = os.environ['ICTDIR'] + '/invisible_cities/database/localdb.NEWDB.sqlite3'
-    demopp = os.environ['ICTDIR'] + '/invisible_cities/database/localdb.DEMOPPDB.sqlite3'
+    new     = os.environ['ICTDIR'] + '/invisible_cities/database/localdb.NEWDB.sqlite3'
+    demopp  = os.environ['ICTDIR'] + '/invisible_cities/database/localdb.DEMOPPDB.sqlite3'
+    next100 = os.environ['ICTDIR'] + '/invisible_cities/database/localdb.NEXT100DB.sqlite3'
 
 def tmap(*args):
     return tuple(map(*args))

--- a/invisible_cities/database/localdb.DEMOPPDB.sqlite3
+++ b/invisible_cities/database/localdb.DEMOPPDB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0cb869bcde6ca9ae401aa0e230a02c31e4c4bfda97d112c4128187d697e8b43e
+oid sha256:8712a6eb771892c3c4a98c018dc006f99efe9f99b4b1876b8a01e233d461743c
 size 2482176

--- a/invisible_cities/database/localdb.NEXT100DB.sqlite3
+++ b/invisible_cities/database/localdb.NEXT100DB.sqlite3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19738c2f5a59229a17625808f4de170fb63f7691b772db28a17f16255dd935d5
+size 82366464

--- a/manage.sh
+++ b/manage.sh
@@ -211,11 +211,6 @@ function download_test_db {
     python $ICDIR/database/download.py
 }
 
-function download_test_db_dev {
-    echo Downloading dev database
-    python $ICDIR/database/download.py NEWDB_dev
-}
-
 function compile_cython_components {
     python setup.py develop
 }
@@ -265,7 +260,6 @@ case $COMMAND in
     compile_and_test)                compile_and_test ;;
     compile_and_test_par)            compile_and_test_par ;;
     download_test_db)                download_test_db ;;
-    download_test_db_dev)            download_test_db_dev ;;
     clean)                           clean ;;
     show_ic_env)                     show_ic_env ;;
 
@@ -284,7 +278,6 @@ case $COMMAND in
        echo "bash   $THIS compile_and_test"
        echo "bash   $THIS compile_and_test_par"
        echo "bash   $THIS download_test_db"
-       echo "bash   $THIS download_test_db_dev"
        echo "bash   $THIS clean"
        echo "bash   $THIS show_ic_env"
        ;;


### PR DESCRIPTION
To be compatible with different detectors, the code must be able of reading different schemas for the same tables. For instance, `PMTFELowFrequencyNoise` has one column per FE box, so this is different for different detectors. So now the DB downloader will get the table definition from MySQL server instead of being hardcoded in `download.py`. This change also simplifies a lot the code to clone databases.

New tests has been added to check this ability of getting table schemas from the server.

Tests for `load_db` are now parametrized and will run for DEMOPP, NEW and NEXT100.

NEXT100 database has been updated to include all the tables needed by IC, in particular the ones related to the BLR and sensor calibrations. The values included are averages of NEW values. For example, PMTs gains are set to 24.75, SiPM gains to 17.25, etc. This PR adds the sqlite3 copy of NEXT100 DB too.
