### PR TITLE
Fix how city decorator adds a default for detector_db

### DIFF
--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -12,6 +12,7 @@ from typing      import Mapping
 
 import tables as tb
 import numpy  as np
+import inspect
 
 from .. dataflow               import dataflow      as fl
 from .. evm .ic_containers     import SensorData
@@ -72,7 +73,8 @@ def city(city_function):
 
         # For backward-compatibility we set NEW as the default DB in
         # case it is not defined in the config file
-        if 'detector_db' not in kwds:
+        if 'detector_db' in inspect.getfullargspec(city_function).args and \
+           'detector_db' not in kwds:
             conf.detector_db = 'new'
 
         conf.files_in  = sorted(glob(expandvars(conf.files_in)))


### PR DESCRIPTION
In #618 a new parameter was introduced to choose which database to read depending on the detector. Then, all IC cities needed a `detector_db` parameter to read the correct data. To keep backward compatibility a default value for `detector_db` was needed even if that variable was not in the config file to be run.

To do so, a change was introduced in the decorator `@city`. The problem now, as @jmunozv has reported, is that there are some functions in clients of IC (FANAL) that use `@city` but do not read the database at all, so there is not point in giving them `detector_db`.

The change introduced in this PR uses python reflection mechanisms to pass a default `detector_db` value only to those cities that need it.

Maybe @paolafer or @jmunozv can review this.