### PR TITLE
Increase string length for creator process, according to nexus.

### DIFF
--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -82,8 +82,8 @@ def test_irene_electrons_40keV(config_tmpdir, ICDATADIR, s12params,
     # since they are in general test-specific
     # NB: avoid taking defaults for run number (test-specific)
 
-    PATH_IN  = os.path.join(ICDATADIR    , 'electrons_40keV_z250_RWF.h5')
-    PATH_OUT = os.path.join(config_tmpdir, 'electrons_40keV_z250_CWF.h5')
+    PATH_IN  = os.path.join(ICDATADIR    , 'electrons_40keV_ACTIVE_10evts_RWF.h5')
+    PATH_OUT = os.path.join(config_tmpdir, 'electrons_40keV_ACTIVE_10evts_CWF.h5')
 
     nrequired  = 2
 

--- a/invisible_cities/database/test_data/electrons_40keV_ACTIVE_10evts_RWF.h5
+++ b/invisible_cities/database/test_data/electrons_40keV_ACTIVE_10evts_RWF.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca43fc96b2393385371b54cdf8af38456b516c85f0097a8f257f757b9921372c
+size 1497328

--- a/invisible_cities/evm/nh5.py
+++ b/invisible_cities/evm/nh5.py
@@ -76,16 +76,16 @@ class MCHitInfo(tb.IsDescription):
 class MCParticleInfo(tb.IsDescription):
     """Stores the simulated particles as metadata using Pytables.
     """
-    particle_indx  = tb.  Int16Col(    pos=0)
-    particle_name  = tb. StringCol(20, pos=1)
-    primary        = tb.  Int16Col(    pos=2)
-    mother_indx    = tb.  Int16Col(    pos=3)
-    initial_vertex = tb.Float32Col(    pos=4, shape=4)
-    final_vertex   = tb.Float32Col(    pos=5, shape=4)
-    initial_volume = tb. StringCol(20, pos=6)
-    final_volume   = tb. StringCol(20, pos=7)
-    momentum       = tb.Float32Col(    pos=8, shape=3)
-    kin_energy     = tb.Float32Col(    pos=9)
+    particle_indx  = tb.  Int16Col(     pos= 0)
+    particle_name  = tb. StringCol( 20, pos= 1)
+    primary        = tb.  Int16Col(     pos= 2)
+    mother_indx    = tb.  Int16Col(     pos= 3)
+    initial_vertex = tb.Float32Col(     pos= 4, shape=4)
+    final_vertex   = tb.Float32Col(     pos= 5, shape=4)
+    initial_volume = tb. StringCol( 20, pos= 6)
+    final_volume   = tb. StringCol( 20, pos= 7)
+    momentum       = tb.Float32Col(     pos= 8, shape=3)
+    kin_energy     = tb.Float32Col(     pos= 9)
     creator_proc   = tb. StringCol(100, pos=10)
 
 

--- a/invisible_cities/evm/nh5.py
+++ b/invisible_cities/evm/nh5.py
@@ -86,7 +86,7 @@ class MCParticleInfo(tb.IsDescription):
     final_volume   = tb. StringCol(20, pos=7)
     momentum       = tb.Float32Col(    pos=8, shape=3)
     kin_energy     = tb.Float32Col(    pos=9)
-    creator_proc   = tb. StringCol(20, pos=10)
+    creator_proc   = tb. StringCol(100, pos=10)
 
 
 class SENSOR_WF(tb.IsDescription):


### PR DESCRIPTION
This is an extremely simple PR, in which I change the string length to store the name of the creator process of an MC particle, following the change implemented in nexus. There are hadronic processes whose names are longer than 20 characters, which was the length previously set.