### PR TITLE
Generalize in range

### DIFF
--- a/invisible_cities/core/core_functions.py
+++ b/invisible_cities/core/core_functions.py
@@ -63,7 +63,7 @@ def relative_difference(x, y, *, norm_mode=NormMode.first):
 
 def in_range(data, minval=-np.inf, maxval=np.inf, left_closed=True, right_closed=False):
     """
-    Find values in range [minval, maxval).
+    Find values from minval to maxval.
 
     Parameters
     ---------
@@ -73,16 +73,16 @@ def in_range(data, minval=-np.inf, maxval=np.inf, left_closed=True, right_closed
         Range minimum. Defaults to -inf.
     maxval : int or float, optional
         Range maximum. Defaults to +inf.
-    left   : {"open", "close"}
-        Use close (default) or open  interval on the lower bound
-    right  : {"open", "close"}
-        Use open  (default) or close interval on the upper bound
+    left_closed   : bool
+        Closed semi-interval if True (default); open if false.
+    right_closed  : {"open", "close"}
+        Closed semi-interval if True; open if false (default).
 
     Returns
     -------
     selection : np.ndarray
         Boolean array with the same dimension as the input. Contains True
-        for those values of data in the input range and False for the others.
+        for those values of data within the input range and False for the rest.
     """
     lower_bound = data >= minval if left_closed  else data > minval
     upper_bound = data <= maxval if right_closed else data < maxval

--- a/invisible_cities/core/core_functions.py
+++ b/invisible_cities/core/core_functions.py
@@ -59,7 +59,7 @@ def relative_difference(x, y, *, norm_mode=NormMode.first):
         raise TypeError(f"Unrecognized relative difference option: {norm_mode}")
 
 
-def in_range(data, minval=-np.inf, maxval=np.inf):
+def in_range(data, minval=-np.inf, maxval=np.inf, left="closed", right="open"):
     """
     Find values in range [minval, maxval).
 
@@ -71,6 +71,10 @@ def in_range(data, minval=-np.inf, maxval=np.inf):
         Range minimum. Defaults to -inf.
     maxval : int or float, optional
         Range maximum. Defaults to +inf.
+    left   : {"open", "close"}
+        Use close (default) or open  interval on the lower bound
+    right  : {"open", "close"}
+        Use open  (default) or close interval on the upper bound
 
     Returns
     -------
@@ -78,7 +82,9 @@ def in_range(data, minval=-np.inf, maxval=np.inf):
         Boolean array with the same dimension as the input. Contains True
         for those values of data in the input range and False for the others.
     """
-    return (minval <= data) & (data < maxval)
+    lower_bound = data >= minval if left  == "closed" else data > minval
+    upper_bound = data <= maxval if right == "closed" else data < maxval
+    return lower_bound & upper_bound
 
 
 def weighted_mean_and_var(data       : Sequence,

--- a/invisible_cities/core/core_functions.py
+++ b/invisible_cities/core/core_functions.py
@@ -19,11 +19,6 @@ class NormMode(enum.Enum):
     mean    = 4
 
 
-class Interval(AutoNameEnumBase):
-    open   = enum.auto()
-    closed = enum.auto()
-
-
 def merge_two_dicts(a,b):
     return {**a, **b}
 
@@ -66,7 +61,7 @@ def relative_difference(x, y, *, norm_mode=NormMode.first):
         raise TypeError(f"Unrecognized relative difference option: {norm_mode}")
 
 
-def in_range(data, minval=-np.inf, maxval=np.inf, left=Interval.closed, right=Interval.open):
+def in_range(data, minval=-np.inf, maxval=np.inf, left_closed=True, right_closed=False):
     """
     Find values in range [minval, maxval).
 
@@ -89,10 +84,8 @@ def in_range(data, minval=-np.inf, maxval=np.inf, left=Interval.closed, right=In
         Boolean array with the same dimension as the input. Contains True
         for those values of data in the input range and False for the others.
     """
-    if left not in Interval or right not in Interval:
-        raise ValueError("left and right must be an instance of Interval")
-    lower_bound = data >= minval if left  is Interval.closed else data > minval
-    upper_bound = data <= maxval if right is Interval.closed else data < maxval
+    lower_bound = data >= minval if left_closed  else data > minval
+    upper_bound = data <= maxval if right_closed else data < maxval
     return lower_bound & upper_bound
 
 

--- a/invisible_cities/core/core_functions.py
+++ b/invisible_cities/core/core_functions.py
@@ -9,12 +9,19 @@ import numpy as np
 
 from typing import Sequence
 
+from .. types.ic_types import AutoNameEnumBase
+
 
 class NormMode(enum.Enum):
     first   = 0
     second  = 1
     sumof   = 3
     mean    = 4
+
+
+class Interval(AutoNameEnumBase):
+    open   = enum.auto()
+    closed = enum.auto()
 
 
 def merge_two_dicts(a,b):
@@ -59,7 +66,7 @@ def relative_difference(x, y, *, norm_mode=NormMode.first):
         raise TypeError(f"Unrecognized relative difference option: {norm_mode}")
 
 
-def in_range(data, minval=-np.inf, maxval=np.inf, left="closed", right="open"):
+def in_range(data, minval=-np.inf, maxval=np.inf, left=Interval.closed, right=Interval.open):
     """
     Find values in range [minval, maxval).
 
@@ -82,8 +89,10 @@ def in_range(data, minval=-np.inf, maxval=np.inf, left="closed", right="open"):
         Boolean array with the same dimension as the input. Contains True
         for those values of data in the input range and False for the others.
     """
-    lower_bound = data >= minval if left  == "closed" else data > minval
-    upper_bound = data <= maxval if right == "closed" else data < maxval
+    if left not in Interval or right not in Interval:
+        raise ValueError("left and right must be an instance of Interval")
+    lower_bound = data >= minval if left  is Interval.closed else data > minval
+    upper_bound = data <= maxval if right is Interval.closed else data < maxval
     return lower_bound & upper_bound
 
 

--- a/invisible_cities/core/core_functions_test.py
+++ b/invisible_cities/core/core_functions_test.py
@@ -40,6 +40,7 @@ def test_timefunc(capfd):
     time_measured = float(time_measured)
     np.isclose(time, time_measured)
 
+
 def test_flat():
     inner_len = 12
     outer_len =  5
@@ -49,11 +50,14 @@ def test_flat():
         for j in range(inner_len):
             assert flattened[j + i * inner_len] == nested_list[i][j]
 
+
 def test_lrange():
     assert core.lrange(10) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
+
 def test_trange():
     assert core.trange(10) == (0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+
 
 @given(random_length_float_arrays())
 def test_in_range_infinite(data):

--- a/invisible_cities/core/core_functions_test.py
+++ b/invisible_cities/core/core_functions_test.py
@@ -83,7 +83,7 @@ def test_in_range_right_shape(data):
 @given(sorted_unique_arrays)
 def test_in_range_left_open_interval(data):
     # right doesn't matter because it's infinite
-    output = core.in_range(data, minval=data[0], maxval=np.inf, left="open")
+    output = core.in_range(data, minval=data[0], maxval=np.inf, left=core.Interval.open)
     assert not output[0]
     assert all(output[1:])
 
@@ -91,7 +91,7 @@ def test_in_range_left_open_interval(data):
 @given(sorted_unique_arrays)
 def test_in_range_right_open_interval(data):
     # left doesn't matter because it's infinite
-    output = core.in_range(data, minval=-np.inf, maxval=data[-1], right="open")
+    output = core.in_range(data, minval=-np.inf, maxval=data[-1], right=core.Interval.open)
     assert not output[-1]
     assert all(output[:-1])
 
@@ -99,14 +99,14 @@ def test_in_range_right_open_interval(data):
 @given(sorted_unique_arrays)
 def test_in_range_left_close_interval(data):
     # right doesn't matter because it's infinite
-    output = core.in_range(data, minval=data[0], maxval=np.inf, left="closed")
+    output = core.in_range(data, minval=data[0], maxval=np.inf, left=core.Interval.closed)
     assert all(output)
 
 
 @given(sorted_unique_arrays)
 def test_in_range_right_close_interval(data):
     # left doesn't matter because it's infinite
-    output = core.in_range(data, minval=-np.inf, maxval=data[-1], right="closed")
+    output = core.in_range(data, minval=-np.inf, maxval=data[-1], right=core.Interval.closed)
     assert all(output)
 
 

--- a/invisible_cities/core/core_functions_test.py
+++ b/invisible_cities/core/core_functions_test.py
@@ -83,7 +83,7 @@ def test_in_range_right_shape(data):
 @given(sorted_unique_arrays)
 def test_in_range_left_open_interval(data):
     # right doesn't matter because it's infinite
-    output = core.in_range(data, minval=data[0], maxval=np.inf, left=core.Interval.open)
+    output = core.in_range(data, minval=data[0], maxval=np.inf, left_closed=False)
     assert not output[0]
     assert all(output[1:])
 
@@ -91,7 +91,7 @@ def test_in_range_left_open_interval(data):
 @given(sorted_unique_arrays)
 def test_in_range_right_open_interval(data):
     # left doesn't matter because it's infinite
-    output = core.in_range(data, minval=-np.inf, maxval=data[-1], right=core.Interval.open)
+    output = core.in_range(data, minval=-np.inf, maxval=data[-1], right_closed=False)
     assert not output[-1]
     assert all(output[:-1])
 
@@ -99,25 +99,15 @@ def test_in_range_right_open_interval(data):
 @given(sorted_unique_arrays)
 def test_in_range_left_close_interval(data):
     # right doesn't matter because it's infinite
-    output = core.in_range(data, minval=data[0], maxval=np.inf, left=core.Interval.closed)
+    output = core.in_range(data, minval=data[0], maxval=np.inf, left_closed=True)
     assert all(output)
 
 
 @given(sorted_unique_arrays)
 def test_in_range_right_close_interval(data):
     # left doesn't matter because it's infinite
-    output = core.in_range(data, minval=-np.inf, maxval=data[-1], right=core.Interval.closed)
+    output = core.in_range(data, minval=-np.inf, maxval=data[-1], right_closed=True)
     assert all(output)
-
-
-@mark.parametrize("              left                right".split(),
-                  ((            "open",             "open"),
-                   (          "closed", core.Interval.open),
-                   (core.Interval.open,           "closed")))
-@given(data=sorted_unique_arrays)
-def test_in_range_raises_ValueError_when_invalid_argument(data, left, right):
-    with raises(ValueError):
-        output = core.in_range(data, left=left, right=right)
 
 
 @mark.parametrize(" first  second       norm_mode        expected".split(),

--- a/invisible_cities/core/core_functions_test.py
+++ b/invisible_cities/core/core_functions_test.py
@@ -110,6 +110,16 @@ def test_in_range_right_close_interval(data):
     assert all(output)
 
 
+@mark.parametrize("              left                right".split(),
+                  ((            "open",             "open"),
+                   (          "closed", core.Interval.open),
+                   (core.Interval.open,           "closed")))
+@given(data=sorted_unique_arrays)
+def test_in_range_raises_ValueError_when_invalid_argument(data, left, right):
+    with raises(ValueError):
+        output = core.in_range(data, left=left, right=right)
+
+
 @mark.parametrize(" first  second       norm_mode        expected".split(),
                   ((  1  ,    2  , core.NormMode.first ,   -1    ),
                    (  4  ,    2  , core.NormMode.second,    1    ),


### PR DESCRIPTION
The `in_range` function has been always working to select data in a left-closed, right-open interval (`[ )` ). This PR generalizes it adding two keyword arguments to select which type of interval to use in each of the bounds.

Some tests are added to verify this new functionality.