### PR TITLE
Allow penthesilea to run with 0 S1

### DIFF
--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -430,8 +430,12 @@ def hit_builder(dbfile, run_number, drift_v, reco, rebin_slices, rebin_method):
         # take events with exactly one s1. Otherwise, the
         # convention is to take the first peak in the S1 object
         # as reference.
-        first_s1 = np.where(selector_output.s1_peaks)[0][0]
-        s1_t     = pmap.s1s[first_s1].time_at_max_energy
+        if len(selector_output.s1_peaks) > 0:
+            first_s1 = np.where(selector_output.s1_peaks)[0][0]
+            s1_t     = pmap.s1s[first_s1].time_at_max_energy
+        else:
+            first_s2 = np.where(selector_output.s2_peaks)[0][0]
+            s1_t     = pmap.s2s[first_s2].times[0]
 
         # here hits are computed for each peak and each slice.
         # In case of an exception, a hit is still created with a NN cluster.

--- a/invisible_cities/cities/penthesilea_test.py
+++ b/invisible_cities/cities/penthesilea_test.py
@@ -124,7 +124,7 @@ def test_penthesilea_threshold_rebin(ICDATADIR, output_tmpdir):
 
     conf        = configure('dummy invisible_cities/config/penthesilea.conf'.split())
     rebin_thresh = 4000
-    
+
     conf.update(dict(run_number      =        -6340,
                      files_in        =      file_in,
                      file_out        =     file_out,
@@ -243,13 +243,34 @@ def test_penthesilea_exact_result(ICDATADIR, output_tmpdir):
               "Filters/s12_selector")
     with tb.open_file(true_output)  as true_output_file:
         with tb.open_file(file_out) as      output_file:
-            print(true_output_file)
-            print(output_file)
             for table in tables:
                 got      = getattr(     output_file.root, table)
                 expected = getattr(true_output_file.root, table)
                 assert_tables_equality(got, expected)
 
+def test_penthesilea_exact_result_noS1(ICDATADIR, output_tmpdir):
+    file_in     = os.path.join(ICDATADIR    ,  "Kr83_nexus_v5_03_00_ACTIVE_7bar_10evts_PMP.h5")
+    file_out    = os.path.join(output_tmpdir,                   "exact_result_penthesilea_noS1.h5")
+    true_output = os.path.join(ICDATADIR    , "Kr83_nexus_v5_03_00_ACTIVE_7bar_noS1.HDST.h5")
+
+    conf = configure("penthesilea invisible_cities/config/penthesilea.conf".split())
+    conf.update(dict(run_number   = -6340,
+                     files_in     = file_in,
+                     file_out     = file_out,
+                     event_range  = all_events,
+                     s1_nmin      = 0))
+
+    penthesilea(**conf)
+
+    tables = (     "MC/extents"     ,  "MC/hits", "MC/particles", "MC/generators",
+                 "RECO/Events"      , "DST/Events",
+              "Filters/s12_selector")
+    with tb.open_file(true_output)  as true_output_file:
+        with tb.open_file(file_out) as      output_file:
+            for table in tables:
+                got      = getattr(     output_file.root, table)
+                expected = getattr(true_output_file.root, table)
+                assert_tables_equality(got, expected)
 
 # test for PR 628
 def test_penthesilea_xyrecofail(config_tmpdir, Xe2nu_pmaps_mc_filename):

--- a/invisible_cities/core/testing_utils.py
+++ b/invisible_cities/core/testing_utils.py
@@ -2,6 +2,7 @@ import numpy  as np
 
 from pytest                 import approx
 from numpy.testing          import assert_array_equal
+from numpy.testing          import assert_equal
 from numpy.testing          import assert_allclose
 from hypothesis.strategies  import integers
 from hypothesis.strategies  import floats
@@ -140,19 +141,23 @@ def assert_PMap_equality(pmp0, pmp1):
 def assert_tables_equality(got_table, expected_table):
     table_got      =      got_table[:]
     table_expected = expected_table[:]
-    assert len(table_got) == len(table_expected)
+    assert len(table_got      ) == len(table_expected      )
+    assert len(table_got.dtype) == len(table_expected.dtype)
 
-    for got, expected in zip(table_got, table_expected):
-        assert type(got) == type(expected)
-        try:
-            assert got == expected
-        except ValueError:
+    if table_got.dtype.names is not None:
+        for col_name in table_got.dtype.names:
+            got      = table_got[col_name]
+            expected = table_got[col_name]
+            assert type(got) == type(expected)
             try:
-                assert np.isclose (got, expected)
-            except ValueError:
-                assert np.allclose(got, expected)
-        except AssertionError:
-            assert all([np.allclose(got[name], expected[name], equal_nan=True) for name in got.dtype.names])
+                assert_allclose(got, expected)
+            except TypeError:
+                assert_equal   (got, expected)
+    else:
+        try:
+            assert_allclose(got_table, expected_table)
+        except TypeError:
+            assert_equal   (got_table, expected_table)
 
 def assert_cluster_equality(a_cluster, b_cluster):
     assert np.allclose(a_cluster.posxy , b_cluster.posxy )

--- a/invisible_cities/core/testing_utils.py
+++ b/invisible_cities/core/testing_utils.py
@@ -151,6 +151,8 @@ def assert_tables_equality(got_table, expected_table):
                 assert np.isclose (got, expected)
             except ValueError:
                 assert np.allclose(got, expected)
+        except AssertionError:
+            assert all([np.allclose(got[name], expected[name], equal_nan=True) for name in got.dtype.names])
 
 def assert_cluster_equality(a_cluster, b_cluster):
     assert np.allclose(a_cluster.posxy , b_cluster.posxy )

--- a/invisible_cities/core/testing_utils_test.py
+++ b/invisible_cities/core/testing_utils_test.py
@@ -1,11 +1,14 @@
 import numpy as np
 
-from pytest                import mark
-from flaky                 import flaky
-from hypothesis            import given
-from hypothesis.strategies import floats
-from hypothesis.strategies import integers
-from . testing_utils       import all_elements_close
+from pytest                       import mark
+from flaky                        import flaky
+from hypothesis                   import given
+from hypothesis.strategies        import floats
+from hypothesis.strategies        import integers
+from hypothesis.     extra.pandas import data_frames
+from hypothesis.     extra.pandas import column
+from . testing_utils              import all_elements_close
+from . testing_utils              import assert_tables_equality
 
 
 @flaky(max_runs=2)
@@ -25,3 +28,15 @@ def test_all_elements_close_simple(mu, sigma, t_rel, t_abs):
 def test_all_elements_close_par(mu, sigma):
     x = np.random.normal(mu, sigma, 10)
     assert all_elements_close(x, t_rel=5 * sigma, t_abs=5 * sigma)
+
+@given(data_frames([column('A', dtype=int  ),
+                    column('B', dtype=float),
+                    column('C', dtype=str  )]))
+def test_assert_tables_equality(df):
+    table = df.to_records(index=False)
+    assert_tables_equality(table, table)
+
+def test_assert_tables_equality_withNaN():
+    table = np.array([('Rex', 9, 81.0), ('Fido', 3, np.nan)],
+                     dtype=[('name', 'U10'), ('age', 'i4'), ('weight', 'f4')])
+    assert_tables_equality(table, table)             

--- a/invisible_cities/database/test_data/Kr83_nexus_v5_03_00_ACTIVE_7bar_noS1.HDST.h5
+++ b/invisible_cities/database/test_data/Kr83_nexus_v5_03_00_ACTIVE_7bar_noS1.HDST.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:334e082abf3ceb7dde589094f058408b09f7397cecfdbf3a843fff533fcaaecc
+size 89803

--- a/invisible_cities/database/test_data/Kr83_nexus_v5_03_00_ACTIVE_7bar_noS1.HDST.h5
+++ b/invisible_cities/database/test_data/Kr83_nexus_v5_03_00_ACTIVE_7bar_noS1.HDST.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:334e082abf3ceb7dde589094f058408b09f7397cecfdbf3a843fff533fcaaecc
-size 89803
+oid sha256:66cca60d3e0c443cb9fe9ce1377172d7e64229322feb17b7ea5638d345400f01
+size 89349


### PR DESCRIPTION
**Status**: Not final but may need some discussion.

This is a PR to allow Penthesilea and Dorothea to run with events with no S1 signals. 

Dorothea already allowed us to run for 0 S1s. In this case, the S1 peak parameters were set to NaN as well as the Z. The Z could easily changed by 0 at the analysis level with this simple line:

```
kdst['Z'] = np.where(kdst.nS1 == 0, 0.0, kdst.Z)
```
Therefore, since dorothea works efficiently I would probably not change the code and reassign the Z at the analysis level although at the test level, the default S1 values can be troublesome, as I'll explain later.

In the case of Penthesilea, the drift time of the S2s will be calculated relative to the time of the first time bin of the first S2 (so first slice of the first S2 will have a drift time equal to 0, the rest will be equal to the time difference between their time position and the first slice). The change to do this is minimal and easy (already uploaded).

However, when adding an specific code to test penthesilea with 0 S1s, I've noticed an Assertion Error that I'm currently unsure about how to handle. The values compared are actually equal but the Assertion Error jumps because there are NaN values in the arrays that are compared. 

This happens in the comparison of the stored S1 information. As I said before, in the absence of S1, the code initializes everything to NaN values, for analysis there is no problem with this but at the test level, it seems that two NaNs are not equal. To fix this I can think of three options:

1) Change the default values of S1s to have a different value and not NaN (fast solution although I suspect it may require changing several things in some tests)
2) Write a piece of code that handles the 0 S1 case as an specific case (more work and less elegant but maybe the "rightest" solution?)
3) Adapt the assertion code to handle the NaN comparison and not result in an error.

I already wrote point 3 (and is also in the uploaded code) so you could take a look at it. I'm not sure if giving an exception to the AssertionError is the most sensitive thing to do although it should fail if it's not equal (besides NaN cases).  Anyway, this is the status as of now, how do you think this should be approached?