### PR TITLE
store pandas as pytable

### DIFF
--- a/invisible_cities/core/exceptions.py
+++ b/invisible_cities/core/exceptions.py
@@ -76,3 +76,6 @@ class NoParticleInfoInFile(ICException):
 
 class VoxelNotInList(ICException):
     pass
+
+class TableMismatch(ICException):
+    pass

--- a/invisible_cities/core/testing_utils.py
+++ b/invisible_cities/core/testing_utils.py
@@ -101,7 +101,6 @@ def _compare_dataframes(assertion, df1, df2, check_types=True, **kwargs):
         col2 = df2[col]
         if check_types:
             assert col1.dtype == col2.dtype
-        print(col, col1.values - col2.values)
         assertion(col1.values, col2.values, **kwargs)
 
 

--- a/invisible_cities/io/dst_io.py
+++ b/invisible_cities/io/dst_io.py
@@ -5,8 +5,9 @@ from tables import NoSuchNodeError
 from tables import HDF5ExtError
 import warnings
 
-from .. reco import tbl_functions as tbl
+from .. core.exceptions    import TableMismatch
 from .  table_io           import make_table
+
 
 def load_dst(filename, group, node):
     """load a kdst if filename, group and node correctly found"""
@@ -27,10 +28,6 @@ def load_dsts(dst_list, group, node):
     dsts = [load_dst(filename, group, node) for filename in dst_list]
     return pd.concat(dsts)
 
-class TableMismatchError(Exception):
-    def __init__(self):
-        s  = 'The table and dataframe dont match! '
-        Exception.__init__(self, s)
 
 def _store_pandas_as_tables(h5out, df, group_name, table_name, compression='ZLIB4', descriptive_string=None, str_col_length=32):
     if len(df) == 0:
@@ -59,7 +56,7 @@ def _store_pandas_as_tables(h5out, df, group_name, table_name, compression='ZLIB
                            description = descriptive_string,
                            compression = compression)
     if not np.array_equal(df.columns,table.colnames):
-        raise TableMismatchError
+        raise TableMismatch
     for indx in df.index:
         tablerow = table.row
         for colname in table.colnames:

--- a/invisible_cities/io/dst_io.py
+++ b/invisible_cities/io/dst_io.py
@@ -42,13 +42,11 @@ def _make_tabledef(column_types:pd.Series,str_col_length:int=32)->dict:
 def _store_pandas_as_tables(h5out:tb.file.File, df:pd.DataFrame, group_name:str, table_name:str, compression:str='ZLIB4', descriptive_string:[str]="", str_col_length:int=32)->None:
     if len(df) == 0:
         warnings.warn(f'dataframe is empty', UserWarning)
-    if '/'+group_name not in h5out:
+    if group_name not in h5out.root:
         group = h5out.create_group(h5out.root,group_name)
-    else:
-        group = getattr(h5out.root,group_name)
-    if table_name in group:
-        table=getattr(group,table_name)
-    else:
+
+    group = getattr(h5out.root,group_name)
+    if table_name not in group:
         tabledef=_make_tabledef(df.dtypes)
         table = make_table(h5out,
                            group       = group_name,
@@ -57,6 +55,7 @@ def _store_pandas_as_tables(h5out:tb.file.File, df:pd.DataFrame, group_name:str,
                            description = descriptive_string,
                            compression = compression)
 
+    table=getattr(group,table_name)
     if not np.array_equal(df.columns,table.colnames):
         raise TableMismatch(f'dataframe differs from already existing table structure')
     for indx in df.index:

--- a/invisible_cities/io/dst_io.py
+++ b/invisible_cities/io/dst_io.py
@@ -1,10 +1,12 @@
 import tables as tb
 import pandas as pd
+import numpy  as np
 from tables import NoSuchNodeError
 from tables import HDF5ExtError
 import warnings
 
-
+from .. reco import tbl_functions as tbl
+from .  table_io           import make_table
 
 def load_dst(filename, group, node):
     """load a kdst if filename, group and node correctly found"""
@@ -24,3 +26,43 @@ def load_dst(filename, group, node):
 def load_dsts(dst_list, group, node):
     dsts = [load_dst(filename, group, node) for filename in dst_list]
     return pd.concat(dsts)
+
+class TableMismatchError(Exception):
+    def __init__(self):
+        s  = 'The table and dataframe dont match! '
+        Exception.__init__(self, s)
+
+def _store_pandas_as_tables(h5out, df, group_name, table_name, compression='ZLIB4', descriptive_string=None, str_col_length=32):
+    if len(df) == 0:
+        warnings.warn(f' dataframe is empty', UserWarning)
+    if '/'+group_name not in h5out:
+        group = h5out.create_group(h5out.root,group_name)
+    else:
+        group = getattr(h5out.root,group_name)
+    if table_name in group:
+        table=getattr(group,table_name)
+    else:
+        tabledef={}
+        for indx, colname in enumerate(df.columns):
+            coltype = df[colname].dtype.name
+            try:
+                tabledef[colname] = tb.Col.from_type(coltype, pos = indx)
+            except ValueError:
+                tabledef[colname] = tb.StringCol(32, pos = indx)
+
+        if descriptive_string is None:
+            descriptive_string = ''
+        table = make_table(h5out,
+                           group       = group_name,
+                           name        = table_name,
+                           fformat     = tabledef,
+                           description = descriptive_string,
+                           compression = compression)
+    if not np.array_equal(df.columns,table.colnames):
+        raise TableMismatchError
+    for indx in df.index:
+        tablerow = table.row
+        for colname in table.colnames:
+            tablerow[colname] = df.at[indx,colname]
+        tablerow.append()
+    table.flush()

--- a/invisible_cities/io/dst_io.py
+++ b/invisible_cities/io/dst_io.py
@@ -41,7 +41,7 @@ def _make_tabledef(column_types:pd.Series,str_col_length:int=32)->dict:
 
 def _store_pandas_as_tables(h5out:tb.file.File, df:pd.DataFrame, group_name:str, table_name:str, compression:str='ZLIB4', descriptive_string:[str]="", str_col_length:int=32)->None:
     if len(df) == 0:
-        warnings.warn(f' dataframe is empty', UserWarning)
+        warnings.warn(f'dataframe is empty', UserWarning)
     if '/'+group_name not in h5out:
         group = h5out.create_group(h5out.root,group_name)
     else:
@@ -58,8 +58,7 @@ def _store_pandas_as_tables(h5out:tb.file.File, df:pd.DataFrame, group_name:str,
                            compression = compression)
 
     if not np.array_equal(df.columns,table.colnames):
-        warnings.warn(f' dataframe differs from already existing table structure', UserWarning)
-        raise TableMismatch
+        raise TableMismatch(f'dataframe differs from already existing table structure')
     for indx in df.index:
         tablerow = table.row
         for colname in table.colnames:

--- a/invisible_cities/io/dst_io.py
+++ b/invisible_cities/io/dst_io.py
@@ -1,13 +1,14 @@
 import tables as tb
 import pandas as pd
 import numpy  as np
-from tables import NoSuchNodeError
-from tables import HDF5ExtError
+
 import warnings
 
+from    tables             import NoSuchNodeError
+from    tables             import HDF5ExtError
 from .. core.exceptions    import TableMismatch
 from .  table_io           import make_table
-
+from    typing             import Optional
 
 def load_dst(filename, group, node):
     """load a kdst if filename, group and node correctly found"""
@@ -29,7 +30,7 @@ def load_dsts(dst_list, group, node):
     return pd.concat(dsts)
 
 
-def _store_pandas_as_tables(h5out, df, group_name, table_name, compression='ZLIB4', descriptive_string=None, str_col_length=32):
+def _store_pandas_as_tables(h5out:tb.file.File, df:pd.DataFrame, group_name:str, table_name:str, compression:str='ZLIB4', descriptive_string:Optional[str]=None, str_col_length:int=32)->None:
     if len(df) == 0:
         warnings.warn(f' dataframe is empty', UserWarning)
     if '/'+group_name not in h5out:

--- a/invisible_cities/io/dst_io.py
+++ b/invisible_cities/io/dst_io.py
@@ -29,38 +29,38 @@ def load_dsts(dst_list, group, node):
     dsts = [load_dst(filename, group, node) for filename in dst_list]
     return pd.concat(dsts)
 
-def _make_tabledef(column_types:pd.Series,str_col_length:int=32)->dict:
-    tabledef={}
+def _make_tabledef(column_types : pd.Series, str_col_length : int=32) -> dict:
+    tabledef = {}
     for indx, colname in enumerate(column_types.index):
         coltype = column_types[colname].name
         if coltype == 'object':
-            tabledef[colname] = tb.StringCol(str_col_length, pos = indx)
+            tabledef[colname] = tb.StringCol(str_col_length, pos=indx)
         else:
-            tabledef[colname] = tb.Col.from_type(coltype, pos = indx)
+            tabledef[colname] = tb.Col.from_type(coltype, pos=indx)
     return tabledef
 
-def _store_pandas_as_tables(h5out:tb.file.File, df:pd.DataFrame, group_name:str, table_name:str, compression:str='ZLIB4', descriptive_string:[str]="", str_col_length:int=32)->None:
+def _store_pandas_as_tables(h5out : tb.file.File, df : pd.DataFrame, group_name : str, table_name : str, compression : str='ZLIB4', descriptive_string : [str]="", str_col_length : int=32) -> None:
     if len(df) == 0:
         warnings.warn(f'dataframe is empty', UserWarning)
     if group_name not in h5out.root:
-        group = h5out.create_group(h5out.root,group_name)
+        group = h5out.create_group(h5out.root, group_name)
 
-    group = getattr(h5out.root,group_name)
+    group = getattr(h5out.root, group_name)
     if table_name not in group:
-        tabledef=_make_tabledef(df.dtypes)
-        table = make_table(h5out,
-                           group       = group_name,
-                           name        = table_name,
-                           fformat     = tabledef,
-                           description = descriptive_string,
-                           compression = compression)
+        tabledef = _make_tabledef(df.dtypes)
+        table    =  make_table(h5out,
+                               group       = group_name,
+                               name        = table_name,
+                               fformat     = tabledef,
+                               description = descriptive_string,
+                               compression = compression)
 
-    table=getattr(group,table_name)
-    if not np.array_equal(df.columns,table.colnames):
+    table = getattr(group, table_name)
+    if not np.array_equal(df.columns, table.colnames):
         raise TableMismatch(f'dataframe differs from already existing table structure')
     for indx in df.index:
         tablerow = table.row
         for colname in table.colnames:
-            tablerow[colname] = df.at[indx,colname]
+            tablerow[colname] = df.at[indx, colname]
         tablerow.append()
     table.flush()

--- a/invisible_cities/io/dst_io.py
+++ b/invisible_cities/io/dst_io.py
@@ -45,7 +45,7 @@ def _store_pandas_as_tables(h5out, df, group_name, table_name, compression='ZLIB
             try:
                 tabledef[colname] = tb.Col.from_type(coltype, pos = indx)
             except ValueError:
-                tabledef[colname] = tb.StringCol(32, pos = indx)
+                tabledef[colname] = tb.StringCol(str_col_length, pos = indx)
 
         if descriptive_string is None:
             descriptive_string = ''

--- a/invisible_cities/io/dst_io_test.py
+++ b/invisible_cities/io/dst_io_test.py
@@ -26,9 +26,9 @@ from hypothesis.strategies   import text
 
 @fixture()
 def empty_dataframe(columns=['int_value', 'float_value', 'bool_value', 'str_value'], dtypes=['int32', 'float32', 'bool', 'object'], index=None):
-    assert len(columns)==len(dtypes)
+    assert len(columns) == len(dtypes)
     df = pd.DataFrame(index=index)
-    for c,d in zip(columns, dtypes):
+    for c, d in zip(columns, dtypes):
         df[c] = pd.Series(dtype=d)
     return df
 
@@ -97,20 +97,20 @@ def test_load_dsts_warns_if_not_existing_file(ICDATADIR):
 
 @given(df=dataframe)
 def test_store_pandas_as_tables_exact(config_tmpdir, df):
-    filename   = config_tmpdir+'dataframe_to_table_exact.h5'
+    filename   = config_tmpdir + 'dataframe_to_table_exact.h5'
     group_name = 'test_group'
     table_name = 'table_name_1'
-    with tb.open_file(filename,'w') as h5out:
+    with tb.open_file(filename, 'w') as h5out:
         _store_pandas_as_tables(h5out, df, group_name, table_name)
     df_read = load_dst(filename, group_name, table_name)
     assert_dataframes_close(df_read, df, False, rtol=1e-5)
 
 @given(df1=dataframe, df2=dataframe)
 def test_store_pandas_as_tables_2df(config_tmpdir, df1, df2):
-    filename   = config_tmpdir+'dataframe_to_table_exact.h5'
+    filename   = config_tmpdir + 'dataframe_to_table_exact.h5'
     group_name = 'test_group'
     table_name = 'table_name_2'
-    with tb.open_file(filename,'w') as h5out:
+    with tb.open_file(filename, 'w') as h5out:
         _store_pandas_as_tables(h5out, df1, group_name, table_name)
         _store_pandas_as_tables(h5out, df2, group_name, table_name)
     df_read = load_dst(filename, group_name, table_name)
@@ -118,38 +118,38 @@ def test_store_pandas_as_tables_2df(config_tmpdir, df1, df2):
 
 @given(df1=dataframe, df2=dataframe_diff)
 def test_store_pandas_as_tables_raises_exception(config_tmpdir, df1, df2):
-    filename   = config_tmpdir+'dataframe_to_table_exact.h5'
+    filename   = config_tmpdir + 'dataframe_to_table_exact.h5'
     group_name = 'test_group'
     table_name = 'table_name_2'
-    with tb.open_file(filename,'w') as h5out:
+    with tb.open_file(filename, 'w') as h5out:
         _store_pandas_as_tables(h5out, df1, group_name, table_name)
         with raises(TableMismatch):
             _store_pandas_as_tables(h5out, df2, group_name, table_name)
 
 @given(df=strings_dataframe)
 def test_strings_store_pandas_as_tables(config_tmpdir, df):
-    filename   = config_tmpdir+'dataframe_to_table_exact.h5'
+    filename   = config_tmpdir + 'dataframe_to_table_exact.h5'
     group_name = 'test_group'
     table_name = 'table_name_str'
-    with tb.open_file(filename,'w') as h5out:
+    with tb.open_file(filename, 'w') as h5out:
         _store_pandas_as_tables(h5out, df, group_name, table_name)
     df_read    = load_dst(filename, group_name, table_name)
     #we have to cast from byte strings to compare with original dataframe
-    df_read.str_val=df_read.str_val.str.decode('utf-8')
+    df_read.str_val = df_read.str_val.str.decode('utf-8')
     assert_dataframes_equal(df_read, df, False)
 
 def test_make_tabledef(empty_dataframe):
-    tabledef=_make_tabledef(empty_dataframe.dtypes)
-    expected_tabledef={'int_value'  :tb.Int32Col  (             shape=(), dflt=0    , pos=0),
-                       'float_value':tb.Float32Col(             shape=(), dflt=0    , pos=1),
-                       'bool_value' :tb.BoolCol   (             shape=(), dflt=False, pos=2),
-                       'str_value'  :tb.StringCol (itemsize=32, shape=(), dflt=b''  , pos=3)}
-    assert tabledef==expected_tabledef
+    tabledef = _make_tabledef(empty_dataframe.dtypes)
+    expected_tabledef = {'int_value'   : tb.Int32Col  (             shape=(), dflt=0    , pos=0),
+                         'float_value' : tb.Float32Col(             shape=(), dflt=0    , pos=1),
+                         'bool_value'  : tb.BoolCol   (             shape=(), dflt=False, pos=2),
+                         'str_value'   : tb.StringCol (itemsize=32, shape=(), dflt=b''  , pos=3)}
+    assert tabledef == expected_tabledef
 
 def test_store_pandas_as_tables_raises_warning_empty_dataframe(config_tmpdir, empty_dataframe):
-    filename   = config_tmpdir+'dataframe_to_table_exact.h5'
+    filename   = config_tmpdir + 'dataframe_to_table_exact.h5'
     group_name = 'test_group'
     table_name = 'table_name_3'
-    with tb.open_file(filename,'w') as h5out:
+    with tb.open_file(filename, 'w') as h5out:
         with pytest.warns(UserWarning, match='dataframe is empty'):
             _store_pandas_as_tables(h5out, empty_dataframe, group_name, table_name)

--- a/invisible_cities/io/dst_io_test.py
+++ b/invisible_cities/io/dst_io_test.py
@@ -141,3 +141,11 @@ def test_make_tabledef(empty_dataframe):
                        'bool_value' :tb.BoolCol   (             shape=(), dflt=False, pos=2),
                        'str_value'  :tb.StringCol (itemsize=32, shape=(), dflt=b''  , pos=3)}
     assert tabledef==expected_tabledef
+
+def test_store_pandas_as_tables_raises_warning_empty_dataframe(config_tmpdir, empty_dataframe):
+    filename   = config_tmpdir+'dataframe_to_table_exact.h5'
+    group_name = 'test_group'
+    table_name = 'table_name_3'
+    with tb.open_file(filename,'w') as h5out:
+        with pytest.warns(UserWarning, match='dataframe is empty'):
+            _store_pandas_as_tables(h5out, empty_dataframe, group_name, table_name)

--- a/invisible_cities/io/dst_io_test.py
+++ b/invisible_cities/io/dst_io_test.py
@@ -2,18 +2,22 @@ import os
 import pandas as pd
 import tables as tb
 from ..core.testing_utils import assert_dataframes_close
-from .      dst_io        import load_dst
-from .      dst_io        import load_dsts
-from .      dst_io        import _store_pandas_as_tables
+from ..core.exceptions    import TableMismatch
+from . dst_io             import load_dst
+from . dst_io             import load_dsts
+from . dst_io             import _store_pandas_as_tables
 
 import warnings
 import pytest
-import hypothesis.strategies as st
+
+from pytest                  import raises
+from numpy     .testing      import assert_raises
+from hypothesis              import given
 from hypothesis.extra.pandas import columns
 from hypothesis.extra.pandas import data_frames
 from hypothesis.extra.pandas import column
 from hypothesis.extra.pandas import range_indexes
-from hypothesis              import given
+
 
 def test_load_dst(KrMC_kdst):
     df_read = load_dst(*KrMC_kdst[0].file_info)
@@ -68,26 +72,38 @@ def test_load_dsts_warns_if_not_existing_file(ICDATADIR):
         load_dsts([good_file, wrong_file], group, node)
 
 
-df = data_frames(index=range_indexes(min_size=1),columns=[column('int_value', dtype=int),column('float_val',dtype='float'),column('bool_value',dtype=bool)])
-@given(df = df)
-def  test_store_pandas_as_tables_exact(config_tmpdir, df):
-    filename = config_tmpdir+'dataframe_to_table_exact.h5'
-    group_name ='test_group'
+dataframe=data_frames(index=range_indexes(min_size=1), columns=[column('int_value' , dtype = int    ),
+                                                                column('float_val' , dtype = float),
+                                                                column('bool_value', dtype = bool   )])
+@given(df=dataframe)
+def test_store_pandas_as_tables_exact(config_tmpdir, df):
+    filename   = config_tmpdir+'dataframe_to_table_exact.h5'
+    group_name = 'test_group'
     table_name = 'table_name_1'
     with tb.open_file(filename,'w') as h5out:
-        _store_pandas_as_tables(h5out, df, group_name,table_name)
+        _store_pandas_as_tables(h5out, df, group_name, table_name)
     df_read = load_dst(filename, group_name, table_name)
     assert_dataframes_close(df_read, df, False, rtol=1e-5)
 
-df2 = data_frames(index=range_indexes(min_size=1),columns=[column('int_value', dtype=int),column('float_val',dtype='float'),column('bool_value',dtype=bool)])
-@given(df1 = df, df2=df)
-def  test_store_pandas_as_tables_2df(config_tmpdir, df1, df2):
-    filename = config_tmpdir+'dataframe_to_table_exact.h5'
-    group_name ='test_group'
+@given(df1=dataframe, df2=dataframe)
+def test_store_pandas_as_tables_2df(config_tmpdir, df1, df2):
+    filename   = config_tmpdir+'dataframe_to_table_exact.h5'
+    group_name = 'test_group'
     table_name = 'table_name_2'
     with tb.open_file(filename,'w') as h5out:
-        _store_pandas_as_tables(h5out, df1, group_name,table_name)
-        _store_pandas_as_tables(h5out, df2, group_name,table_name)
+        _store_pandas_as_tables(h5out, df1, group_name, table_name)
+        _store_pandas_as_tables(h5out, df2, group_name, table_name)
     df_read = load_dst(filename, group_name, table_name)
-    assert_dataframes_close(df_read, pd.concat([df1, df2]).reset_index(drop=True),False, rtol=1e-5)
+    assert_dataframes_close(df_read, pd.concat([df1, df2]).reset_index(drop=True), False, rtol=1e-5)
 
+dataframe_diff=data_frames(index=range_indexes(min_size=1, max_size=5),columns=[column('int_value', dtype = int    ),
+                                                                                column('float_val', dtype = float)])
+@given(df1=dataframe, df2=dataframe_diff)
+def test_store_pandas_as_tables_raises_exception(config_tmpdir, df1, df2):
+    filename   = config_tmpdir+'dataframe_to_table_exact.h5'
+    group_name = 'test_group'
+    table_name = 'table_name_2'
+    with tb.open_file(filename,'w') as h5out:
+        _store_pandas_as_tables(h5out, df1, group_name, table_name)
+        with raises(TableMismatch):
+            _store_pandas_as_tables(h5out, df2, group_name, table_name)


### PR DESCRIPTION
the function that transforms pandas dataframe to pytable, reading column names and types directly from dataframe; some tests are still missing and in particularly what to do with string object of dataframes