### PR TITLE
Update DEMOPP database

### DIFF
--- a/invisible_cities/database/localdb.DEMOPPDB.sqlite3
+++ b/invisible_cities/database/localdb.DEMOPPDB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8712a6eb771892c3c4a98c018dc006f99efe9f99b4b1876b8a01e233d461743c
+oid sha256:27bca7c34a8b1c8d06f5806a0e24e5f9920bcfa86f3cf777788cb4aed8babcbb
 size 2482176

--- a/manage.sh
+++ b/manage.sh
@@ -208,7 +208,7 @@ function show_ic_env {
 
 function download_test_db {
     echo Downloading database
-    python $ICDIR/database/download.py
+    python $ICDIR/database/download.py $ARGUMENT
 }
 
 function compile_cython_components {


### PR DESCRIPTION
This PR updates `DEMOPP` database that has now the proper sensor id's and positions.

It also includes a small change in manage.sh that allows to download only one DB. If no option is given to `bash manage.sh download_test_db` all databases will be downloaded (`NEWDB`, `DEMOPPDB`, `NEXT100DB`).

With this change it is possible to download only one database: `bash manage.sh download_test_db DEMOPPDB`