### PR TITLE
Fix hypothesis health checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ install:
   - source manage.sh work_in_python_version_no_tests ${IC_PYTHON_VERSION}
 
 script:
-  - HYPOTHESIS_PROFILE=travis-ci bash manage.sh run_tests
+  - HYPOTHESIS_PROFILE=travis-ci bash manage.sh run_tests_par

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ install:
   - source manage.sh work_in_python_version_no_tests ${IC_PYTHON_VERSION}
 
 script:
-  - HYPOTHESIS_PROFILE=hard bash manage.sh run_tests_par 4
+  - HYPOTHESIS_PROFILE=hard bash manage.sh run_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ install:
   - source manage.sh work_in_python_version_no_tests ${IC_PYTHON_VERSION}
 
 script:
-  - HYPOTHESIS_PROFILE=hard bash manage.sh run_tests
+  - HYPOTHESIS_PROFILE=travis-ci bash manage.sh run_tests

--- a/conftest.py
+++ b/conftest.py
@@ -4,6 +4,7 @@ from hypothesis import settings
 from hypothesis import Verbosity
 
 # In addition to the 'default' profile, we provide
+settings.register_profile("travis-ci" , settings(max_examples = 1000, deadline=300))
 settings.register_profile("hard"      , settings(max_examples = 1000))
 settings.register_profile("dev"       , settings(max_examples =   10))
 settings.register_profile("hard_nocov", settings(max_examples = 1000, use_coverage=False))

--- a/invisible_cities/core/testing_utils_test.py
+++ b/invisible_cities/core/testing_utils_test.py
@@ -7,6 +7,7 @@ from hypothesis.strategies        import floats
 from hypothesis.strategies        import integers
 from hypothesis.     extra.pandas import data_frames
 from hypothesis.     extra.pandas import column
+from hypothesis.     extra.pandas import range_indexes
 from . testing_utils              import all_elements_close
 from . testing_utils              import assert_tables_equality
 
@@ -31,7 +32,8 @@ def test_all_elements_close_par(mu, sigma):
 
 @given(data_frames([column('A', dtype=int  ),
                     column('B', dtype=float),
-                    column('C', dtype=str  )]))
+                    column('C', dtype=str  )],
+                   index = range_indexes(max_size=5)))
 def test_assert_tables_equality(df):
     table = df.to_records(index=False)
     assert_tables_equality(table, table)

--- a/invisible_cities/reco/monitor_functions_test.py
+++ b/invisible_cities/reco/monitor_functions_test.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from hypothesis              import given
 from hypothesis              import settings
+from hypothesis              import HealthCheck
 from hypothesis.extra.pandas import columns, data_frames
 from hypothesis.strategies   import floats
 
@@ -417,7 +418,7 @@ kdst_variables = ['nS2', 'S1w'  , 'S1h', 'S1e', 'S1t', 'S2w', 'S2h', 'S2e', 'S2q
 
 
 @given(data_frames(columns=columns(kdst_variables, elements=floats(allow_nan=False))))
-@settings(deadline=None)
+@settings(deadline=None, suppress_health_check=(HealthCheck.too_slow,))
 def test_fill_kdst_var_1d(kdst):
     var_dict = defaultdict(list)
     monf.fill_kdst_var_1d (kdst, var_dict)
@@ -430,7 +431,7 @@ def test_fill_kdst_var_1d(kdst):
 
 
 @given(data_frames(columns=columns(kdst_variables, elements=floats(allow_nan=False))))
-@settings(deadline=None)
+@settings(deadline=None, suppress_health_check=(HealthCheck.too_slow,))
 def test_fill_kdst_var_2d(kdst):
     var_dict = defaultdict(list)
     monf.fill_kdst_var_1d (kdst, var_dict)


### PR DESCRIPTION
Every now and then the travis build fails because of data generation being too slow. This is a combination of two things:
- `data_frames` strategy is out of our hands
- the large number of columns increases execution time significantly and can't/shouldn't be reduced

This PR suppresses the HealthCheck for those tests using this strategy.