### PR TITLE
Fix drop voxel function

### DIFF
--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -311,7 +311,7 @@ def drop_end_point_voxels(voxels: Sequence[Voxel], energy_threshold: float, min_
         ### be sure that the voxel to be eliminated has at least one neighbour
         ### beyond itself
         the_neighbours = np.array([neighbours(the_vox, v) for v in voxels])
-        if len(the_neighbours>0) <= 1:
+        if len(the_neighbours[the_neighbours>0]) <= 1:
             return 0
 
         ### remove voxel from list of voxels

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -331,7 +331,7 @@ def drop_end_point_voxels(voxels: Sequence[Voxel], energy_threshold: float, min_
                         min_v = v
 
             ### add voxel energy to voxel
-            setattr(min_v, e_type, getattr(min_v, e_type) + getattr(the_vox, e_type))
+            min_v.energy += the_vox.energy
 
             return 1
 
@@ -351,8 +351,8 @@ def drop_end_point_voxels(voxels: Sequence[Voxel], energy_threshold: float, min_
                         min_v = v
 
         ### add voxel energy to hit and to voxel, separately
-        setattr(min_hit, e_type, getattr(min_hit, e_type) + getattr(the_vox, e_type))
-        setattr(min_v,   e_type, getattr(min_v, e_type)   + getattr(the_vox, e_type))
+        setattr(min_hit, e_type, getattr(min_hit, e_type) + the_vox.energy)
+        min_v.energy += the_vox.energy
 
         return 1
 

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -361,7 +361,6 @@ def drop_end_point_voxels(voxels: Sequence[Voxel], energy_threshold: float, min_
     while True:
         n_modified_voxels = 0
         trks = make_track_graphs(mod_voxels)
-        vxl_size = mod_voxels[0].size
 
         for t in trks:
             if len(t.nodes()) < min_vxls:

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -664,13 +664,6 @@ def test_paolina_functions_with_voxels_without_associated_hits(blob_radius, min_
         assert np.allclose(blob_centre(b), b.pos)
 
 
-@given(bunch_of_corrected_hits(), box_sizes, radius)
-def test_voxelize_hits_with_hit_energy_different_from_default_value(hits, requested_voxel_dimensions, blob_radius):
-    with raises(AttributeError):
-        voxels_c = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False, energy_type=HitEnergy.energy_c)
-        voxels_l = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False, energy_type=HitEnergy.energy_l)
-
-
 @given(box_sizes, radius, fraction_zero_one)
 def test_paolina_functions_with_hit_energy_different_from_default_value(requested_voxel_dimensions, blob_radius, fraction_zero_one):
 

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -671,8 +671,8 @@ def test_voxelize_hits_with_hit_energy_different_from_default_value(hits, reques
         voxels_l = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False, energy_type=HitEnergy.energy_l)
 
 
-@given(box_sizes, radius)
-def test_paolina_functions_with_hit_energy_different_from_default_value(requested_voxel_dimensions, blob_radius):
+@given(box_sizes, radius, fraction_zero_one)
+def test_paolina_functions_with_hit_energy_different_from_default_value(requested_voxel_dimensions, blob_radius, fraction_zero_one):
 
     npeak = 0
     Q     = 1
@@ -683,13 +683,14 @@ def test_paolina_functions_with_hit_energy_different_from_default_value(requeste
     energy_c = energy + 2
     x_peak = y_peak = 0
     hits = [Hit(npeak, Cluster(Q, xy(-1,0), xy(var,var),nsipm), 1, energy, xy(x_peak,y_peak), energy_l, energy_c),
-            Hit(npeak, Cluster(Q, xy( 0,0), xy(var,var),nsipm), 2, energy, xy(x_peak,y_peak), energy_l, energy_c),
-            Hit(npeak, Cluster(Q, xy( 0,1), xy(var,var),nsipm), 3, energy, xy(x_peak,y_peak), energy_l, energy_c),
-            Hit(npeak, Cluster(Q, xy( 1,0), xy(var,var),nsipm), 4, energy, xy(x_peak,y_peak), energy_l, energy_c),
-            Hit(npeak, Cluster(Q, xy( 4,5), xy(var,var),nsipm), 4, energy, xy(x_peak,y_peak), energy_l, energy_c),
-            Hit(npeak, Cluster(Q, xy( 5,3), xy(var,var),nsipm), 5, energy, xy(x_peak,y_peak), energy_l, energy_c)]
+            Hit(npeak, Cluster(Q, xy( 0,0), xy(var,var),nsipm), 2, energy, xy(x_peak,y_peak), energy_l, energy_c-1),
+            Hit(npeak, Cluster(Q, xy( 0,1), xy(var,var),nsipm), 3, energy, xy(x_peak,y_peak), energy_l, energy_c-2),
+            Hit(npeak, Cluster(Q, xy( 1,0), xy(var,var),nsipm), 4, energy, xy(x_peak,y_peak), energy_l, energy_c+1),
+            Hit(npeak, Cluster(Q, xy( 4,5), xy(var,var),nsipm), 4, energy, xy(x_peak,y_peak), energy_l, energy_c+2),
+            Hit(npeak, Cluster(Q, xy( 5,3), xy(var,var),nsipm), 5, energy, xy(x_peak,y_peak), energy_l, energy_c+3)]
     voxels = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False)
     tracks = make_track_graphs(voxels)
+
     voxels_c = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False, energy_type=HitEnergy.energy_c)
     tracks_c = make_track_graphs(voxels_c)
 
@@ -700,6 +701,11 @@ def test_paolina_functions_with_hit_energy_different_from_default_value(requeste
     energies_c.sort()
 
     assert not np.allclose(energies, energies_c)
+
+    energies_c = [v.E for v in voxels_c]
+    e_thr = min(energies_c) + fraction_zero_one * (max(energies_c) - min(energies_c))
+    # Test that this function doesn't fail
+    mod_voxels_c = drop_end_point_voxels(voxels_c, e_thr, min_vxls=0)
 
 
 def test_make_tracks_function(ICDATADIR):

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -684,6 +684,18 @@ def test_paolina_functions_with_hit_energy_different_from_default_value(hits, re
     # Test that this function doesn't fail
     mod_voxels_c = drop_end_point_voxels(voxels_c, e_thr, min_vxls=0)
 
+    tot_energy     = sum(getattr(h, energy_type.value) for v in voxels_c     for h in v.hits) 
+    tot_mod_energy = sum(getattr(h, energy_type.value) for v in mod_voxels_c for h in v.hits) 
+
+    assert np.isclose(tot_energy, tot_mod_energy)
+
+    tot_default_energy     = sum(h.energy for v in voxels_c     for h in v.hits)
+    tot_mod_default_energy = sum(h.energy for v in mod_voxels_c for h in v.hits)
+
+    # We don't want to modify the default energy of hits, if the voxels are made with energy_c
+    if len(mod_voxels_c) < len(voxels_c):
+        assert tot_default_energy > tot_mod_default_energy
+
 
 def test_make_tracks_function(ICDATADIR):
 

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -688,6 +688,10 @@ def test_paolina_functions_with_hit_energy_different_from_default_value(hits, re
     # Test that this function doesn't fail
     mod_voxels_c = drop_end_point_voxels(voxels_c, e_thr, min_vxls=0)
 
+    for voxel in mod_voxels_c:
+        assert     np.isclose(voxel.energy, sum(h.energy_c for h in voxel.hits))
+        assert not np.isclose(voxel.energy, sum(h.energy   for h in voxel.hits))
+
 
 def test_make_tracks_function(ICDATADIR):
 

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -19,6 +19,7 @@ parametrize = mark.parametrize
 
 from hypothesis            import given
 from hypothesis            import settings
+from hypothesis            import assume
 from hypothesis.strategies import composite
 from hypothesis.strategies import lists
 from hypothesis.strategies import floats
@@ -85,6 +86,7 @@ def hit(draw, min_value=1, max_value=100):
     E     = draw(floats  ( 50, 100))
     E_l   = draw(floats  ( 50, 100))
     E_c   = draw(floats  ( 50, 100))
+    assume(not np.isclose(E_c, E))
     x_peak= draw(floats  (-10,  10))
     y_peak= draw(floats  (-10,  10))
 
@@ -664,23 +666,9 @@ def test_paolina_functions_with_voxels_without_associated_hits(blob_radius, min_
         assert np.allclose(blob_centre(b), b.pos)
 
 
-@given(box_sizes, radius, fraction_zero_one)
-def test_paolina_functions_with_hit_energy_different_from_default_value(requested_voxel_dimensions, blob_radius, fraction_zero_one):
+@given(bunch_of_corrected_hits(), box_sizes, radius, fraction_zero_one)
+def test_paolina_functions_with_hit_energy_different_from_default_value(hits, requested_voxel_dimensions, blob_radius, fraction_zero_one):
 
-    npeak = 0
-    Q     = 1
-    var   = 0
-    nsipm = 1
-    energy = 5
-    energy_l = energy + 1
-    energy_c = energy + 2
-    x_peak = y_peak = 0
-    hits = [Hit(npeak, Cluster(Q, xy(-1,0), xy(var,var),nsipm), 1, energy, xy(x_peak,y_peak), energy_l, energy_c),
-            Hit(npeak, Cluster(Q, xy( 0,0), xy(var,var),nsipm), 2, energy, xy(x_peak,y_peak), energy_l, energy_c-1),
-            Hit(npeak, Cluster(Q, xy( 0,1), xy(var,var),nsipm), 3, energy, xy(x_peak,y_peak), energy_l, energy_c-2),
-            Hit(npeak, Cluster(Q, xy( 1,0), xy(var,var),nsipm), 4, energy, xy(x_peak,y_peak), energy_l, energy_c+1),
-            Hit(npeak, Cluster(Q, xy( 4,5), xy(var,var),nsipm), 4, energy, xy(x_peak,y_peak), energy_l, energy_c+2),
-            Hit(npeak, Cluster(Q, xy( 5,3), xy(var,var),nsipm), 5, energy, xy(x_peak,y_peak), energy_l, energy_c+3)]
     voxels = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False)
     tracks = make_track_graphs(voxels)
 


### PR DESCRIPTION
This PR fixes (and add a test to show the incorrect behaviour) a problem in the `drop_voxel` function, when a hit energy different than the default one was used to build the voxels. While a `Hit` object has several energies (raw, corrected...), a `Voxel` object just has one, and it has to be accessed through the `voxel.energy` attribute.
Additionally, another bug in the check of the length of the neighbour list has been found and fixed.