### PR TITLE
Allow for 0 S1s after penthesilea S1 selection.

### DIFF
--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -430,7 +430,7 @@ def hit_builder(dbfile, run_number, drift_v, reco, rebin_slices, rebin_method):
         # take events with exactly one s1. Otherwise, the
         # convention is to take the first peak in the S1 object
         # as reference.
-        if len(selector_output.s1_peaks) > 0:
+        if np.any(selector_output.s1_peaks):
             first_s1 = np.where(selector_output.s1_peaks)[0][0]
             s1_t     = pmap.s1s[first_s1].time_at_max_energy
         else:

--- a/invisible_cities/cities/penthesilea_test.py
+++ b/invisible_cities/cities/penthesilea_test.py
@@ -250,15 +250,16 @@ def test_penthesilea_exact_result(ICDATADIR, output_tmpdir):
 
 def test_penthesilea_exact_result_noS1(ICDATADIR, output_tmpdir):
     file_in     = os.path.join(ICDATADIR    ,  "Kr83_nexus_v5_03_00_ACTIVE_7bar_10evts_PMP.h5")
-    file_out    = os.path.join(output_tmpdir,                   "exact_result_penthesilea_noS1.h5")
-    true_output = os.path.join(ICDATADIR    , "Kr83_nexus_v5_03_00_ACTIVE_7bar_noS1.HDST.h5")
+    file_out    = os.path.join(output_tmpdir,               "exact_result_penthesilea_noS1.h5")
+    true_output = os.path.join(ICDATADIR    ,   "Kr83_nexus_v5_03_00_ACTIVE_7bar_noS1.HDST.h5")
 
     conf = configure("penthesilea invisible_cities/config/penthesilea.conf".split())
-    conf.update(dict(run_number   = -6340,
-                     files_in     = file_in,
-                     file_out     = file_out,
+    conf.update(dict(run_number   =      -6340,
+                     files_in     =    file_in,
+                     file_out     =   file_out,
                      event_range  = all_events,
-                     s1_nmin      = 0))
+                     s1_nmin      =          0,
+                     s1_emin      =         10 * units.pes))
 
     penthesilea(**conf)
 

--- a/invisible_cities/core/testing_utils.py
+++ b/invisible_cities/core/testing_utils.py
@@ -146,8 +146,8 @@ def assert_tables_equality(got_table, expected_table):
 
     if table_got.dtype.names is not None:
         for col_name in table_got.dtype.names:
-            got      = table_got[col_name]
-            expected = table_got[col_name]
+            got      = table_got     [col_name]
+            expected = table_expected[col_name]
             assert type(got) == type(expected)
             try:
                 assert_allclose(got, expected)

--- a/invisible_cities/database/test_data/Kr83_nexus_v5_03_00_ACTIVE_7bar_noS1.HDST.h5
+++ b/invisible_cities/database/test_data/Kr83_nexus_v5_03_00_ACTIVE_7bar_noS1.HDST.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:66cca60d3e0c443cb9fe9ce1377172d7e64229322feb17b7ea5638d345400f01
-size 89349
+oid sha256:bacc03d7bca51fbe59932c04b9851e536296d75e7b44b16051537e5462e92a16
+size 89333


### PR DESCRIPTION
Previous code (PR #640 ) only worked if there where 0 S1s at the pmap level, not
after the S1 selection in penthesilea. This commit adapts the code to
that possibility which is the intended behavior. 