### PR TITLE
Upload database

### DIFF
--- a/invisible_cities/database/localdb.NEWDB.sqlite3
+++ b/invisible_cities/database/localdb.NEWDB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6755b910d3f590c47e3b69312f0941c0481cc7b0e6a93a6684337b4abd4bad11
-size 177504256
+oid sha256:8c9abde2a005be2a96073ad96cd778b506e0de39e7dc69e11d3c50212ac70351
+size 197898240

--- a/invisible_cities/database/localdb.NEWDB.sqlite3
+++ b/invisible_cities/database/localdb.NEWDB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8c9abde2a005be2a96073ad96cd778b506e0de39e7dc69e11d3c50212ac70351
+oid sha256:bb6054fff8a575a7c786697b5389827e69128d87da6eaf331fdd4eecfde2a662
 size 197898240


### PR DESCRIPTION
NEW Database has been uploaded with the gains for SiPMs and PMTs as well as the pdfs based on the calibrations from run 7146.

![sipmRunDifferencePlots](https://user-images.githubusercontent.com/32193826/58547941-a6206180-8208-11e9-8219-63150f655cf9.png)


![pmtRunDifferencePlots](https://user-images.githubusercontent.com/32193826/58547989-bd5f4f00-8208-11e9-87ce-ea30f779080b.png)

