### PR TITLE
Return dropped voxels

### DIFF
--- a/invisible_cities/cities/esmeralda.py
+++ b/invisible_cities/cities/esmeralda.py
@@ -159,9 +159,10 @@ def track_blob_info_creator_extractor(vox_size         : [float, float, float],
                                    'vox_size_x', 'vox_size_y', 'vox_size_z'])
 
         if len(hitc.hits)>0:
-            voxels     = plf.voxelize_hits(hitc.hits, vox_size, strict_vox_size, evm.HitEnergy.Ec)
-            mod_voxels = plf.drop_end_point_voxels(voxels, energy_threshold, min_voxels)
-            tracks     = plf.make_track_graphs(mod_voxels)
+            voxels           = plf.voxelize_hits(hitc.hits, vox_size, strict_vox_size, evm.HitEnergy.Ec)
+            (    mod_voxels,
+             dropped_voxels) = plf.drop_end_point_voxels(voxels, energy_threshold, min_voxels)
+            tracks           = plf.make_track_graphs(mod_voxels)
 
             vox_size_x = voxels[0].size[0]
             vox_size_y = voxels[0].size[1]
@@ -229,7 +230,7 @@ def make_event_summary(event_number  : int              ,
                        out_of_map    : bool
                        ) -> pd.DataFrame:
     """
-    For a given event number, timestamp, topology info dataframe, paolina hits and kdst information returns a 
+    For a given event number, timestamp, topology info dataframe, paolina hits and kdst information returns a
     dataframe with the whole event summary.
 
     Parameters
@@ -454,7 +455,7 @@ def esmeralda(files_in, file_out, compression, event_range, print_mod, run_numbe
                          fl.branch(write_high_th_filter)              ,
                          hits_passed_high_th   .filter                ,
                          create_extract_track_blob_info               ,
-                         filter_events_topology                       , 
+                         filter_events_topology                       ,
                          fl.branch(write_hits_paolina)                ,
                          events_passed_topology.filter                ,
                          event_count_out       .spy                   ,

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -339,6 +339,10 @@ def drop_end_point_voxels(voxels: Sequence[Voxel], energy_threshold: float, min_
         for v in min_vs:
             v.E += the_vox.E/sum_en_v * v.E
 
+    def nan_energy(voxel):
+        voxel.E = np.nan
+        for hit in voxel.hits:
+            setattr(hit, e_type, np.nan)
 
     mod_voxels     = copy.deepcopy(voxels)
     dropped_voxels = []
@@ -361,6 +365,7 @@ def drop_end_point_voxels(voxels: Sequence[Voxel], energy_threshold: float, min_
                         mod_voxels    .remove(extreme)
                         dropped_voxels.append(extreme)
                         drop_voxel(mod_voxels, extreme)
+                        nan_energy(extreme)
                         modified = True
 
     return mod_voxels, dropped_voxels

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -337,7 +337,7 @@ def drop_end_point_voxels(voxels: Sequence[Voxel], energy_threshold: float, min_
         for h in min_hs:
             setattr(h, e_type, getattr(h, e_type) + getattr(h, e_type) * the_vox.E/sum_en_h)
         for v in min_vs:
-            v.E += the_vox.E/sum_en_v * v.E
+            v.E = sum(getattr(h, e_type) for h in v.hits)
 
     def nan_energy(voxel):
         voxel.E = np.nan

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -501,7 +501,7 @@ def test_energy_is_conserved_with_dropped_voxels(hits, requested_voxel_dimension
 
     energies = [v.E for v in voxels]
     e_thr = min(energies) + fraction_zero_one * (max(energies) - min(energies))
-    mod_voxels = drop_end_point_voxels(voxels, e_thr, min_voxels)
+    mod_voxels, _ = drop_end_point_voxels(voxels, e_thr, min_voxels)
     tot_final_energy = sum(v.E for v in mod_voxels)
     final_trks = make_track_graphs(mod_voxels)
     final_trk_energies = [sum(vox.E for vox in t.nodes()) for t in final_trks]
@@ -527,7 +527,7 @@ def test_initial_voxels_are_the_same_after_dropping_voxels(ICDATADIR):
     # This is the core of the test: collect data before/after ...
     ante_energies  = [v.E   for v in voxels]
     ante_positions = [v.XYZ for v in voxels]
-    mod_voxels = drop_end_point_voxels(voxels, e_thr, min_voxels)
+    mod_voxels, _ = drop_end_point_voxels(voxels, e_thr, min_voxels)
     post_energies  = [v.E   for v in voxels]
     post_positions = [v.XYZ for v in voxels]
 
@@ -559,7 +559,7 @@ def test_tracks_with_dropped_voxels(ICDATADIR):
     ini_energies = [sum(vox.E for vox in t.nodes()) for t in ini_trks]
     ini_n_voxels = np.array([len(t.nodes()) for t in ini_trks])
 
-    mod_voxels = drop_end_point_voxels(voxels, e_thr, min_voxels)
+    mod_voxels, _ = drop_end_point_voxels(voxels, e_thr, min_voxels)
 
     trks = make_track_graphs(mod_voxels)
     n_of_tracks = len(trks)
@@ -582,11 +582,12 @@ def test_drop_voxels_deterministic(ICDATADIR):
     min_voxels = 3
     vox_size   = [15.] * 3
 
-    all_hits     = load_hits(hit_file)
-    hits         = all_hits[evt_number].hits
-    voxels       = voxelize_hits(hits, vox_size, strict_voxel_size=False)
-    mod_voxels   = drop_end_point_voxels(sorted(voxels, key = lambda v:v.E, reverse = False), e_thr, min_voxels)
-    mod_voxels_r = drop_end_point_voxels(sorted(voxels, key = lambda v:v.E, reverse = True ), e_thr, min_voxels)
+    all_hits        = load_hits(hit_file)
+    hits            = all_hits[evt_number].hits
+    voxels          = voxelize_hits(hits, vox_size, strict_voxel_size=False)
+    mod_voxels  , _ = drop_end_point_voxels(sorted(voxels, key = lambda v:v.E, reverse = False), e_thr, min_voxels)
+    mod_voxels_r, _ = drop_end_point_voxels(sorted(voxels, key = lambda v:v.E, reverse = True ), e_thr, min_voxels)
+
     for v1, v2 in zip(sorted(mod_voxels, key = lambda v:v.E), sorted(mod_voxels_r, key = lambda v:v.E)):
         assert np.isclose(v1.E, v2.E)
 
@@ -596,7 +597,7 @@ def test_voxel_drop_in_short_tracks():
     e_thr = sum(v.E for v in voxels) + 1.
     min_voxels = 0
 
-    mod_voxels = drop_end_point_voxels(voxels, e_thr, min_voxels)
+    mod_voxels, _ = drop_end_point_voxels(voxels, e_thr, min_voxels)
 
     assert len(mod_voxels) >= 1
 
@@ -678,7 +679,7 @@ def test_paolina_functions_with_voxels_without_associated_hits(blob_radius, min_
 
     energies = [v.E for v in voxels]
     e_thr = min(energies) + fraction_zero_one * (max(energies) - min(energies))
-    mod_voxels = drop_end_point_voxels(voxels, e_thr, min_voxels)
+    mod_voxels, _ = drop_end_point_voxels(voxels, e_thr, min_voxels)
     trks = make_track_graphs(mod_voxels)
     for t in tracks:
         a, b = find_extrema(t)
@@ -707,10 +708,10 @@ def test_paolina_functions_with_hit_energy_different_from_default_value(hits, re
     energies_c = [v.E for v in voxels_c]
     e_thr = min(energies_c) + fraction_zero_one * (max(energies_c) - min(energies_c))
     # Test that this function doesn't fail
-    mod_voxels_c = drop_end_point_voxels(voxels_c, e_thr, min_vxls=0)
+    mod_voxels_c, _ = drop_end_point_voxels(voxels_c, e_thr, min_vxls=0)
 
-    tot_energy     = sum(getattr(h, energy_type.value) for v in voxels_c     for h in v.hits) 
-    tot_mod_energy = sum(getattr(h, energy_type.value) for v in mod_voxels_c for h in v.hits) 
+    tot_energy     = sum(getattr(h, energy_type.value) for v in voxels_c     for h in v.hits)
+    tot_mod_energy = sum(getattr(h, energy_type.value) for v in mod_voxels_c for h in v.hits)
 
     assert np.isclose(tot_energy, tot_mod_energy)
 
@@ -772,4 +773,3 @@ def test_make_voxel_graph_keeps_all_voxels(hits, voxel_dimensions):
     tracks = make_track_graphs(voxels)
     # assert sum of track energy equal to sum of hits energies
     assert_almost_equal(sum(get_track_energy(track) for track in tracks), sum(h.E for h in hits))
-

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -558,6 +558,21 @@ def test_drop_end_point_voxels_doesnt_modify_other_energy_types(hits, requested_
        requested_voxel_dimensions = box_sizes,
        min_voxels                 = min_n_of_voxels,
        fraction_zero_one          = fraction_zero_one)
+def test_drop_voxels_voxel_energy_is_sum_of_hits_general(hits, requested_voxel_dimensions, min_voxels, fraction_zero_one, energy_type):
+    voxels        = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False, energy_type=energy_type)
+    energies      = [v.E for v in voxels]
+    e_thr         = min(energies) + fraction_zero_one * (max(energies) - min(energies))
+    mod_voxels, _ = drop_end_point_voxels(voxels, e_thr, min_voxels)
+    for v in mod_voxels:
+        assert np.isclose(v.E, sum(getattr(h, energy_type.value) for h in v.hits))
+
+
+
+@mark.parametrize("energy_type", HitEnergy)
+@given(hits                       = bunch_of_corrected_hits(),
+       requested_voxel_dimensions = box_sizes,
+       min_voxels                 = min_n_of_voxels,
+       fraction_zero_one          = fraction_zero_one)
 def test_drop_end_point_voxels_constant_number_of_voxels_and_hits(hits, requested_voxel_dimensions, min_voxels, fraction_zero_one, energy_type):
     voxels           = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False, energy_type=energy_type)
     energies         = [v.E for v in voxels]

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -8,7 +8,7 @@ import numpy    as np
 import networkx as nx
 
 from itertools import combinations
-from functools import cmp_to_key
+from operator  import attrgetter
 
 from numpy.testing import assert_almost_equal
 
@@ -534,21 +534,15 @@ def test_dropped_voxels_have_nan_energy(hits, requested_voxel_dimensions, min_vo
        min_voxels                 = min_n_of_voxels,
        fraction_zero_one          = fraction_zero_one)
 def test_drop_end_point_voxels_doesnt_modify_other_energy_types(hits, requested_voxel_dimensions, min_voxels, fraction_zero_one, energy_type):
-    def compare_voxels(v1, v2):
-        if v1.X != v2.X: return -1 if v1.X < v2.X else +1
-        if v1.Y != v2.Y: return -1 if v1.Y < v2.Y else +1
-        if v1.Z != v2.Z: return -1 if v1.Z < v2.Z else +1
-        return 0
-
     def energy_from_hits(voxel, e_type):
         return [getattr(hit, e_type) for hit in voxel.hits]
 
     voxels     = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False, energy_type=energy_type)
-    voxels     = sorted(voxels, key=cmp_to_key(compare_voxels))
+    voxels     = sorted(voxels, key=attrgetter("xyz"))
     energies   = [v.E for v in voxels]
     e_thr      = min(energies) + fraction_zero_one * (max(energies) - min(energies))
     mod, drop  = drop_end_point_voxels(voxels, e_thr, min_voxels)
-    new_voxels = sorted(mod + drop, key=cmp_to_key(compare_voxels))
+    new_voxels = sorted(mod + drop, key=attrgetter("xyz"))
 
     for e_type in HitEnergy:
         if e_type is energy_type: continue


### PR DESCRIPTION
This PR will modify the `drop_end_point_voxels` to return both the modified voxels and the dropped ones so they can be given to `esmeralda` and write them to the output file.