### PR TITLE
Upload database to fix masked channel

### DIFF
--- a/invisible_cities/database/localdb.NEWDB.sqlite3
+++ b/invisible_cities/database/localdb.NEWDB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1afb7ec20a172a410cd0e7c698727fbee636414be39bf6db4f5e7db546e9b2a5
+oid sha256:b0ff72e35811fff697fe46cf1aa32e070b9e7ce5e8d82b79481b3712f81ac800
 size 218296320


### PR DESCRIPTION
With this PR DB is uploaded in order to unmask PMT channel in neutrinos and in Canfranc.