### PR TITLE
Fix bug when reading hit time

### DIFF
--- a/invisible_cities/database/test_data/hits_1hit_perSiPM_30pes_6817_trigger2_v0.9.9_20190111_krth1600.0.h5
+++ b/invisible_cities/database/test_data/hits_1hit_perSiPM_30pes_6817_trigger2_v0.9.9_20190111_krth1600.0.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9fb239bea0179987bbc969db94407b23c69825e02db1e752ccd886df52b2b98
+size 55653

--- a/invisible_cities/io/hits_io.py
+++ b/invisible_cities/io/hits_io.py
@@ -66,7 +66,7 @@ def load_hits_skipping_NN(DST_file_name):
 
     for i in range(dst_size):
         current_event = all_events.setdefault(event[i],
-                                              HitCollection(event[i], time[i] * 1e-3))
+                                              HitCollection(event[i], time[i]))
         hit = Hit(npeak[i],
                  Cluster(Q[i], xy(X[i], Y[i]), xy(Xrms[i], Yrms[i]),
                          nsipm[i], Z[i], E[i]), Z[i], E[i], xy(Xpeak[i], Ypeak[i]))

--- a/invisible_cities/io/hits_io.py
+++ b/invisible_cities/io/hits_io.py
@@ -34,7 +34,7 @@ def load_hits(DST_file_name):
 
     for i in range(dst_size):
         current_event = all_events.setdefault(event[i],
-                                              HitCollection(event[i], time[i] * 1e-3))
+                                              HitCollection(event[i], time[i]))
         hit = Hit(npeak[i],
                  Cluster(Q[i], xy(X[i], Y[i]), xy(Xrms[i], Yrms[i]),
                          nsipm[i], Z[i], E[i]), Z[i], E[i], xy(Xpeak[i], Ypeak[i]))

--- a/invisible_cities/io/hits_io_test.py
+++ b/invisible_cities/io/hits_io_test.py
@@ -2,15 +2,18 @@ import os
 import numpy  as np
 import tables as tb
 import pandas as pd
-from . dst_io              import load_dst
+import time   as tm
+
 from numpy.testing import assert_allclose
 
+from . dst_io              import load_dst
 from .. core.testing_utils import assert_dataframes_equal
 from .. types.ic_types     import xy
 from .. evm.event_model    import Cluster
 from .. evm.event_model    import Hit
 from .. evm.event_model    import HitCollection
 from .  hits_io            import hits_writer
+from .  hits_io            import load_hits
 from .. types.ic_types     import NN
 
 def test_load_hits_load_events(TlMC_hits):
@@ -100,3 +103,13 @@ def test_hits_writer(config_tmpdir, hits_toy_data):
     assert_allclose(q    , dst.Q    .values)
     assert_allclose(e    , dst.E    .values)
 
+
+def test_hit_time_is_in_second(ICDATADIR):
+    output_file = os.path.join(ICDATADIR, "hits_1hit_perSiPM_30pes_6817_trigger2_v0.9.9_20190111_krth1600.0.h5")
+    the_hits = load_hits(output_file)
+
+    for evt, hit_coll in the_hits.items():
+        evt_time = hit_coll.time
+        year = int(tm.strftime("%Y", tm.localtime(evt_time)))
+
+        assert 2008 < year < 2050


### PR DESCRIPTION
In this PR I fix a bug in the way we read the hits. A multiplicative `1e-3` factor was used, without taking into account that the same factor is already used when the hit is written (see `build_hits` function in `cities/components.py`), to convert milliseconds (coming from raw data) to seconds. A test has been added to ensure that the time we read is in seconds. I have chosen as a check range of dates 2008-2050; on one hand, 2008 is the year NEXT started and, on the other hand, if we are still using IC in 2050 it will not be me the one who will debug the code ;-). 