### PR TITLE
Charge type in threshold hits

### DIFF
--- a/invisible_cities/reco/hits_functions.py
+++ b/invisible_cities/reco/hits_functions.py
@@ -40,7 +40,7 @@ def merge_NN_hits(hits : List[evm.Hit], same_peak : bool = True) -> List[evm.Hit
         h.E += en
     return non_nn_hits
 
-def threshold_hits(hits : List[evm.Hit], th : float) -> List[evm.Hit]:
+def threshold_hits(hits : List[evm.Hit], th : float, on_corrected : bool=False) -> List[evm.Hit]:
     """Returns list of the hits which charge is above the threshold. The energy of the hits below the threshold is distributed among the hits in the same time slice. """
     if th==0:
         return hits
@@ -49,14 +49,17 @@ def threshold_hits(hits : List[evm.Hit], th : float) -> List[evm.Hit]:
         for z_slice in np.unique([x.Z for x in hits]):
             slice_hits  = [x for x in hits if x.Z == z_slice]
             e_slice     = sum([x.E for x in slice_hits])
-            mask_thresh = np.array([x.Q>=th for x in slice_hits])
-            if sum(mask_thresh)<1:
+            if on_corrected:
+                mask_thresh = np.array([x.Qc >= th for x in slice_hits])
+            else:
+                mask_thresh = np.array([x.Q  >= th for x in slice_hits])
+            if sum(mask_thresh) < 1:
                 hit = evm.Hit(slice_hits[0].npeak, evm.Cluster(NN, xy(0,0), xy(0,0), 0), z_slice, e_slice, xy(slice_hits[0].Xpeak,slice_hits[0].Ypeak))
                 new_hits.append(hit)
                 continue
-            hits_pass_th=list(compress(deepcopy(slice_hits), mask_thresh))
+            hits_pass_th = list(compress(deepcopy(slice_hits), mask_thresh))
             es = split_energy(e_slice, hits_pass_th)
             for i,x in enumerate(hits_pass_th):
-                x.E=es[i]
+                x.E = es[i]
                 new_hits.append(x)
         return new_hits

--- a/invisible_cities/reco/hits_functions_test.py
+++ b/invisible_cities/reco/hits_functions_test.py
@@ -2,6 +2,7 @@ import os
 import numpy                     as     np
 from   numpy.testing             import assert_allclose
 from   numpy.testing             import assert_almost_equal
+from   numpy.testing             import assert_raises
 from   .. core.configure         import configure
 from   .. evm.event_model        import Hit
 from   .. evm.event_model        import Cluster
@@ -26,36 +27,39 @@ from hypothesis.strategies       import composite
 
 @composite
 def hit(draw, min_value=1, max_value=100):
-    x     = draw(floats  (  1,   5))
-    y     = draw(floats  (-10,  10))
-    xvar  = draw(floats  (.01,  .5))
-    yvar  = draw(floats  (.10,  .9))
-    Q     = draw(floats  ( -10, 100).map(lambda x: NN if x<=0 else x))
-    nsipm = draw(integers(  1,  20))
-    npeak = 0
-    z     = draw(floats  ( 50, 100))
-    E     = draw(floats  ( 50, 100))
-    x_peak= draw(floats  (  1,   5))
-    y_peak= draw(floats  (-10,  10))
-    return Hit(npeak,Cluster(Q,xy(x,y),xy(xvar,yvar),nsipm),z,E,xy(x_peak,y_peak))
+    x      = draw(floats  (  1,   5))
+    y      = draw(floats  (-10,  10))
+    xvar   = draw(floats  (.01,  .5))
+    yvar   = draw(floats  (.10,  .9))
+    Q      = draw(floats  (-10, 100).map(lambda x: NN if x<=0 else x))
+    nsipm  = draw(integers(  1,  20))
+    npeak  = 0
+    z      = draw(floats  ( 50, 100))
+    E      = draw(floats  ( 50, 100))
+    x_peak = draw(floats  (  1,   5))
+    y_peak = draw(floats  (-10,  10))
+    Qc     = draw(floats  (  0, 100).map(lambda x: -1 if Q==NN else x))
+    assume(abs(Qc - Q) > 1e-3)
+    return Hit(npeak,Cluster(Q, xy(x, y), xy(xvar, yvar), nsipm,  Qc=Qc), z, E, xy(x_peak, y_peak))
 
 @composite
 def list_of_hits(draw):
     list_of_hits = draw(lists(hit(), min_size=2, max_size=10))
-    assume(sum((h.Q >0 for h in list_of_hits))>=1)
+    assume(sum((h.Q > 0 for h in list_of_hits)) >= 1)
     return list_of_hits
 
 @composite
-def thresholds(draw,min_value=1,max_value=1):
-    th1 = draw (integers(  10,  20))
+def thresholds(draw, min_value=1, max_value=1):
+    th1 = draw (integers(  10   ,  20))
     th2 = draw (integers(  th1+1,  30))
     return th1, th2
+
 @given(list_of_hits())
 def test_merge_NN_not_modify_input(hits):
-    hits_org=deepcopy(hits)
-    before_len = len(hits)
+    hits_org    = deepcopy(hits)
+    before_len  = len(hits)
     hits_merged = merge_NN_hits(hits)
-    after_len = len(hits)
+    after_len   = len(hits)
     assert before_len == after_len
     for h1, h2 in zip(hits, hits_org):
         assert_hit_equality(h1, h2)
@@ -67,25 +71,26 @@ def test_merge_hits_energy_conserved(hits):
 
 def test_merge_NN_hits_exact(TlMC_hits, TlMC_hits_merged):
     for ev, hitc in TlMC_hits.items():
-        hits_test  = TlMC_hits_merged[ev].hits
+        hits_test   = TlMC_hits_merged[ev].hits
         hits_merged = merge_NN_hits(hitc.hits)
         assert len(hits_test) == len(hits_merged)
         for h1, h2 in zip(hits_test, hits_merged):
             print(h1.Xrms, h1.Yrms, h2.Xrms, h2.Yrms)
             assert_hit_equality(h1, h2)
-@given(threshs=thresholds(1,1))
+
+@given(threshs=thresholds(1, 1))
 @settings(deadline=None, max_examples = 1)
 @mark.slow
 def test_threshold_hits_with_penthesilea(config_tmpdir, Kr_pmaps_run4628_filename, threshs):
-    th1, th2=threshs
-    PATH_IN =  Kr_pmaps_run4628_filename
-    nrequired = 1
-    conf = configure('dummy invisible_cities/config/penthesilea.conf'.split())
+    th1, th2     = threshs
+    PATH_IN      = Kr_pmaps_run4628_filename
+    nrequired    = 1
+    conf         = configure('dummy invisible_cities/config/penthesilea.conf'.split())
     PATH_OUT_th1 = os.path.join(config_tmpdir, 'KrDST_4628_th1.h5')
-    conf.update(dict(run_number = 4628,
-                     files_in   = PATH_IN,
-                     file_out   = PATH_OUT_th1,
-                     event_range = (0, nrequired),
+    conf.update(dict(run_number        = 4628,
+                     files_in          = PATH_IN,
+                     file_out          = PATH_OUT_th1,
+                     event_range       = (0, nrequired),
                      slice_reco_params = dict(
                          Qthr          = th1 * units.pes,
                          Qlm           = 0 * units.pes,
@@ -108,26 +113,34 @@ def test_threshold_hits_with_penthesilea(config_tmpdir, Kr_pmaps_run4628_filenam
     hits_pent_th1 = hio.load_hits(PATH_OUT_th1)
     hits_pent_th2 = hio.load_hits(PATH_OUT_th2)
     ev_num = 1
-    hits_thresh  = threshold_hits (hits_pent_th1[ev_num].hits, th=th2)
+    hits_thresh  = threshold_hits (hits_pent_th1[ev_num].hits, th = th2)
     assert len(hits_pent_th2[ev_num].hits)==len(hits_thresh)
-    for h1, h2 in zip(hits_pent_th2[ev_num].hits,hits_thresh):
-        assert_almost_equal (h1.E, h2.E, 3)
-        assert_almost_equal (h1.Q, h2.Q, 3)
-        assert h1.Z==h2.Z
-        assert h1.X==h2.X
-        assert h1.Y==h2.Y
+    for h1, h2 in zip(hits_pent_th2[ev_num].hits, hits_thresh):
+        assert_hit_equality(h1, h2)
+
 
 @given(list_of_hits(), floats())
 def test_threshold_hits_not_modify_input(hits, th):
-    hits_org=deepcopy(hits)
-    before_len = len(hits)
+    hits_org    = deepcopy(hits)
+    before_len  = len(hits)
     hits_thresh = threshold_hits(hits,th)
-    after_len = len(hits)
+    after_len   = len(hits)
     assert before_len == after_len
     for h1, h2 in zip(hits, hits_org):
         assert_hit_equality(h1, h2)
 
+
 @given(list_of_hits(), floats())
-def test_threshold_hits_energy_conserved(hits,th):
-    hits_thresh = threshold_hits(hits,th)
-    assert_almost_equal(sum((h.E for h in hits)), sum((h.E for h in hits_thresh)))
+def test_threshold_hits_energy_conserved(hits, th):
+    hits_thresh   = threshold_hits(hits, th)
+    assert_almost_equal(sum((h.E for h in hits)), sum((h.E for h in hits_thresh  )))
+    hits_thresh_c = threshold_hits(hits, th, on_corrected = True)
+    assert_almost_equal(sum((h.E for h in hits)), sum((h.E for h in hits_thresh_c)))
+
+
+@given(list_of_hits(), floats())
+def test_threshold_hits_all_larger_than_th(hits, th):
+    hits_thresh      = threshold_hits(hits, th                     )
+    hits_thresh_cor  = threshold_hits(hits, th, on_corrected = True)
+    assert (h.Q  > th or h.Q == NN for h in hits_thresh    )
+    assert (h.Qc > th or h.Q == NN for h in hits_thresh_cor)


### PR DESCRIPTION
Adds option to correct hits based on Qc, leaving default option to be Q