### PR TITLE
DataFrame based readers for MC data

### DIFF
--- a/invisible_cities/io/mcinfo_io.py
+++ b/invisible_cities/io/mcinfo_io.py
@@ -342,11 +342,12 @@ def load_mcsensor_response_df(file_name : str,
                     how         = 'left')
     sns.evt_number.fillna(method='bfill', inplace = True)
 
-    sns['times'] = sns[sns.sensor_id.isin(pmt_ids)].time_bin * pmt_bin
-    sns.times.fillna(sns.time_bin * sipm_bin, inplace = True)
+    sns['time'] = sns[sns.sensor_id.isin(pmt_ids)].time_bin * pmt_bin
+    sns.time.fillna(sns.time_bin * sipm_bin, inplace = True)
 
     sns.evt_number = sns.evt_number.astype(int)
-    sns.set_index(['evt_number', 'sensor_id', 'time_bin'], inplace = True)
+    sns.rename(columns = {'evt_number': 'event_id'}, inplace = True)
+    sns.set_index(['event_id', 'sensor_id', 'time_bin'], inplace = True)
 
     return extents.evt_number.unique(), pmt_bin, sipm_bin, sns
 

--- a/invisible_cities/io/mcinfo_io.py
+++ b/invisible_cities/io/mcinfo_io.py
@@ -211,7 +211,7 @@ def load_mchits_df(h5in    : tb.file.File,
                          'x'           : hits_tb.col('hit_position')[:, 0],
                          'y'           : hits_tb.col('hit_position')[:, 1],
                          'z'           : hits_tb.col('hit_position')[:, 2],
-                         'E'           : hits_tb.col('hit_energy')})
+                         'energy'      : hits_tb.col('hit_energy')})
 
     evt_hit_df = extents[['last_hit', 'evt_number']]
     evt_hit_df.set_index('last_hit', inplace = True)
@@ -252,25 +252,25 @@ def load_mcparticles_df(iFileName: str) -> pd.DataFrame:
         p_tb = iFile.root.MC.particles
 
         # Generating parts DataFrame
-        parts = pd.DataFrame({'pid'     : p_tb.col('particle_indx'),
-                              'pname'   : p_tb.col('particle_name').astype('U20'),
-                              'primary' : p_tb.col('primary').astype('bool'),
-                              'mid'     : p_tb.col('mother_indx'),
-                              'ini_x'   : p_tb.col('initial_vertex')[:, 0],
-                              'ini_y'   : p_tb.col('initial_vertex')[:, 1],
-                              'ini_z'   : p_tb.col('initial_vertex')[:, 2],
-                              'ini_t'   : p_tb.col('initial_vertex')[:, 3],
-                              'fin_x'   : p_tb.col('final_vertex')[:, 0],
-                              'fin_y'   : p_tb.col('final_vertex')[:, 1],
-                              'fin_z'   : p_tb.col('final_vertex')[:, 2],
-                              'fin_t'   : p_tb.col('final_vertex')[:, 3],
-                              'ini_vol' : p_tb.col('initial_volume').astype('U20'),
-                              'fin_vol' : p_tb.col('final_volume').astype('U20'),
-                              'ini_px'  : p_tb.col('momentum')[:, 0],
-                              'ini_py'  : p_tb.col('momentum')[:, 1],
-                              'ini_pz'  : p_tb.col('momentum')[:, 2],
-                              'k_eng'   : p_tb.col('kin_energy'),
-                              'c_proc'  : p_tb.col('creator_proc').astype('U20')})
+        parts = pd.DataFrame({'particle_id'       : p_tb.col('particle_indx'),
+                              'particle_name'     : p_tb.col('particle_name').astype('U20'),
+                              'primary'           : p_tb.col('primary').astype('bool'),
+                              'mother_id'         : p_tb.col('mother_indx'),
+                              'initial_x'         : p_tb.col('initial_vertex')[:, 0],
+                              'initial_y'         : p_tb.col('initial_vertex')[:, 1],
+                              'initial_z'         : p_tb.col('initial_vertex')[:, 2],
+                              'initial_t'         : p_tb.col('initial_vertex')[:, 3],
+                              'final_x'           : p_tb.col('final_vertex')[:, 0],
+                              'final_y'           : p_tb.col('final_vertex')[:, 1],
+                              'final_z'           : p_tb.col('final_vertex')[:, 2],
+                              'final_t'           : p_tb.col('final_vertex')[:, 3],
+                              'initial_volume'    : p_tb.col('initial_volume').astype('U20'),
+                              'final_volume'      : p_tb.col('final_volume').astype('U20'),
+                              'initial_momentum_x': p_tb.col('momentum')[:, 0],
+                              'initial_momentum_y': p_tb.col('momentum')[:, 1],
+                              'initial_momentum_z': p_tb.col('momentum')[:, 2],
+                              'kin_energy'        : p_tb.col('kin_energy'),
+                              'creator_proc'      : p_tb.col('creator_proc').astype('U20')})
 
         # Adding event info
         evt_part_df = extents[['last_particle', 'evt_number']]
@@ -284,7 +284,7 @@ def load_mcparticles_df(iFileName: str) -> pd.DataFrame:
         parts.event_id = parts.event_id.astype(int)
 
         # Setting the indexes
-        parts.set_index(['event_id', 'pid'], inplace=True)
+        parts.set_index(['event_id', 'particle_id'], inplace=True)
 
     return parts
 

--- a/invisible_cities/io/mcinfo_io_test.py
+++ b/invisible_cities/io/mcinfo_io_test.py
@@ -207,11 +207,11 @@ def test_load_mchits_df(mc_particle_and_hits_nexus_data):
         hit_df  = load_mchits_df(h5in, extents)
 
     evt = 0
-    assert np.allclose(X, hit_df.loc[evt].x   .values)
-    assert np.allclose(Y, hit_df.loc[evt].y   .values)
-    assert np.allclose(Z, hit_df.loc[evt].z   .values)
-    assert np.allclose(E, hit_df.loc[evt].E   .values)
-    assert np.allclose(t, hit_df.loc[evt].time.values)
+    assert np.allclose(X, hit_df.loc[evt].x     .values)
+    assert np.allclose(Y, hit_df.loc[evt].y     .values)
+    assert np.allclose(Z, hit_df.loc[evt].z     .values)
+    assert np.allclose(E, hit_df.loc[evt].energy.values)
+    assert np.allclose(t, hit_df.loc[evt].time  .values)
 
 
 def test_load_mchits_fromstr(mc_particle_and_hits_nexus_data):
@@ -220,11 +220,11 @@ def test_load_mchits_fromstr(mc_particle_and_hits_nexus_data):
     hit_df = load_mchits_fromstr(efile)
 
     evt = 0
-    assert np.allclose(X, hit_df.loc[evt].x   .values)
-    assert np.allclose(Y, hit_df.loc[evt].y   .values)
-    assert np.allclose(Z, hit_df.loc[evt].z   .values)
-    assert np.allclose(E, hit_df.loc[evt].E   .values)
-    assert np.allclose(t, hit_df.loc[evt].time.values)
+    assert np.allclose(X, hit_df.loc[evt].x     .values)
+    assert np.allclose(Y, hit_df.loc[evt].y     .values)
+    assert np.allclose(Z, hit_df.loc[evt].z     .values)
+    assert np.allclose(E, hit_df.loc[evt].energy.values)
+    assert np.allclose(t, hit_df.loc[evt].time  .values)
 
 
 def test_load_mcparticles(mc_particle_and_hits_nexus_data):
@@ -260,17 +260,21 @@ def test_load_mcparticles_df(mc_particle_and_hits_nexus_data):
     evt  = 0
     p_id = 1
     particle = mcparticle_df.loc[evt].loc[p_id]
-    assert particle.pname == name
-    assert np.isclose(particle.k_eng, k_eng)
+    assert particle.particle_name == name
+    assert np.isclose(particle.kin_energy, k_eng)
 
-    ini_vtx = particle[['ini_x', 'ini_y', 'ini_z', 'ini_t']]
-    assert_allclose(ini_vtx.tolist(), vi)
+    init_vtx = particle[['initial_x', 'initial_y',
+                         'initial_z', 'initial_t']]
+    assert_allclose(init_vtx.tolist(), vi)
 
-    fin_vtx = particle[['fin_x', 'fin_y', 'fin_z', 'fin_t']]
+    fin_vtx = particle[['final_x', 'final_y',
+                        'final_z', 'final_t']]
     assert_allclose(fin_vtx.tolist(), vf)
 
-    ini_mom = particle[['ini_px', 'ini_py', 'ini_pz']]
-    assert_allclose(ini_mom.tolist(), p)
+    init_mom = particle[['initial_momentum_x',
+                         'initial_momentum_y',
+                         'initial_momentum_z']]
+    assert_allclose(init_mom.tolist(), p)
 
 
 def test_load_sensors_data(mc_sensors_nexus_data):

--- a/invisible_cities/io/mcinfo_io_test.py
+++ b/invisible_cities/io/mcinfo_io_test.py
@@ -13,6 +13,7 @@ from .  mcinfo_io import read_mchits_df
 from .  mcinfo_io import load_mcparticles
 from .  mcinfo_io import load_mcparticles_df
 from .  mcinfo_io import read_mcparticles_df
+from .  mcinfo_io import get_sensor_binning
 from .  mcinfo_io import load_mcsensor_response
 from .  mcinfo_io import load_mcsensor_response_df
 from .  mcinfo_io import mc_info_writer
@@ -326,6 +327,18 @@ def test_load_sensors_data(mc_sensors_nexus_data):
     samples = list(zip(bins, wvf.charges))
 
     assert np.allclose(samples, sipm)
+
+
+def test_get_sensor_binning(mc_sensors_nexus_data):
+    fullsim_data, *_ = mc_sensors_nexus_data
+
+    sensor_binning = 100 * units.nanosecond, 1 * units.microsecond
+
+    binning = get_sensor_binning(fullsim_data)
+
+    assert len(binning) == 2
+    assert binning[0] in sensor_binning
+    assert binning[1] in sensor_binning
 
 
 def test_load_mcsensor_response_df(mc_sensors_nexus_data):

--- a/invisible_cities/io/mcinfo_io_test.py
+++ b/invisible_cities/io/mcinfo_io_test.py
@@ -1,18 +1,24 @@
 import os
 import numpy  as np
+import pandas as pd
 import tables as tb
 
-from glob    import glob
-from os.path import expandvars
+from glob          import glob
+from os.path       import expandvars
+from numpy.testing import assert_allclose
 
 from .  mcinfo_io import load_mchits
+from .  mcinfo_io import load_mchits_df
+from .  mcinfo_io import load_mchits_fromstr
 from .  mcinfo_io import load_mcparticles
+from .  mcinfo_io import load_mcparticles_df
 from .  mcinfo_io import load_mcsensor_response
+from .  mcinfo_io import load_mcsensor_response_df
 from .  mcinfo_io import mc_info_writer
 from .  mcinfo_io import read_mcinfo_evt
 
 from .. core            import system_of_units as units
-from ..core.exceptions  import NoParticleInfoInFile
+from .. core.exceptions import NoParticleInfoInFile
 
 from .. reco.tbl_functions import get_mc_info
 
@@ -193,6 +199,34 @@ def test_load_mchits(mc_particle_and_hits_nexus_data):
     assert np.allclose(t, ht)
 
 
+def test_load_mchits_df(mc_particle_and_hits_nexus_data):
+    efile, _, _, _, _, _, _, X, Y, Z, E, t = mc_particle_and_hits_nexus_data
+
+    with tb.open_file(efile) as h5in:
+        extents = pd.read_hdf(efile, 'MC/extents')
+        hit_df  = load_mchits_df(h5in, extents)
+
+    evt = 0
+    assert np.allclose(X, hit_df.loc[evt].x   .values)
+    assert np.allclose(Y, hit_df.loc[evt].y   .values)
+    assert np.allclose(Z, hit_df.loc[evt].z   .values)
+    assert np.allclose(E, hit_df.loc[evt].E   .values)
+    assert np.allclose(t, hit_df.loc[evt].time.values)
+
+
+def test_load_mchits_fromstr(mc_particle_and_hits_nexus_data):
+    efile, _, _, _, _, _, _, X, Y, Z, E, t = mc_particle_and_hits_nexus_data
+
+    hit_df = load_mchits_fromstr(efile)
+
+    evt = 0
+    assert np.allclose(X, hit_df.loc[evt].x   .values)
+    assert np.allclose(Y, hit_df.loc[evt].y   .values)
+    assert np.allclose(Z, hit_df.loc[evt].z   .values)
+    assert np.allclose(E, hit_df.loc[evt].E   .values)
+    assert np.allclose(t, hit_df.loc[evt].time.values)
+
+
 def test_load_mcparticles(mc_particle_and_hits_nexus_data):
     efile, name, vi, vf, p, Ep, nhits, X, Y, Z, E, t = mc_particle_and_hits_nexus_data
 
@@ -218,6 +252,27 @@ def test_load_mcparticles(mc_particle_and_hits_nexus_data):
     assert np.allclose(t, ht)
 
 
+def test_load_mcparticles_df(mc_particle_and_hits_nexus_data):
+    efile, name, vi, vf, p, k_eng, *_ = mc_particle_and_hits_nexus_data
+
+    mcparticle_df = load_mcparticles_df(efile)
+
+    evt  = 0
+    p_id = 1
+    particle = mcparticle_df.loc[evt].loc[p_id]
+    assert particle.pname == name
+    assert np.isclose(particle.k_eng, k_eng)
+
+    ini_vtx = particle[['ini_x', 'ini_y', 'ini_z', 'ini_t']]
+    assert_allclose(ini_vtx.tolist(), vi)
+
+    fin_vtx = particle[['fin_x', 'fin_y', 'fin_z', 'fin_t']]
+    assert_allclose(fin_vtx.tolist(), vf)
+
+    ini_mom = particle[['ini_px', 'ini_py', 'ini_pz']]
+    assert_allclose(ini_mom.tolist(), p)
+
+
 def test_load_sensors_data(mc_sensors_nexus_data):
     efile, pmt0_first, pmt0_last, pmt0_tot_samples, sipm_id, sipm = mc_sensors_nexus_data
 
@@ -239,6 +294,34 @@ def test_load_sensors_data(mc_sensors_nexus_data):
     samples = list(zip(bins, wvf.charges))
 
     assert np.allclose(samples, sipm)
+
+
+def test_load_mcsensor_response_df(mc_sensors_nexus_data):
+    efile, pmt0_first, pmt0_last, pmt0_tot_samples, sipm_id, sipm = mc_sensors_nexus_data
+
+    ## Should be generalised for other detectors but data
+    ## available at the moment is for new.
+    ## Should consider adding to test data!
+    list_evt, _, _, wfs = load_mcsensor_response_df(efile, 'new', -6400)
+
+    ## Check first pmt
+    pmt0_id   = 0
+    wf        = wfs.loc[list_evt[0]].loc[pmt0_id]
+    n_samp    = len(wf)
+    indx0     = (wf.index[0], wf.iloc[0].charge)
+    indx_last = (wf.index[n_samp - 1], wf.iloc[n_samp - 1].charge)
+
+    assert n_samp    == pmt0_tot_samples
+    assert indx0     == pmt0_first
+    assert indx_last == pmt0_last
+
+    ## Check chosen SiPM
+    sipm_wf = wfs.loc[list_evt[0]].loc[sipm_id]
+    bin_q   = [(sipm_wf.index[i], sipm_wf.iloc[i].charge)
+               for i in range(len(sipm_wf))]
+
+    assert np.all(bin_q == sipm)
+
 
 
 def test_read_last_sensor_response(mc_sensors_nexus_data):


### PR DESCRIPTION
New readers based on the FANAL readers
which speed up input for nexus saved
hdf5 data.

For a small file with 3 events, 395 hits, 212 particles:
load_mchits takes ~23.2 ms, new function: ~14 ms
load_mcparticles takes ~78 ms, new function ~25 ms

A larger file with 1000 evt, ~12000 hits:
load_mchits takes ~700 ms, new function ~25 ms