### PR TITLE
Fix diomira test_diomira_can_fix_random_seed

### DIFF
--- a/invisible_cities/cities/diomira_test.py
+++ b/invisible_cities/cities/diomira_test.py
@@ -220,7 +220,10 @@ def test_diomira_exact_result(ICDATADIR, output_tmpdir):
                 assert_tables_equality(got, expected)
 
 
-def test_diomira_can_fix_random_seed():
+def test_diomira_can_fix_random_seed(output_tmpdir):
+    file_out    = os.path.join(output_tmpdir,                       "exact_result_diomira.h5")
+
     conf = configure("diomira invisible_cities/config/diomira.conf".split())
-    conf.update(dict(random_seed = 123))
+    conf.update(dict(random_seed = 123),
+                file_out     = file_out)
     diomira(**conf)


### PR DESCRIPTION
This PR fixes a bug in `test_diomira_can_fix_random_seed`. That function was using directly the output path from the sample config file, which was `/tmp/electrons_40keV_z250_test_RWF.h5` instead of using the temporary dir created by pytest.

The problem is that when two users try to run the test on the same machine, the first of them will create the file when it is executed and the second one will get an error like this:

`E               OSError: file ``/tmp/electrons_40keV_z250_test_RWF.h5`` exists but it can not be written`

because that file already exists and the owner is a different user.

This PR fixes that error, using the facility provided by test as in all the other tests.