### PR TITLE
Fix bug in cal functions related to detector type

### DIFF
--- a/invisible_cities/reco/calib_functions.py
+++ b/invisible_cities/reco/calib_functions.py
@@ -273,7 +273,7 @@ def compute_seeds_from_spectrum(sens_values, bins, ped_vals):
 
 
 def seeds_and_bounds(sensor_type, run_no, n_chann, scaler, bins, spectrum, ped_vals,
-                     ped_errs, func='dfunc', use_db_gain_seeds=True):
+                     detector, ped_errs, func='dfunc', use_db_gain_seeds=True):
     """ Define the seeds and bounds to be used for calibration fits.
 
         Parameters
@@ -292,6 +292,8 @@ def seeds_and_bounds(sensor_type, run_no, n_chann, scaler, bins, spectrum, ped_v
         Spectra, charge values of the signal.
         ped_vals      : np.array
         Values for the pedestal fit.
+        detector      : string
+        Input for the used detector.
         ped_errs      : np.array
         Errors of the values for the pedestal fit.
         func          : callable, optional
@@ -311,7 +313,7 @@ def seeds_and_bounds(sensor_type, run_no, n_chann, scaler, bins, spectrum, ped_v
     norm_seed = spectrum.sum()
     sens_values = sensor_values(sensor_type, scaler, bins, spectrum, ped_vals)
     if use_db_gain_seeds:
-        gain_seed, gain_sigma_seed = seeds_db(sensor_type, run_no, n_chann)
+        gain_seed, gain_sigma_seed = seeds_db(sensor_type, detector, run_no, n_chann)
 
     else:
         gain_seed, gain_sigma_seed = compute_seeds_from_spectrum(sens_values, bins, ped_vals)

--- a/invisible_cities/reco/calib_functions.py
+++ b/invisible_cities/reco/calib_functions.py
@@ -278,8 +278,8 @@ def seeds_and_bounds(sensor_type, run_no, n_chann, scaler, bins, spectrum, ped_v
 
         Parameters
         ----------
-        sensor_type   : string
-        Input of type of sensor: sipm or pmt.
+        sensor_type   : AutoNameEnumBase
+        Input of type of sensor: SensorType.SIPM or SensorType.PMT.
         run_no        : int
         Run number.
         n_chann       : int

--- a/invisible_cities/reco/calib_functions_test.py
+++ b/invisible_cities/reco/calib_functions_test.py
@@ -289,7 +289,7 @@ def test_compute_seeds_from_spectrum(ICDATADIR):
         assert gain_sigma_seed != 0
 
 
-def test_seeds_without_using_db(ICDATADIR):
+def test_seeds_without_using_db(ICDATADIR, dbnew):
     PATH_IN = os.path.join(ICDATADIR, 'sipmcalspectra_R6358.h5')
     h5in    = tb.open_file(PATH_IN, 'r')
     run_no  = get_run_number(h5in)
@@ -326,7 +326,7 @@ def test_seeds_without_using_db(ICDATADIR):
         scaler_func   = cf.dark_scaler(dar[p_range][p_bins])
         seeds, bounds = cf.seeds_and_bounds(SensorType.SIPM, run_no, ich,
                                             scaler_func, bins[p_range], led[p_range],
-                                            ped_vals, gfitRes.errors,
+                                            ped_vals, dbnew, gfitRes.errors,
                                             use_db_gain_seeds=False)
         assert all(seeds)
         assert bounds == ((0, 0, 0, 0.001), (np.inf, 10000, 10000, 10000))


### PR DESCRIPTION
This PR fix a bug that remained after PR of compatibility for different detector was approved. In the function seeds_db there was not the type of detector argument.