### PR TITLE
Upload database

### DIFF
--- a/invisible_cities/database/localdb.NEWDB.sqlite3
+++ b/invisible_cities/database/localdb.NEWDB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bb6054fff8a575a7c786697b5389827e69128d87da6eaf331fdd4eecfde2a662
-size 197898240
+oid sha256:1afb7ec20a172a410cd0e7c698727fbee636414be39bf6db4f5e7db546e9b2a5
+size 218296320


### PR DESCRIPTION
NEW Database has been uploaded with the gains for SiPMs and PMTs as well as the pdfs based on the calibrations from run 7235.

![sipmRunDifferencePlots](https://user-images.githubusercontent.com/32193826/60591618-1f2e4e00-9d9f-11e9-8864-b591e0025b0b.png)

![pmt_gain_comparison](https://user-images.githubusercontent.com/32193826/60591652-32411e00-9d9f-11e9-8bb9-259e50b72ede.png)
