### PR TITLE
Fix bug in the computation of xy position

### DIFF
--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -410,7 +410,7 @@ def hit_builder(dbfile, run_number, drift_v, reco, rebin_slices, rebin_method):
     sipm_ys  = datasipm.Y.values
     sipm_xys = np.stack((sipm_xs, sipm_ys), axis=1)
 
-    baricenter = partial(corona,
+    barycenter = partial(corona,
                          all_sipms      =  datasipm,
                          Qthr           =  0 * units.pes,
                          Qlm            =  0 * units.pes,
@@ -444,7 +444,7 @@ def hit_builder(dbfile, run_number, drift_v, reco, rebin_slices, rebin_method):
 
             xys     = sipm_xys[peak.sipms.ids           ]
             qs      =          peak.sipms.sum_over_times
-            try              : cluster = baricenter(xys, qs)[0]
+            try              : cluster = barycenter(xys, qs)[0]
             except XYRecoFail: xy_peak = xy(NN, NN)
             else             : xy_peak = xy(cluster.X, cluster.Y)
 

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -328,7 +328,6 @@ def peak_classifier(**params):
 def compute_xy_position(dbfile, run_number, **reco_params):
     # `reco_params` is the set of parameters for the corona
     # algorithm either for the full corona or for barycenter
-#    datasipm = load_db.DataSiPM(0) ----> revisar, 
     datasipm = load_db.DataSiPM(dbfile, run_number)
 
     def compute_xy_position(xys, qs):

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -325,11 +325,11 @@ def peak_classifier(**params):
     return partial(pmap_filter, selector)
 
 
-def compute_xy_position(dbfile, **reco_params):
+def compute_xy_position(dbfile, run_number, **reco_params):
     # `reco_params` is the set of parameters for the corona
     # algorithm either for the full corona or for barycenter
 #    datasipm = load_db.DataSiPM(0) ----> revisar, 
-    datasipm = load_db.DataSiPM(dbfile, 0)
+    datasipm = load_db.DataSiPM(dbfile, run_number)
 
     def compute_xy_position(xys, qs):
         return corona(xys, qs, datasipm, **reco_params)

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -1,5 +1,7 @@
 import os
 
+import numpy as np
+
 from argparse  import Namespace
 from functools import partial
 
@@ -8,11 +10,17 @@ from pytest import raises
 
 from .. core.configure  import EventRange as ER
 from .. core.exceptions import InvalidInputFileStructure
+from .. core.exceptions import ClusterEmptyList
+
+from .. core.system_of_units_c import units
 
 from .  components import event_range
 from .  components import WfType
 from .  components import   wf_from_files
 from .  components import pmap_from_files
+from .  components import compute_xy_position
+
+from .. database import load_db
 
 
 def _create_dummy_conf_with_event_range(value):
@@ -58,3 +66,32 @@ def test_sources_invalid_input_raises_InvalidInputFileStructure(ICDATADIR, sourc
     s = source((full_filename,))
     with raises(InvalidInputFileStructure):
         next(s)
+
+
+def test_compute_xy_position_depend_on_masked_channels():
+    minimum_seed_charge = 6*units.pes
+    reco_parameters = {'Qthr': 2*units.pes,
+                       'Qlm': minimum_seed_charge,
+                       'lm_radius': 0*units.mm,
+                       'new_lm_radius': 15 * units.mm,
+                       'msipm': 9,
+                       'consider_masked': True}
+    run_number = 6977
+    find_xy_pos = compute_xy_position('new', run_number, **reco_parameters)
+
+    # masked_channel = 11009, x_pos = -65, y_pos = 15
+    # the channels entering the reco algorithm are the ones in a square of 3x3
+    # that includes the masked channel. The test is supposed to fail if the
+    # compute_xy_position function doesn't use the run_number parameter.
+    xs_to_test  = np.array([-65, -65, -55, -55, -55, -45, -45, -45])
+    ys_to_test  = np.array([  5,  25,   5,  15,  25,   5,  15,  25])
+    xys_to_test = np.stack((xs_to_test, ys_to_test), axis=1)
+
+    charge         = minimum_seed_charge - 1
+    seed_charge    = minimum_seed_charge + 1
+    charge_to_test = np.array([charge, charge, charge, seed_charge, charge, charge, charge, charge])
+
+    try:
+        find_xy_pos(xys_to_test, charge_to_test)
+    except(ClusterEmptyList):
+        assert False

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -68,7 +68,7 @@ def test_sources_invalid_input_raises_InvalidInputFileStructure(ICDATADIR, sourc
         next(s)
 
 
-def test_compute_xy_position_depend_on_masked_channels():
+def test_compute_xy_position_depends_on_actual_run_number():
     """
     The channels entering the reco algorithm are the ones in a square of 3x3
     that includes the masked channel.

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -69,6 +69,18 @@ def test_sources_invalid_input_raises_InvalidInputFileStructure(ICDATADIR, sourc
 
 
 def test_compute_xy_position_depend_on_masked_channels():
+    """
+    The channels entering the reco algorithm are the ones in a square of 3x3
+    that includes the masked channel.
+    Scheme of SiPM positions (the numbers are the SiPM charges):
+    x - - - >
+    y | 5 5 5
+      | X 7 5
+      | 5 5 5
+
+    This test is meant to fail if them compute_xy_position function
+    doesn't use the run_number parameter.
+    """
     minimum_seed_charge = 6*units.pes
     reco_parameters = {'Qthr': 2*units.pes,
                        'Qlm': minimum_seed_charge,
@@ -79,10 +91,6 @@ def test_compute_xy_position_depend_on_masked_channels():
     run_number = 6977
     find_xy_pos = compute_xy_position('new', run_number, **reco_parameters)
 
-    # masked_channel = 11009, x_pos = -65, y_pos = 15
-    # the channels entering the reco algorithm are the ones in a square of 3x3
-    # that includes the masked channel. The test is supposed to fail if the
-    # compute_xy_position function doesn't use the run_number parameter.
     xs_to_test  = np.array([-65, -65, -55, -55, -55, -45, -45, -45])
     ys_to_test  = np.array([  5,  25,   5,  15,  25,   5,  15,  25])
     xys_to_test = np.stack((xs_to_test, ys_to_test), axis=1)

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -76,7 +76,7 @@ def test_compute_xy_position_depends_on_actual_run_number():
     x - - - >
     y | 5 5 5
       | X 7 5
-      | 5 5 5
+      v 5 5 5
 
     This test is meant to fail if them compute_xy_position function
     doesn't use the run_number parameter.

--- a/invisible_cities/cities/dorothea.py
+++ b/invisible_cities/cities/dorothea.py
@@ -77,7 +77,7 @@ def dorothea(files_in, file_out, compression, event_range, print_mod, detector_d
     pmap_passed           = fl.map(attrgetter("passed"), args="selector_output", out="pmap_passed")
     pmap_select           = fl.count_filter(bool, args="pmap_passed")
 
-    reco_algo             = compute_xy_position(detector_db, **global_reco_params)
+    reco_algo             = compute_xy_position(detector_db, run_number, **global_reco_params)
     build_pointlike_event = fl.map(build_pointlike_event_(detector_db, run_number, drift_v, reco_algo),
                                    args = ("pmap", "selector_output", "event_number", "timestamp"),
                                    out  = "pointlike_event"                                       )

--- a/invisible_cities/cities/penthesilea.py
+++ b/invisible_cities/cities/penthesilea.py
@@ -68,11 +68,11 @@ def penthesilea(files_in, file_out, compression, event_range, print_mod, detecto
     pmap_passed           = df.map(attrgetter("passed"), args="selector_output", out="pmap_passed")
     pmap_select           = df.count_filter(bool, args="pmap_passed")
 
-    reco_algo_slice       = compute_xy_position(detector_db, **slice_reco_params)
+    reco_algo_slice       = compute_xy_position(detector_db, run_number, **slice_reco_params)
     build_hits            = df.map(hit_builder(detector_db, run_number, drift_v, reco_algo_slice, rebin, RebinMethod[rebin_method]),
                                    args = ("pmap", "selector_output", "event_number", "timestamp"),
                                    out  = "hits"                                                 )
-    reco_algo_global      = compute_xy_position(detector_db, **global_reco_params)
+    reco_algo_global      = compute_xy_position(detector_db, run_number, **global_reco_params)
     build_pointlike_event = df.map(build_pointlike_event_(detector_db, run_number, drift_v, reco_algo_global),
                                    args = ("pmap", "selector_output", "event_number", "timestamp"),
                                    out  = "pointlike_event"                                      )

--- a/invisible_cities/reco/xy_algorithms.py
+++ b/invisible_cities/reco/xy_algorithms.py
@@ -126,7 +126,7 @@ def corona(pos, qs, all_sipms,
     new_lm_radius = radius, find a new cluster by calling barycenter() on pos/qs of SiPMs within
                     new_lm_radius of new_local_maximum
 
-    masked_sipm = list of positions of masked SiPMs
+    consider_masked  = true if masked SiPMs are considered
 
     returns
     c    : a list of Clusters


### PR DESCRIPTION
This PR fixes a bug in the `compute_xy_position` function. The function was reading value from the database corresponding to run number 0. Now, the function receives the correct run number, as read from the input files. A test has been added, which fails if the function doesn't take into account the given run number.