### PR TITLE
Change blob definition

### DIFF
--- a/invisible_cities/evm/event_model.py
+++ b/invisible_cities/evm/event_model.py
@@ -292,18 +292,18 @@ class VoxelCollection:
         return self.__str__()
 
 
-class Blob(VoxelCollection):
-    """A Blob is a collection of Voxels which adds the energy of the blob. """
-    def __init__(self, a: Voxel, voxels : List[Voxel]) ->None:
-        super().__init__(voxels)
-        self.seed = a
+class Blob():
+    """A Blob is a collection of Hits which adds the energy of the blob. """
+    def __init__(self, a: Tuple[float], hits : List[BHit], radius : float) ->None:
+        super().__init__(hits)
+        self.seed   = a
+        self.radius = radius
 
     def __str__(self):
-        s =  """Blob: (number of voxels = {})\n,
-                voxels = {} \n
+        s =  """Blob: (hits = {} \n
                 seed   = {} \n
                 blob energy = {}
-        """.format(self.number_of_voxels, self.voxels, self.seed, self.E)
+        """.format(self.hits, self.seed, sum(h.E for h in hits))
 
         return  s
 

--- a/invisible_cities/evm/event_model.py
+++ b/invisible_cities/evm/event_model.py
@@ -294,9 +294,9 @@ class VoxelCollection:
 
 class Blob():
     """A Blob is a collection of Hits with a seed and a radius. """
-    def __init__(self, a: Tuple[float], hits : List[BHit], radius : float) ->None:
+    def __init__(self, seed: Tuple[float, float, float], hits : List[BHit], radius : float) ->None:
         super().__init__(hits)
-        self.seed   = a
+        self.seed   = seed
         self.hits   = hits
         self.energy = sum(h.E for h in hits)
         self.radius = radius

--- a/invisible_cities/evm/event_model.py
+++ b/invisible_cities/evm/event_model.py
@@ -293,17 +293,20 @@ class VoxelCollection:
 
 
 class Blob():
-    """A Blob is a collection of Hits which adds the energy of the blob. """
+    """A Blob is a collection of Hits with a seed and a radius. """
     def __init__(self, a: Tuple[float], hits : List[BHit], radius : float) ->None:
         super().__init__(hits)
         self.seed   = a
+        self.hits   = hits
+        self.energy = sum(h.E for h in hits)
         self.radius = radius
 
     def __str__(self):
         s =  """Blob: (hits = {} \n
                 seed   = {} \n
-                blob energy = {}
-        """.format(self.hits, self.seed, sum(h.E for h in hits))
+                blob energy = {} \n
+                blob radius = {}
+        """.format(self.hits, self.seed, self.energy, self.radius)
 
         return  s
 

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -230,6 +230,11 @@ def blob_energies(track_graph : Graph, radius : float) -> Tuple[float, float]:
     Ea = sum(h.E for h in ha)
     Eb = sum(h.E for h in hb)
 
+    # Consider the case where voxels are built without associated hits
+    if len(ha) == 0 and len(hb) == 0 :
+        Ea = voxel_energy_within_radius(distances[a], radius)
+        Eb = voxel_energy_within_radius(distances[b], radius)
+
     return (Eb, Ea) if Ea < Eb else (Ea, Eb)
 
 
@@ -243,6 +248,11 @@ def blob_energies_and_hits(track_graph : Graph, radius : float) -> Tuple[float, 
     Ea = sum(h.E for h in ha)
     Eb = sum(h.E for h in hb)
 
+    # Consider the case where voxels are built without associated hits
+    if len(ha) == 0 and len(hb) == 0 :
+        Ea = voxel_energy_within_radius(distances[a], radius)
+        Eb = voxel_energy_within_radius(distances[b], radius)
+
     return (Eb, Ea, hb, ha) if Ea < Eb else (Ea, Eb, ha, hb)
 
 
@@ -255,6 +265,11 @@ def blob_centres(track_graph : Graph, radius : float) -> Tuple[Tuple[float], Tup
 
     Ea = sum(h.E for h in ha)
     Eb = sum(h.E for h in hb)
+
+    # Consider the case where voxels are built without associated hits
+    if len(ha) == 0 and len(hb) == 0 :
+        Ea = voxel_energy_within_radius(distances[a], radius)
+        Eb = voxel_energy_within_radius(distances[b], radius)
 
     centre_of_blob_a = blob_centre(a)
     centre_of_blob_b = blob_centre(b)

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -221,7 +221,7 @@ def hits_in_blob(track_graph : Graph, radius : float, extreme: Voxel) -> Sequenc
     return blob_hits
 
 
-def blob_energies_hits_and_centres(track_graph : Graph, radius : float) -> Tuple[float, float, Sequence[Tuple[float, float, float]], Sequence[Tuple[float, float, float]], Tuple[float, float, float], Tuple[float, float, float]]:
+def blob_energies_hits_and_centres(track_graph : Graph, radius : float) -> Tuple[float, float, Sequence[BHit], Sequence[BHit], Tuple[float, float, float], Tuple[float, float, float]]:
     """Return the energies, the hits and the positions of the blobs.
        For each pair of observables, the one of the blob of largest energy is returned first."""
     distances = shortest_paths(track_graph)
@@ -251,7 +251,7 @@ def blob_energies(track_graph : Graph, radius : float) -> Tuple[float, float]:
     return E1, E2
 
 
-def blob_energies_and_hits(track_graph : Graph, radius : float) -> Tuple[float, float, Sequence[Tuple[float, float, float]], Sequence[Tuple[float, float, float]]]:
+def blob_energies_and_hits(track_graph : Graph, radius : float) -> Tuple[float, float, Sequence[BHit], Sequence[BHit]]:
     """Return the energies and the hits around the extrema of the track.
        The largest energy is returned first, as well as its hits."""
     E1, E2, h1, h2, _, _ = blob_energies_hits_and_centres(track_graph, radius)

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -176,7 +176,7 @@ def length(track: Graph) -> float:
     return length
 
 
-def voxel_energy_within_radius(distances : Dict[Voxel, float], radius : float) -> float:
+def energy_of_voxels_within_radius(distances : Dict[Voxel, float], radius : float) -> float:
     return sum(v.E for (v, d) in distances.items() if d < radius)
 
 
@@ -233,8 +233,8 @@ def blob_energies_hits_and_centres(track_graph : Graph, radius : float) -> Tuple
 
     # Consider the case where voxels are built without associated hits
     if len(ha) == 0 and len(hb) == 0 :
-        Ea = voxel_energy_within_radius(distances[a], radius)
-        Eb = voxel_energy_within_radius(distances[b], radius)
+        Ea = energy_of_voxels_within_radius(distances[a], radius)
+        Eb = energy_of_voxels_within_radius(distances[b], radius)
 
     ca = blob_centre(a)
     cb = blob_centre(b)

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -230,7 +230,7 @@ def blob_energies(track_graph : Graph, radius : float) -> Tuple[float, float]:
     Ea = sum(h.E for h in ha)
     Eb = sum(h.E for h in hb)
 
-    return (Ea, Eb) if Ea < Eb else (Eb, Ea)
+    return (Eb, Ea) if Ea < Eb else (Ea, Eb)
 
 
 def blob_energies_and_hits(track_graph : Graph, radius : float) -> Tuple[float, float, Tuple[Tuple[float], Tuple[float]]]:
@@ -243,7 +243,7 @@ def blob_energies_and_hits(track_graph : Graph, radius : float) -> Tuple[float, 
     Ea = sum(h.E for h in ha)
     Eb = sum(h.E for h in hb)
 
-    return (Ea, Eb, ha, hb) if Ea < Eb else (Eb, Ea, hb, ha)
+    return (Eb, Ea, hb, ha) if Ea < Eb else (Ea, Eb, ha, hb)
 
 
 def blob_centres(track_graph : Graph, radius : float) -> Tuple[Tuple[float], Tuple[float]]:
@@ -259,7 +259,7 @@ def blob_centres(track_graph : Graph, radius : float) -> Tuple[Tuple[float], Tup
     centre_of_blob_a = blob_centre(a)
     centre_of_blob_b = blob_centre(b)
 
-    return (centre_of_blob_a, centre_of_blob_b) if Ea < Eb else (centre_of_blob_b, centre_of_blob_a)
+    return (centre_of_blob_b, centre_of_blob_a) if Ea < Eb else (centre_of_blob_a, centre_of_blob_b)
 
 
 def make_tracks(evt_number       : float,

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -176,11 +176,11 @@ def length(track: Graph) -> float:
     return length
 
 
-def energy_within_radius(distances : Dict[Voxel, Dict[Voxel, float]], radius : float) -> float:
+def voxel_energy_within_radius(distances : Dict[Voxel, float], radius : float) -> float:
     return sum(v.E for (v, d) in distances.items() if d < radius)
 
 
-def voxels_within_radius(distances : Dict[Voxel, Dict[Voxel, float]],
+def voxels_within_radius(distances : Dict[Voxel, float],
                          radius : float) -> List[Voxel]:
     return [v for (v, d) in distances.items() if d < radius]
 

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -246,6 +246,22 @@ def blob_energies_and_hits(track_graph : Graph, radius : float, energy: HitEnerg
     return (Ea, Eb, ha, hb) if Ea < Eb else (Eb, Ea, hb, ha)
 
 
+def blob_centres(track_graph : Graph, radius : float, energy: HitEnergy = 'E') -> Tuple[Tuple[float], Tuple[float]]:
+    """Return the positions of the blobs."""
+    distances = shortest_paths(track_graph)
+    a, b, _   = find_extrema_and_length(distances)
+    ha = hits_in_blob(track_graph, radius, a, energy)
+    hb = hits_in_blob(track_graph, radius, b, energy)
+
+    Ea = sum(getattr(h, energy) for h in ha)
+    Eb = sum(getattr(h, energy) for h in hb)
+
+    centre_of_blob_a = blob_centre(a, energy)
+    centre_of_blob_b = blob_centre(b, energy)
+
+    return (centre_of_blob_a, centre_of_blob_b) if Ea < Eb else (centre_of_blob_b, centre_of_blob_a)
+
+
 def compute_blobs(track_graph : Graph, radius : float) -> Tuple[Voxel, Voxel, List[Voxel], List[Voxel]]:
     """Return the blobs (list of voxels) around the extrema of the track."""
     distances = shortest_paths(track_graph)

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -233,12 +233,12 @@ def blob_energies(track_graph : Graph, radius : float) -> Tuple[float, float]:
     return (Ea, Eb) if Ea < Eb else (Eb, Ea)
 
 
-def blob_energies_and_hits(track_graph : Graph, radius : float, energy: HitEnergy = 'E') -> Tuple[float, float, Tuple[Tuple[float], Tuple[float]]]:
+def blob_energies_and_hits(track_graph : Graph, radius : float) -> Tuple[float, float, Tuple[Tuple[float], Tuple[float]]]:
     """Return the energies and the hits around the extrema of the track."""
     distances = shortest_paths(track_graph)
     a, b, _   = find_extrema_and_length(distances)
-    ha = hits_in_blob(track_graph, radius, a, energy)
-    hb = hits_in_blob(track_graph, radius, b, energy)
+    ha = hits_in_blob(track_graph, radius, a)
+    hb = hits_in_blob(track_graph, radius, b)
 
     Ea = sum(getattr(h, energy) for h in ha)
     Eb = sum(getattr(h, energy) for h in hb)
@@ -246,18 +246,18 @@ def blob_energies_and_hits(track_graph : Graph, radius : float, energy: HitEnerg
     return (Ea, Eb, ha, hb) if Ea < Eb else (Eb, Ea, hb, ha)
 
 
-def blob_centres(track_graph : Graph, radius : float, energy: HitEnergy = 'E') -> Tuple[Tuple[float], Tuple[float]]:
+def blob_centres(track_graph : Graph, radius : float) -> Tuple[Tuple[float], Tuple[float]]:
     """Return the positions of the blobs."""
     distances = shortest_paths(track_graph)
     a, b, _   = find_extrema_and_length(distances)
-    ha = hits_in_blob(track_graph, radius, a, energy)
-    hb = hits_in_blob(track_graph, radius, b, energy)
+    ha = hits_in_blob(track_graph, radius, a)
+    hb = hits_in_blob(track_graph, radius, b)
 
     Ea = sum(getattr(h, energy) for h in ha)
     Eb = sum(getattr(h, energy) for h in hb)
 
-    centre_of_blob_a = blob_centre(a, energy)
-    centre_of_blob_b = blob_centre(b, energy)
+    centre_of_blob_a = blob_centre(a)
+    centre_of_blob_b = blob_centre(b)
 
     return (centre_of_blob_a, centre_of_blob_b) if Ea < Eb else (centre_of_blob_b, centre_of_blob_a)
 

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -191,6 +191,7 @@ def blob_centre(voxel: Voxel) -> Tuple[float]:
     energies  = [h.E   for h in voxel.hits]
     if sum(energies):
         bary_pos = np.average(positions, weights=energies, axis=0)
+    # Consider the case where voxels are built without associated hits
     else:
         bary_pos = voxel.pos
 

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -262,15 +262,6 @@ def blob_centres(track_graph : Graph, radius : float) -> Tuple[Tuple[float], Tup
     return (centre_of_blob_a, centre_of_blob_b) if Ea < Eb else (centre_of_blob_b, centre_of_blob_a)
 
 
-def compute_blobs(track_graph : Graph, radius : float) -> Tuple[Voxel, Voxel, List[Voxel], List[Voxel]]:
-    """Return the blobs (list of voxels) around the extrema of the track."""
-    distances = shortest_paths(track_graph)
-    a, b, _ = find_extrema_and_length(distances)
-    ba = voxels_within_radius(distances[a], radius)
-    bb = voxels_within_radius(distances[b], radius)
-    return a, b, ba, bb
-
-
 def make_tracks(evt_number       : float,
                 evt_time         : float,
                 voxels           : List[Voxel],

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -277,7 +277,7 @@ def make_tracks(evt_number       : float,
         a, b                               = blob_centres(trk, blob_radius)
         blob_a = Blob(a, hits_a, blob_radius) # type: Blob
         blob_b = Blob(b, hits_b, blob_radius)
-        blobs = (blob_a, blob_b) if blob_a.E < blob_b.E else (blob_b, blob_a)
+        blobs = (blob_a, blob_b)
         track = Track(voxels_from_track_graph(trk), blobs)
         tc.tracks.append(track)
     return tc

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -273,9 +273,10 @@ def make_tracks(evt_number       : float,
     track_graphs = make_track_graphs(voxels) # type: Sequence[Graph]
 #    track_graphs = make_track_graphs(voxels, voxel_dimensions) # type: Sequence[Graph]
     for trk in track_graphs:
-        a, b, voxels_a, voxels_b    = compute_blobs(trk, blob_radius)
-        blob_a = Blob(a, voxels_a) # type: Blob
-        blob_b = Blob(b, voxels_b)
+        energy_a, energy_b, hits_a, hits_b = blob_energies_and_hits(trk, blob_radius)
+        a, b                               = blob_centres(trk, blob_radius)
+        blob_a = Blob(a, hits_a, blob_radius) # type: Blob
+        blob_b = Blob(b, hits_b, blob_radius)
         blobs = (blob_a, blob_b) if blob_a.E < blob_b.E else (blob_b, blob_a)
         track = Track(voxels_from_track_graph(trk), blobs)
         tc.tracks.append(track)

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -185,7 +185,7 @@ def voxels_within_radius(distances : Dict[Voxel, float],
     return [v for (v, d) in distances.items() if d < radius]
 
 
-def blob_centre(voxel: Voxel) -> Tuple[float]:
+def blob_centre(voxel: Voxel) -> Tuple[float, float, float]:
     """Calculate the blob position, starting from the end-point voxel."""
     positions = [h.pos for h in voxel.hits]
     energies  = [h.E   for h in voxel.hits]
@@ -259,7 +259,7 @@ def blob_energies_and_hits(track_graph : Graph, radius : float) -> Tuple[float, 
     return (E1, E2, h1, h2)
 
 
-def blob_centres(track_graph : Graph, radius : float) -> Tuple[Tuple[float], Tuple[float]]:
+def blob_centres(track_graph : Graph, radius : float) -> Tuple[Tuple[float, float, float], Tuple[float, float, float]]:
     """Return the positions of the blobs.
        The blob of largest energy is returned first."""
     _, _, _, _, c1, c2 = blob_energies_hits_and_centres(track_graph, radius)

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -240,8 +240,8 @@ def blob_energies_and_hits(track_graph : Graph, radius : float) -> Tuple[float, 
     ha = hits_in_blob(track_graph, radius, a)
     hb = hits_in_blob(track_graph, radius, b)
 
-    Ea = sum(getattr(h, energy) for h in ha)
-    Eb = sum(getattr(h, energy) for h in hb)
+    Ea = sum(h.E for h in ha)
+    Eb = sum(h.E for h in hb)
 
     return (Ea, Eb, ha, hb) if Ea < Eb else (Eb, Ea, hb, ha)
 
@@ -253,8 +253,8 @@ def blob_centres(track_graph : Graph, radius : float) -> Tuple[Tuple[float], Tup
     ha = hits_in_blob(track_graph, radius, a)
     hb = hits_in_blob(track_graph, radius, b)
 
-    Ea = sum(getattr(h, energy) for h in ha)
-    Eb = sum(getattr(h, energy) for h in hb)
+    Ea = sum(h.E for h in ha)
+    Eb = sum(h.E for h in hb)
 
     centre_of_blob_a = blob_centre(a)
     centre_of_blob_b = blob_centre(b)

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -233,6 +233,19 @@ def blob_energies(track_graph : Graph, radius : float) -> Tuple[float, float]:
     return (Ea, Eb) if Ea < Eb else (Eb, Ea)
 
 
+def blob_energies_and_hits(track_graph : Graph, radius : float, energy: HitEnergy = 'E') -> Tuple[float, float, Tuple[Tuple[float], Tuple[float]]]:
+    """Return the energies and the hits around the extrema of the track."""
+    distances = shortest_paths(track_graph)
+    a, b, _   = find_extrema_and_length(distances)
+    ha = hits_in_blob(track_graph, radius, a, energy)
+    hb = hits_in_blob(track_graph, radius, b, energy)
+
+    Ea = sum(getattr(h, energy) for h in ha)
+    Eb = sum(getattr(h, energy) for h in hb)
+
+    return (Ea, Eb, ha, hb) if Ea < Eb else (Eb, Ea, hb, ha)
+
+
 def compute_blobs(track_graph : Graph, radius : float) -> Tuple[Voxel, Voxel, List[Voxel], List[Voxel]]:
     """Return the blobs (list of voxels) around the extrema of the track."""
     distances = shortest_paths(track_graph)

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -98,7 +98,7 @@ def voxelize_hits(hits             : Sequence[BHit],
         indx_comp = (h_indices == (x, y, z))
         hits_in_bin = list(h for i, h in zip(indx_comp, hits) if all(i))
 
-        voxels.append(Voxel(cx[x], cy[y], cz[z], E[x,y,z], true_dimensions, hits_in_bin))  
+        voxels.append(Voxel(cx[x], cy[y], cz[z], E[x,y,z], true_dimensions, hits_in_bin))
 
     return voxels
 
@@ -221,7 +221,8 @@ def hits_in_blob(track_graph : Graph, radius : float, extreme: Voxel) -> Sequenc
 
 
 def blob_energies(track_graph : Graph, radius : float) -> Tuple[float, float]:
-    """Return the energies around the extrema of the track."""
+    """Return the energies around the extrema of the track.
+       The largest energy is returned first."""
     distances = shortest_paths(track_graph)
     a, b, _   = find_extrema_and_length(distances)
     ha = hits_in_blob(track_graph, radius, a)
@@ -239,7 +240,8 @@ def blob_energies(track_graph : Graph, radius : float) -> Tuple[float, float]:
 
 
 def blob_energies_and_hits(track_graph : Graph, radius : float) -> Tuple[float, float, Tuple[Tuple[float], Tuple[float]]]:
-    """Return the energies and the hits around the extrema of the track."""
+    """Return the energies and the hits around the extrema of the track.
+       The largest energy is returned first, as well as its hits."""
     distances = shortest_paths(track_graph)
     a, b, _   = find_extrema_and_length(distances)
     ha = hits_in_blob(track_graph, radius, a)
@@ -257,7 +259,8 @@ def blob_energies_and_hits(track_graph : Graph, radius : float) -> Tuple[float, 
 
 
 def blob_centres(track_graph : Graph, radius : float) -> Tuple[Tuple[float], Tuple[float]]:
-    """Return the positions of the blobs."""
+    """Return the positions of the blobs.
+       The blob of largest energy is returned first."""
     distances = shortest_paths(track_graph)
     a, b, _   = find_extrema_and_length(distances)
     ha = hits_in_blob(track_graph, radius, a)

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -240,7 +240,10 @@ def blob_energies_hits_and_centres(track_graph : Graph, radius : float) -> Tuple
     ca = blob_centre(a)
     cb = blob_centre(b)
 
-    return (Eb, Ea, hb, ha, cb, ca) if Ea < Eb else (Ea, Eb, ha, hb, ca, cb)
+    if Eb > Ea:
+        return (Eb, Ea, hb, ha, cb, ca)
+    else:
+        return (Ea, Eb, ha, hb, ca, cb)
 
 
 def blob_energies(track_graph : Graph, radius : float) -> Tuple[float, float]:

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -34,6 +34,8 @@ from . paolina_functions import bounding_box
 from . paolina_functions import find_extrema
 from . paolina_functions import find_extrema_and_length
 from . paolina_functions import blob_energies
+from . paolina_functions import blob_energies_and_hits
+from . paolina_functions import blob_centres
 from . paolina_functions import voxelize_hits
 from . paolina_functions import shortest_paths
 from . paolina_functions import make_track_graphs

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -328,22 +328,6 @@ def track_extrema():
     return tracks[0], extrema
 
 
-@parametrize('radius, expected',
-             ((0.5, (1000, 2000)), # Nothing but the endpoints
-              (1.5, (1001, 2000)), # 10 10 10 is 1   away
-              (1.9, (1001, 2001)), # 19 19 19 is 1.7 away
-              (2.1, (1003, 2001)), # 10 10 12 is 2   away
-              (3.1, (1007, 2001)), # 10 10 13 is 3   away
-              (3.5, (1007, 2003)), # 18 18 18 is 3.4 away
-              (4.5, (1015, 2003)), # 10 10 14 is 4   away
-))
-def test_blobs(track_extrema, radius, expected):
-    track, extrema = track_extrema
-    Ea, Eb = expected
-
-    assert blob_energies(track, radius) == (Ea, Eb)
-
-
 def test_voxelize_single_hit():
     hits = [BHit(1, 1, 1, 100)]
     vox_size = np.array([10,10,10], dtype=np.int16)
@@ -545,3 +529,37 @@ def test_voxel_drop_in_short_tracks():
     mod_voxels = drop_end_point_voxels(voxels, e_thr, min_voxels)
 
     assert len(mod_voxels) >= 1
+
+
+@parametrize('radius, expected',
+             ((10., ( 20,  60)),
+              (12., ( 60,  60)),
+              (14., ( 60, 100)),
+              (16., ( 80, 120)),
+              (18., ( 80, 120)),
+              (20., ( 80, 140)),
+              (22., (100, 140))
+ ))
+def test_blobs(radius, expected):
+    hits = [BHit(105.0, 125.0, 77.7, 10),
+            BHit( 95.0, 125.0, 77.7, 10),
+            BHit( 95.0, 135.0, 77.7, 10),
+            BHit(105.0, 135.0, 77.7, 10),
+            BHit(105.0, 115.0, 77.7, 10),
+            BHit( 95.0, 115.0, 77.7, 10),
+            BHit( 95.0, 125.0, 79.5, 10),
+            BHit(105.0, 125.0, 79.5, 10),
+            BHit(105.0, 135.0, 79.5, 10),
+            BHit( 95.0, 135.0, 79.5, 10),
+            BHit( 95.0, 115.0, 79.5, 10),
+            BHit(105.0, 115.0, 79.5, 10),
+            BHit(115.0, 125.0, 79.5, 10),
+            BHit(115.0, 125.0, 85.2, 10)]
+    vox_size = np.array([15.,15.,15.],dtype=np.float16)
+    voxels = voxelize_hits(hits, vox_size)
+    tracks = make_track_graphs(voxels)
+
+    Ea, Eb = expected
+
+    assert len(tracks) == 1
+    assert blob_energies(tracks[0], radius) == (Ea, Eb)

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -537,13 +537,13 @@ def test_voxel_drop_in_short_tracks():
 
 
 @parametrize('radius, expected',
-             ((10., ( 20,  60)),
+             ((10., ( 60,  20)),
               (12., ( 60,  60)),
-              (14., ( 60, 100)),
-              (16., ( 80, 120)),
-              (18., ( 80, 120)),
-              (20., ( 80, 140)),
-              (22., (100, 140))
+              (14., (100,  60)),
+              (16., (120,  80)),
+              (18., (120,  80)),
+              (20., (140,  80)),
+              (22., (140, 100))
  ))
 def test_blobs(radius, expected):
     hits = [BHit(105.0, 125.0, 77.7, 10),
@@ -564,10 +564,8 @@ def test_blobs(radius, expected):
     voxels = voxelize_hits(hits, vox_size)
     tracks = make_track_graphs(voxels)
 
-    Ea, Eb = expected
-
     assert len(tracks) == 1
-    assert blob_energies(tracks[0], radius) == (Ea, Eb)
+    assert blob_energies(tracks[0], radius) == expected
 
 
 @given(bunch_of_hits, box_sizes, radius)

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -563,3 +563,17 @@ def test_blobs(radius, expected):
 
     assert len(tracks) == 1
     assert blob_energies(tracks[0], radius) == (Ea, Eb)
+
+
+@given(bunch_of_hits, box_sizes, radius)
+def test_blob_hits_are_inside_radius(hits, voxel_dimensions, blob_radius):
+    voxels = voxelize_hits(hits, voxel_dimensions)
+    tracks = make_track_graphs(voxels)
+    for t in tracks:
+        Ea, Eb, hits_a, hits_b   = blob_energies_and_hits(t, blob_radius)
+        centre_a, centre_b       = blob_centres(t, blob_radius)
+
+        for h in hits_a:
+            assert np.linalg.norm(h.XYZ - centre_a) < blob_radius
+        for h in hits_b:
+            assert np.linalg.norm(h.XYZ - centre_b) < blob_radius

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -27,14 +27,16 @@ from hypothesis.strategies import integers
 
 from networkx.generators.random_graphs import fast_gnp_random_graph
 
-from .. evm.event_model  import BHit
+from .. evm.event_model import BHit
+from .. evm.event_model import Voxel
 
-from . paolina_functions import Voxel
 from . paolina_functions import bounding_box
+from . paolina_functions import voxel_energy_within_radius
 from . paolina_functions import find_extrema
 from . paolina_functions import find_extrema_and_length
 from . paolina_functions import blob_energies
 from . paolina_functions import blob_energies_and_hits
+from . paolina_functions import blob_centre
 from . paolina_functions import blob_centres
 from . paolina_functions import hits_in_blob
 from . paolina_functions import voxelize_hits
@@ -599,3 +601,21 @@ def test_paolina_functions_with_voxels_without_associated_hits(blob_radius):
         hits_b = hits_in_blob(t, blob_radius, b)
 
         assert len(hits_a) == len(hits_b) == 0
+
+        assert np.allclose(blob_centre(a), a.pos)
+        assert np.allclose(blob_centre(b), b.pos)
+
+        distances = shortest_paths(t)
+        Ea = voxel_energy_within_radius(distances[a], blob_radius)
+        Eb = voxel_energy_within_radius(distances[b], blob_radius)
+
+        if Ea < Eb:
+            assert np.allclose(blob_centres(t, blob_radius)[0], b.pos)
+            assert np.allclose(blob_centres(t, blob_radius)[1], a.pos)
+        else:
+            assert np.allclose(blob_centres(t, blob_radius)[0], a.pos)
+            assert np.allclose(blob_centres(t, blob_radius)[1], b.pos)
+
+        assert blob_energies(t, blob_radius) != (0, 0)
+
+        assert blob_energies_and_hits(t, blob_radius) != (0, 0, [], [])

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -446,6 +446,7 @@ def test_energy_is_conserved_with_dropped_voxels(hits, requested_voxel_dimension
     voxels = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False)
     ini_trks = make_track_graphs(voxels)
     ini_trk_energies = [sum(vox.E for vox in t.nodes()) for t in ini_trks]
+    ini_trk_energies.sort()
 
     energies = [v.E for v in voxels]
     e_thr = min(energies) + fraction_zero_one * (max(energies) - min(energies))
@@ -453,6 +454,7 @@ def test_energy_is_conserved_with_dropped_voxels(hits, requested_voxel_dimension
     tot_final_energy = sum(v.E for v in mod_voxels)
     final_trks = make_track_graphs(mod_voxels)
     final_trk_energies = [sum(vox.E for vox in t.nodes()) for t in final_trks]
+    final_trk_energies.sort()
 
     assert tot_initial_energy == approx(tot_final_energy)
     assert np.allclose(ini_trk_energies, final_trk_energies)

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -31,7 +31,7 @@ from .. evm.event_model import BHit
 from .. evm.event_model import Voxel
 
 from . paolina_functions import bounding_box
-from . paolina_functions import voxel_energy_within_radius
+from . paolina_functions import energy_of_voxels_within_radius
 from . paolina_functions import find_extrema
 from . paolina_functions import find_extrema_and_length
 from . paolina_functions import blob_energies
@@ -606,8 +606,8 @@ def test_paolina_functions_with_voxels_without_associated_hits(blob_radius):
         assert np.allclose(blob_centre(b), b.pos)
 
         distances = shortest_paths(t)
-        Ea = voxel_energy_within_radius(distances[a], blob_radius)
-        Eb = voxel_energy_within_radius(distances[b], blob_radius)
+        Ea = energy_of_voxels_within_radius(distances[a], blob_radius)
+        Eb = energy_of_voxels_within_radius(distances[b], blob_radius)
 
         if Ea < Eb:
             assert np.allclose(blob_centres(t, blob_radius)[0], b.pos)

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -65,6 +65,7 @@ box_dimension = floats(min_value = 1,
 box_sizes = builds(np.array, lists(box_dimension,
                                    min_size = 3,
                                    max_size = 3))
+radius = floats(min_value=1, max_value=100)
 
 eps = 3e-12 # value that works for margin
 


### PR DESCRIPTION
In this PR, I have changed the definition of blob, according to the latest studies performed by @ausonandres and myself. Now each blob centre is calculated as the barycenter of the hits that fall within each one of the end-point voxels. Moreover, the energies of the individual hits are used to build the energy of the blob, instead of the energy of the voxels. Last, but not least, only the hits of the voxels that are at a distance-along-the-track shorter than a fixed distance are considered to be included in the blob. The final requirement for a hit to be included is that its euclidean distance from the centre of the blob is shorter than the blob radius. Tests have been changed following the change in the definition and one more has been added. 
I would like Javi Muñoz to be a reviewer of this PR, I'll add him as soon as he approves the request to be a collaborator.