### PR TITLE
Change hit attribute

### DIFF
--- a/invisible_cities/cities/penthesilea_test.py
+++ b/invisible_cities/cities/penthesilea_test.py
@@ -8,6 +8,7 @@ from .. core.core_functions    import in_range
 from .. core.system_of_units_c import units
 from .. core.testing_utils     import assert_dataframes_close
 from .. core.testing_utils     import assert_tables_equality
+from .. core.testing_utils     import assert_MChit_equality
 from .. core.configure         import configure
 from .. core.configure         import all as all_events
 from .. io                     import dst_io as dio
@@ -172,7 +173,7 @@ def test_penthesilea_true_hits_are_correct(KrMC_true_hits, config_tmpdir):
         penthesilea_hits = penthesilea_evts[evt_no]
 
         assert len(penthesilea_hits) == len(true_hits)
-        assert all(p_hit == t_hit for p_hit, t_hit in zip(penthesilea_hits, true_hits))
+        (assert_MChit_equality(p_hit, t_hit) for p_hit, t_hit in zip(penthesilea_hits, true_hits))
 
 
 @mark.skip("This scenario is not possible in liquid cities")

--- a/invisible_cities/cities/penthesilea_test.py
+++ b/invisible_cities/cities/penthesilea_test.py
@@ -16,6 +16,9 @@ from .. io.mcinfo_io           import load_mchits
 from .  penthesilea            import penthesilea
 
 
+#in order not to fail direct comparation tests when changing hit attribute we compare only the columns that penthesilea is using
+columns = ['event', 'time', 'npeak', 'Xpeak', 'Ypeak', 'nsipm', 'X', 'Y', 'Xrms', 'Yrms', 'Z', 'Q', 'E']
+
 def test_penthesilea_KrMC(KrMC_pmaps_filename, KrMC_hdst, KrMC_kdst, config_tmpdir):
     PATH_IN   = KrMC_pmaps_filename
     PATH_OUT  = os.path.join(config_tmpdir,'Kr_HDST.h5')
@@ -39,10 +42,11 @@ def test_penthesilea_KrMC(KrMC_pmaps_filename, KrMC_hdst, KrMC_kdst, config_tmpd
     df_penthesilea_dst  = dio.load_dst(PATH_OUT , 'DST' , 'Events')
     assert len(set(df_penthesilea_dst .event)) == cnt.events_out
     assert len(set(df_penthesilea_reco.event)) == cnt.events_out
-    assert_dataframes_close(df_penthesilea_reco, DF_TRUE_RECO,
-                            check_types=False)
-    assert_dataframes_close(df_penthesilea_dst , DF_TRUE_DST ,
-                            check_types=False, rtol=1e-4)
+
+    assert_dataframes_close(df_penthesilea_reco[columns], DF_TRUE_RECO[columns],
+                            check_types=False           , rtol=1e-4            )
+    assert_dataframes_close(df_penthesilea_dst          , DF_TRUE_DST          ,
+                            check_types=False           , rtol=1e-4            )
 
 
 def test_penthesilea_filter_events(config_tmpdir, Kr_pmaps_run4628_filename):
@@ -133,7 +137,7 @@ def test_penthesilea_threshold_rebin(ICDATADIR, output_tmpdir):
     expected_dst = dio.load_dst(true_output, 'RECO', 'Events')
 
     assert len(set(output_dst.event)) == len(set(expected_dst.event))
-    assert_dataframes_close(output_dst, expected_dst, check_types=False)
+    assert_dataframes_close(output_dst[columns], expected_dst[columns], check_types=False)
 
 
 @mark.serial
@@ -219,7 +223,7 @@ def test_penthesilea_read_multiple_files(ICDATADIR, output_tmpdir):
             assert last_particle_list[nevents_out_in_first_file] - last_particle_list[nevents_out_in_first_file - 1] == nparticles_in_first_event_out
             assert last_hit_list     [nevents_out_in_first_file] - last_hit_list     [nevents_out_in_first_file - 1] == nhits_in_first_event_out
 
-
+@mark.skip("Temporar skip till we decide on Hit class attributes")
 def test_penthesilea_exact_result(ICDATADIR, output_tmpdir):
     file_in     = os.path.join(ICDATADIR    ,  "Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts.PMP.h5")
     file_out    = os.path.join(output_tmpdir,                   "exact_result_penthesilea.h5")

--- a/invisible_cities/cities/penthesilea_test.py
+++ b/invisible_cities/cities/penthesilea_test.py
@@ -224,7 +224,7 @@ def test_penthesilea_read_multiple_files(ICDATADIR, output_tmpdir):
             assert last_particle_list[nevents_out_in_first_file] - last_particle_list[nevents_out_in_first_file - 1] == nparticles_in_first_event_out
             assert last_hit_list     [nevents_out_in_first_file] - last_hit_list     [nevents_out_in_first_file - 1] == nhits_in_first_event_out
 
-@mark.skip("Temporar skip till we decide on Hit class attributes")
+
 def test_penthesilea_exact_result(ICDATADIR, output_tmpdir):
     file_in     = os.path.join(ICDATADIR    ,  "Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts.PMP.h5")
     file_out    = os.path.join(output_tmpdir,                   "exact_result_penthesilea.h5")

--- a/invisible_cities/core/testing_utils.py
+++ b/invisible_cities/core/testing_utils.py
@@ -165,3 +165,24 @@ def assert_cluster_equality(a_cluster, b_cluster):
     assert             a_cluster.Yrms  == approx (b_cluster.Yrms )
     assert             a_cluster.R     == approx (b_cluster.R    )
     assert             a_cluster.Phi   == approx (b_cluster.Phi  )
+
+def assert_bhit_equality(a_hit, b_hit):
+    assert np.allclose(a_hit.pos , b_hit.pos)
+    assert np.allclose(a_hit.XYZ , b_hit.XYZ)
+
+    assert  a_hit.E  == approx (b_hit.E)
+    assert  a_hit.X  == approx (b_hit.X)
+    assert  a_hit.Y  == approx (b_hit.Y)
+    assert  a_hit.Z  == approx (b_hit.Z)
+
+def assert_MChit_equality(a_hit, b_hit):
+    assert_bhit_equality   (a_hit, b_hit)
+    assert  a_hit.time  == approx (b_hit.time)
+
+def assert_hit_equality(a_hit, b_hit):
+    assert_bhit_equality   (a_hit, b_hit)
+    assert_cluster_equality(a_hit, b_hit)
+    assert a_hit.Ec           == approx (b_hit.Ec         )
+    assert a_hit.Xpeak        == approx (b_hit.Xpeak      )
+    assert a_hit.Ypeak        == approx (b_hit.Ypeak      )
+    assert a_hit.peak_number  == exactly(b_hit.peak_number)

--- a/invisible_cities/database/test_data/Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts.HDST.h5
+++ b/invisible_cities/database/test_data/Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts.HDST.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a62d1384c66b09dad9e476e2be5c708bad7c052b8d1522b03ef22caf097b3c5d
-size 80428
+oid sha256:2dbcbe23e749112af9c4519ecfd9487e39b06132b30bfeff9e4f85089efccf61
+size 80343

--- a/invisible_cities/database/test_data/dst_NEXT_v1_00_05_Tl_ACTIVE_100_0_7bar_DST_10_merged.h5
+++ b/invisible_cities/database/test_data/dst_NEXT_v1_00_05_Tl_ACTIVE_100_0_7bar_DST_10_merged.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7f27dced790128e9953704e5213af4a86a67175eb23171ae4509c055561b08ec
-size 12650
+oid sha256:3fe2354fee3aa164df4ff4ed5424ce2cd79b84c5df030ed048e340e7bc5b83c6
+size 12682

--- a/invisible_cities/evm/nh5.py
+++ b/invisible_cities/evm/nh5.py
@@ -230,11 +230,9 @@ class HitsTable(tb.IsDescription):
     Z        = tb.Float64Col(pos=10)
     Q        = tb.Float64Col(pos=11)
     E        = tb.Float64Col(pos=12)
-    Ql       = tb.Float64Col(pos=13)
-    El       = tb.Float64Col(pos=14)
-    Qc       = tb.Float64Col(pos=15)
-    Ec       = tb.Float64Col(pos=16)
-    Zc       = tb.Float64Col(pos=17)
+    Qc       = tb.Float64Col(pos=13)
+    Ec       = tb.Float64Col(pos=14)
+    track_id = tb.  Int32Col(pos=15)
 
 
 class VoxelsTable(tb.IsDescription):

--- a/invisible_cities/io/hits_io.py
+++ b/invisible_cities/io/hits_io.py
@@ -36,7 +36,7 @@ def load_hits(DST_file_name):
         current_event = all_events.setdefault(event[i],
                                               HitCollection(event[i], time[i]))
         hit = Hit(npeak[i],
-                 Cluster(Q[i], xy(X[i], Y[i]), xy(Xrms[i], Yrms[i]),
+                 Cluster(Q[i], xy(X[i], Y[i]), xy(Xrms[i]**2, Yrms[i]**2),
                          nsipm[i], Z[i], E[i]), Z[i], E[i], xy(Xpeak[i], Ypeak[i]))
         current_event.hits.append(hit)
     return all_events
@@ -68,7 +68,7 @@ def load_hits_skipping_NN(DST_file_name):
         current_event = all_events.setdefault(event[i],
                                               HitCollection(event[i], time[i]))
         hit = Hit(npeak[i],
-                 Cluster(Q[i], xy(X[i], Y[i]), xy(Xrms[i], Yrms[i]),
+                 Cluster(Q[i], xy(X[i], Y[i]), xy(Xrms[i]**2, Yrms[i]**2),
                          nsipm[i], Z[i], E[i]), Z[i], E[i], xy(Xpeak[i], Ypeak[i]))
         if(hit.Q != NN):
             current_event.hits.append(hit)

--- a/invisible_cities/reco/hits_functions.py
+++ b/invisible_cities/reco/hits_functions.py
@@ -37,7 +37,7 @@ def merge_NN_hits(hits : List[evm.Hit], same_peak : bool = True) -> List[evm.Hit
             hits_to_correct.append([h,nn_h.E*(h.E/en_tot)])
 
     for h, en in hits_to_correct:
-        h.energy += en
+        h.E += en
     return non_nn_hits
 
 def threshold_hits(hits : List[evm.Hit], th : float) -> List[evm.Hit]:
@@ -57,6 +57,6 @@ def threshold_hits(hits : List[evm.Hit], th : float) -> List[evm.Hit]:
             hits_pass_th=list(compress(deepcopy(slice_hits), mask_thresh))
             es = split_energy(e_slice, hits_pass_th)
             for i,x in enumerate(hits_pass_th):
-                x.energy=es[i]
+                x.E=es[i]
                 new_hits.append(x)
         return new_hits

--- a/invisible_cities/reco/hits_functions_test.py
+++ b/invisible_cities/reco/hits_functions_test.py
@@ -7,6 +7,7 @@ from   .. evm.event_model        import Hit
 from   .. evm.event_model        import Cluster
 from   .. types.ic_types         import xy
 from   .. core.system_of_units_c import units
+from   .. core.testing_utils     import assert_hit_equality
 from   .. types.ic_types         import NN
 from   .. cities.penthesilea     import penthesilea
 from   .. io                     import hits_io          as hio
@@ -57,7 +58,7 @@ def test_merge_NN_not_modify_input(hits):
     after_len = len(hits)
     assert before_len == after_len
     for h1, h2 in zip(hits, hits_org):
-        assert h1== h2
+        assert_hit_equality(h1, h2)
 
 @given(list_of_hits())
 def test_merge_hits_energy_conserved(hits):
@@ -68,9 +69,10 @@ def test_merge_NN_hits_exact(TlMC_hits, TlMC_hits_merged):
     for ev, hitc in TlMC_hits.items():
         hits_test  = TlMC_hits_merged[ev].hits
         hits_merged = merge_NN_hits(hitc.hits)
-        assert len(hits_test)==len(hits_merged)
-        for h1, h2 in zip(hits_test,hits_merged):
-            assert h1==h2
+        assert len(hits_test) == len(hits_merged)
+        for h1, h2 in zip(hits_test, hits_merged):
+            print(h1.Xrms, h1.Yrms, h2.Xrms, h2.Yrms)
+            assert_hit_equality(h1, h2)
 @given(threshs=thresholds(1,1))
 @settings(deadline=None, max_examples = 1)
 @mark.slow
@@ -123,7 +125,7 @@ def test_threshold_hits_not_modify_input(hits, th):
     after_len = len(hits)
     assert before_len == after_len
     for h1, h2 in zip(hits, hits_org):
-        assert h1== h2
+        assert_hit_equality(h1, h2)
 
 @given(list_of_hits(), floats())
 def test_threshold_hits_energy_conserved(hits,th):

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -37,7 +37,7 @@ def bounding_box(seq : BHit) -> Sequence[np.ndarray]:
 def voxelize_hits(hits             : Sequence[BHit],
                   voxel_dimensions : np.ndarray,
                   strict_voxel_size: bool = False,
-                  energy_type      : HitEnergy = HitEnergy.energy) -> List[Voxel]:
+                  energy_type      : HitEnergy = HitEnergy.E) -> List[Voxel]:
     # 1. Find bounding box of all hits.
     # 2. Allocate hits to regular sub-boxes within bounding box, using histogramdd.
     # 3. Calculate voxel energies by summing energies of hits within each sub-box.
@@ -331,7 +331,7 @@ def drop_end_point_voxels(voxels: Sequence[Voxel], energy_threshold: float, min_
                         min_v = v
 
             ### add voxel energy to voxel
-            min_v.energy += the_vox.energy
+            min_v.E += the_vox.E
 
             return 1
 
@@ -351,8 +351,8 @@ def drop_end_point_voxels(voxels: Sequence[Voxel], energy_threshold: float, min_
                         min_v = v
 
         ### add voxel energy to hit and to voxel, separately
-        setattr(min_hit, e_type, getattr(min_hit, e_type) + the_vox.energy)
-        min_v.energy += the_vox.energy
+        setattr(min_hit, e_type, getattr(min_hit, e_type) + the_vox.E)
+        min_v.E += the_vox.E
 
         return 1
 


### PR DESCRIPTION
This simple PR removes El, Ql and Zc from Hit and Cluster class and adds track_id to Hit class since it will be needed in Esmeralda.
What is not clear is if we want to keep the energies as properties since in paolina_functions they are modified and is a bit messy to keep track of which attributes are changeable and which arent, thoughts @paolafer , @jjgomezcadenas, @jerenner 