### PR TITLE
Fix possible bug with exception in building clusters.

### DIFF
--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -378,8 +378,8 @@ def build_pointlike_event(dbfile, run_number, drift_v, reco):
                 clusters = reco(xys, qs)
             except XYRecoFail:
                 c    = NNN()
-                Z    = tuple(NN for _ in evt.nS1)
-                DT   = tuple(NN for _ in evt.nS1)
+                Z    = tuple(NN for _ in range(0, evt.nS1))
+                DT   = tuple(NN for _ in range(0, evt.nS1))
                 Zrms = NN
             else:
                 c = clusters[0]

--- a/invisible_cities/cities/penthesilea_test.py
+++ b/invisible_cities/cities/penthesilea_test.py
@@ -244,3 +244,48 @@ def test_penthesilea_exact_result(ICDATADIR, output_tmpdir):
                 got      = getattr(     output_file.root, table)
                 expected = getattr(true_output_file.root, table)
                 assert_tables_equality(got, expected)
+
+
+# test for PR 628
+def test_penthesilea_xyrecofail(config_tmpdir, Xe2nu_pmaps_mc_filename):
+    PATH_IN =  Xe2nu_pmaps_mc_filename
+
+    PATH_OUT = os.path.join(config_tmpdir, 'Xe2nu_2nu_hdst.h5')
+    conf = configure('dummy invisible_cities/config/penthesilea.conf'.split())
+    conf.update(dict(run_number = -6000,
+                     files_in   = PATH_IN,
+                     file_out   = PATH_OUT,
+
+                     drift_v     =      1 * units.mm / units.mus,
+                     s1_nmin     =      1,
+                     s1_nmax     =      1,
+                     s1_emin     =      0 * units.pes,
+                     s1_emax     =   1e+6 * units.pes,
+                     s1_wmin     =      1 * units.ns,
+                     s1_wmax     =   1.e6 * units.ns,
+                     s1_hmin     =      0 * units.pes,
+                     s1_hmax     =   1e+6 * units.pes,
+                     s1_ethr     =    0.5 * units.pes,
+                     s2_nmin     =      1,
+                     s2_nmax     =    100,
+                     s2_emin     =      0 * units.pes,
+                     s2_emax     =    1e8 * units.pes,
+                     s2_wmin     =    2.5 * units.mus,
+                     s2_wmax     =     10 * units.ms,
+                     s2_hmin     =      0 * units.pes,
+                     s2_hmax     =    1e6 * units.pes,
+                     s2_ethr     =      1 * units.pes,
+                     s2_nsipmmin =      1,
+                     s2_nsipmmax =   2000,
+                     rebin       =      2,
+                     global_reco_params = dict(),
+                     slice_reco_params = dict(
+                         Qthr            =  30 * units.pes,
+                         Qlm             =  30 * units.pes,
+                         lm_radius       =  0 * units.mm ,
+                         new_lm_radius   =  0 * units.mm ,
+                         msipm = 1 ),
+                     event_range = (826, 827)))
+
+    # check it runs
+    penthesilea(**conf)

--- a/invisible_cities/conftest.py
+++ b/invisible_cities/conftest.py
@@ -646,6 +646,13 @@ def Kr_pmaps_run4628_filename(ICDATADIR):
     filename = os.path.join(ICDATADIR, "Kr_pmaps_run4628.h5")
     return filename
 
+
+@pytest.fixture(scope='session')
+def Xe2nu_pmaps_mc_filename(ICDATADIR):
+    filename = os.path.join(ICDATADIR, "Xe2nu_NEW_v1_05_02_nexus_v5_03_08_ACTIVE_10.2bar_run4.0_0_pmaps.h5")
+    return filename
+
+
 @pytest.fixture(scope='session')
 def voxels_toy_data(ICDATADIR):
     event = np.zeros(100)

--- a/invisible_cities/database/test_data/Xe2nu_NEW_v1_05_02_nexus_v5_03_08_ACTIVE_10.2bar_run4.0_0_pmaps.h5
+++ b/invisible_cities/database/test_data/Xe2nu_NEW_v1_05_02_nexus_v5_03_08_ACTIVE_10.2bar_run4.0_0_pmaps.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53c9f2d9efc32acf3a7ccc39953d44046869c39a7e65f8903cd64f5c232c8583
+size 8202369


### PR DESCRIPTION
The function `build_pointlike_event` of `cities.components` has been changed since there were two loops like this one:  _(for _ in evt.nS1)_, where evt.nS1 is an int type. Now it appears to work properly, so is this change correct?