### PR TITLE
Faster function to load MC hits

### DIFF
--- a/invisible_cities/io/mcinfo_io.py
+++ b/invisible_cities/io/mcinfo_io.py
@@ -292,7 +292,7 @@ def compute_mchits_dict(mcevents:Mapping[int, Mapping[int, MCParticle]]) -> Mapp
 
 
 def read_mchit_evt (mctables: (tb.Table, tb.Table, tb.Table, tb.Table),
-                     event_number: int, last_row=0) -> ([tb.Table], [tb.Table], [tb.Table]):
+                     event_number: int, last_row=0) -> [tb.Table]:
     h5extents    = mctables[0]
     h5hits       = mctables[1]
 

--- a/invisible_cities/io/mcinfo_io.py
+++ b/invisible_cities/io/mcinfo_io.py
@@ -213,9 +213,6 @@ def read_mcinfo_evt (mctables: (tb.Table, tb.Table, tb.Table, tb.Table), event_n
                     ipart        = int(previous_row['last_particle']) + 1
 
             ihit_end  = this_row['last_hit']
-            if not return_only_hits:
-                ipart_end = this_row['last_particle']
-
             if len(h5hits) != 0:
                 while ihit <= ihit_end:
                     hit_rows.append(h5hits[ihit])
@@ -223,6 +220,7 @@ def read_mcinfo_evt (mctables: (tb.Table, tb.Table, tb.Table, tb.Table), event_n
 
             if return_only_hits: break
 
+            ipart_end = this_row['last_particle']
             while ipart <= ipart_end:
                 particle_rows.append(h5particles[ipart])
                 ipart += 1

--- a/invisible_cities/io/mcinfo_io.py
+++ b/invisible_cities/io/mcinfo_io.py
@@ -168,8 +168,7 @@ def load_mchits(file_name: str,
                 event_range=(0, int(1e9))) -> Mapping[int, Sequence[MCHit]]:
 
     with tb.open_file(file_name, mode='r') as h5in:
-        mcevents    = read_mcinfo(h5in, event_range)
-        mchits_dict = compute_mchits_dict(mcevents)
+        mchits_dict = read_mchit_info(h5in, event_range)
 
     return mchits_dict
 

--- a/invisible_cities/io/mcinfo_io.py
+++ b/invisible_cities/io/mcinfo_io.py
@@ -188,7 +188,7 @@ def load_mcsensor_response(file_name: str,
 
 
 def read_mcinfo_evt (mctables: (tb.Table, tb.Table, tb.Table, tb.Table), event_number: int, last_row=0,
-                     return_only_hits=False) -> ([tb.Table], [tb.Table], [tb.Table]):
+                     return_only_hits: bool=False) -> ([tb.Table], [tb.Table], [tb.Table]):
     h5extents    = mctables[0]
     h5hits       = mctables[1]
     h5particles  = mctables[2]


### PR DESCRIPTION
In this PR I changed the function called by `load_mchits()`, which loads the true MC hits of a range of events in a file. The previous function  loads all the true information (including particles) and returns only hits, while this function loads only the hits. The time is reduced to ~75% of the original time, for a file of ~8000 events of 511-keV gamma interactions, therefore I thought that this new implementation could be worth it. I haven't added any test, because we have already a test for the `load_mchits()` function, which uses internally the new function. This change should be transparent to the user. 