### PR TITLE
Add too-many-hits filter esmeralda

### DIFF
--- a/invisible_cities/cities/esmeralda.py
+++ b/invisible_cities/cities/esmeralda.py
@@ -172,7 +172,7 @@ def track_blob_info_creator_extractor(vox_size         : [float, float, float],
     """
     def create_extract_track_blob_info(hitc):
         df = pd.DataFrame(columns=list(types_dict_tracks.keys()))
-        if len(hitc.hits)>max_num_hits:
+        if len(hitc.hits) > max_num_hits:
             return df, hitc, True
         #track_hits is a new Hitcollection object that contains hits belonging to tracks, and hits that couldnt be corrected
         track_hitc = evm.HitCollection(hitc.event, hitc.time)
@@ -185,7 +185,7 @@ def track_blob_info_creator_extractor(vox_size         : [float, float, float],
             hitc      = evm.HitCollection(hitc.event, hitc.time)
             hitc.hits = hits_without_nan
 
-        if len(hitc.hits)>0:
+        if len(hitc.hits) > 0:
             voxels           = plf.voxelize_hits(hitc.hits, vox_size, strict_vox_size, evm.HitEnergy.Ep)
             (    mod_voxels,
              dropped_voxels) = plf.drop_end_point_voxels(voxels, energy_threshold, min_voxels)

--- a/invisible_cities/cities/esmeralda.py
+++ b/invisible_cities/cities/esmeralda.py
@@ -145,7 +145,8 @@ def track_blob_info_creator_extractor(vox_size         : [float, float, float],
                                       strict_vox_size  : bool                 ,
                                       energy_threshold : float                ,
                                       min_voxels       : int                  ,
-                                      blob_radius      : float
+                                      blob_radius      : float                ,
+                                      max_num_hits     : int
                                      ) -> Callable:
     """
     For a given paolina parameters returns a function that extract tracks / blob information from a HitCollection.
@@ -170,6 +171,9 @@ def track_blob_info_creator_extractor(vox_size         : [float, float, float],
     A function that from a given HitCollection returns a pandas DataFrame with per track information.
     """
     def create_extract_track_blob_info(hitc):
+        df = pd.DataFrame(columns=list(types_dict_tracks.keys()))
+        if len(hitc.hits)>max_num_hits:
+            return df, hitc, True
         #track_hits is a new Hitcollection object that contains hits belonging to tracks, and hits that couldnt be corrected
         track_hitc = evm.HitCollection(hitc.event, hitc.time)
         out_of_map = np.any(np.isnan([h.Ep for h in hitc.hits]))
@@ -180,7 +184,7 @@ def track_blob_info_creator_extractor(vox_size         : [float, float, float],
             #create new Hitcollection object but keep the name hitc
             hitc      = evm.HitCollection(hitc.event, hitc.time)
             hitc.hits = hits_without_nan
-        df = pd.DataFrame(columns=list(types_dict_tracks.keys()))
+
         if len(hitc.hits)>0:
             voxels           = plf.voxelize_hits(hitc.hits, vox_size, strict_vox_size, evm.HitEnergy.Ep)
             (    mod_voxels,

--- a/invisible_cities/cities/esmeralda.py
+++ b/invisible_cities/cities/esmeralda.py
@@ -477,12 +477,11 @@ def esmeralda(files_in, file_out, compression, event_range, print_mod, run_numbe
                          copy_Ec_to_Ep_hit_attribute                  ,
                          create_extract_track_blob_info               ,
                          filter_events_topology                       ,
+                         fl.branch(make_final_summary, write_summary) ,
                          fl.branch(write_topology_filter)             ,
                          fl.branch(write_hits_paolina)                ,
                          events_passed_topology.filter                ,
                          event_count_out       .spy                   ,
-                         fl.fork( write_tracks                        ,
-                                 (make_final_summary, write_summary))),
-
+                         write_tracks                                ),
                      result = dict(events_in =event_count_in .future ,
                                    events_out=event_count_out.future ))

--- a/invisible_cities/cities/esmeralda.py
+++ b/invisible_cities/cities/esmeralda.py
@@ -362,8 +362,6 @@ def esmeralda(files_in, file_out, compression, event_range, print_mod, run_numbe
         apply_temp               : bool
             whether to apply temporal corrections
             must be set to False if no temporal correction dataframe exists in map file
-        norm_strat               : 'max', 'mean' or 'kr'
-           strategy to normalize the energy
 
     paolina_params               :dict
         vox_size                 : [float, float, float]
@@ -378,6 +376,8 @@ def esmeralda(files_in, file_out, compression, event_range, print_mod, run_numbe
             after min_voxel number of voxels is reached no dropping will happen.
         blob_radius             : float
             radius of blob
+        max_num_hits            : int
+            maximum number of hits allowed per event to run paolina functions.
     ----------
     Input
     ----------
@@ -385,12 +385,16 @@ def esmeralda(files_in, file_out, compression, event_range, print_mod, run_numbe
     ----------
     Output
     ----------
-    RECO    : corrected hits table, according to the given map and hits threshold and merging parameters
-    MC info : (if run number <=0)
-    PAOLINA : Summary of topological anlaysis containing:
-        Events  : corrected (paolina) hits, hits table after performing paolina drop_voxels
-        Tracks  : summary  of per track topological information
-        Summary : summary of per event information
+    - CHITS corrected hits table,
+        - lowTh  - contains corrected hits table that passed h.Q >= charge_threshold_low constrain
+        - highTh - contains corrected hits table that passed h.Q >= charge_threshold_high constrain.
+                   it also contains:
+                   - Ep field that is the energy of a hit after applying drop_end_point_voxel algorithm.
+                   - track_id denoting to which track from Tracking/Tracks dataframe the hit belong to 
+    - MC info (if run number <=0)
+    - Tracking/Tracks - summary of per track information
+    - Summary/events  - summary of per event information
+    - DST/Events      - copy of kdst information from penthesilea
 
 """
 
@@ -473,10 +477,10 @@ def esmeralda(files_in, file_out, compression, event_range, print_mod, run_numbe
                          copy_Ec_to_Ep_hit_attribute                  ,
                          create_extract_track_blob_info               ,
                          filter_events_topology                       ,
+                         fl.branch(write_topology_filter)             ,
                          fl.branch(write_hits_paolina)                ,
                          events_passed_topology.filter                ,
                          event_count_out       .spy                   ,
-                         fl.branch(write_topology_filter)             ,
                          fl.fork( write_tracks                        ,
                                  (make_final_summary, write_summary))),
 

--- a/invisible_cities/cities/esmeralda_test.py
+++ b/invisible_cities/cities/esmeralda_test.py
@@ -325,9 +325,9 @@ def test_esmeralda_all_hits_after_drop_voxels(data_hdst, esmeralda_tracks, corre
     #check that the sum of Ep and Ec energies is the same
     assert np.nansum(df_phits.Ec) == np.nansum(df_phits.Ep)
 
-def test_esmeralda_filters_long_events(data_hdst, esmeralda_tracks, correction_map_filename, config_tmpdir):
+def test_esmeralda_filters_events_with_too_many_hits(data_hdst, correction_map_filename, config_tmpdir):
     PATH_IN   = data_hdst
-    PATH_OUT  = os.path.join(config_tmpdir, "exact_tracks_esmeralda_drop_voxels.h5")
+    PATH_OUT  = os.path.join(config_tmpdir, "esmeralda_filters_long_events.h5")
     conf      = configure('dummy invisible_cities/config/esmeralda.conf'.split())
     nevt_req  = 9
     all_hits  = 601
@@ -358,15 +358,19 @@ def test_esmeralda_filters_long_events(data_hdst, esmeralda_tracks, correction_m
 
     #assert only paolina_events inside tracks
     assert set(tracks .event.unique()) == paolina_events
+
     #assert all events in summary table
     assert summary.event.nunique() == nevt_req
     #assert ntrk is 0 for non_paolina events
     assert np.all(summary[ summary.event.isin(paolina_events)].evt_ntrks >  0        )
     assert np.all(summary[~summary.event.isin(paolina_events)].evt_ntrks == 0        )
     assert np.all(summary[~summary.event.isin(paolina_events)].evt_nhits >  nhits_max)
+
     #assert all hits and events are in hits table
     assert len(hits) == 601
     assert hits.event.nunique() == nevt_req
+
+    #assert all events in topology filter with corresponding bool
     topology_filter = dio.load_dst(PATH_OUT, 'Filters', 'topology_select')
     assert len(topology_filter) == nevt_req
     assert np.all(topology_filter[ topology_filter.event.isin(paolina_events)].passed == 1)

--- a/invisible_cities/cities/esmeralda_test.py
+++ b/invisible_cities/cities/esmeralda_test.py
@@ -27,7 +27,7 @@ def test_esmeralda_contains_all_tables(KrMC_hdst_filename, correction_map_MC_fil
                          threshold_charge_low  = 6  * units.pes            ,
                          threshold_charge_high = 30 * units.pes            ,
                          same_peak             = True                      ,
-                         apply_temp            = False                   )))
+                         apply_temp            = False                    )))
     esmeralda(**conf)
 
     with tb.open_file(PATH_OUT) as h5out:
@@ -152,7 +152,8 @@ def test_esmeralda_tracks_exact(data_hdst, esmeralda_tracks, correction_map_file
                          strict_vox_size       = False                  ,
                          energy_threshold      = 0 * units.keV          ,
                          min_voxels            = 2                      ,
-                         blob_radius           = 21 * units.mm)        ))
+                         blob_radius           = 21 * units.mm          ,
+                         max_num_hits          = 10000                 )))
     cnt = esmeralda(**conf)
 
     df_tracks           =  dio.load_dst(PATH_OUT, 'Tracking', 'Tracks' )
@@ -184,7 +185,7 @@ def test_esmeralda_empty_input_file(config_tmpdir, ICDATADIR):
 #if the first analyzed events has no overlap in blob buggy esmeralda will cast all overlap energy to integers
 def test_esmeralda_blob_overlap_bug(data_hdst, correction_map_filename, config_tmpdir):
     PATH_IN   = data_hdst
-    PATH_OUT  = os.path.join(config_tmpdir, "exact_tracks_esmeralda.h5")
+    PATH_OUT  = os.path.join(config_tmpdir, "exact_tracks_esmeralda_bug.h5")
     conf      = configure('dummy invisible_cities/config/esmeralda.conf'.split())
     nevt_req  = 4, 8
 
@@ -194,7 +195,7 @@ def test_esmeralda_blob_overlap_bug(data_hdst, correction_map_filename, config_t
                      run_number                = 6822                   ,
                      cor_hits_params           = dict(
                          map_fname             = correction_map_filename,
-                         threshold_charge_low  =  10   * units.pes       ,
+                         threshold_charge_low  = 10   * units.pes       ,
                          threshold_charge_high = 30   * units.pes       ,
                          same_peak             = True                   ,
                          apply_temp            = False                 ),
@@ -203,7 +204,9 @@ def test_esmeralda_blob_overlap_bug(data_hdst, correction_map_filename, config_t
                          strict_vox_size       = False                  ,
                          energy_threshold      = 0 * units.keV          ,
                          min_voxels            = 2                      ,
-                         blob_radius           = 21 * units.mm)        ))
+                         blob_radius           = 21 * units.mm          ,
+                         max_num_hits          = 10000                 )))
+
     cnt = esmeralda(**conf)
 
     df_tracks = dio.load_dst(PATH_OUT, 'Tracking', 'Tracks')
@@ -229,7 +232,8 @@ def test_esmeralda_exact_result_all_events(ICDATADIR, KrMC_hdst_filename, correc
                          strict_vox_size       = False                     ,
                          energy_threshold      = 0 * units.keV             ,
                          min_voxels            = 2                         ,
-                         blob_radius           = 21 * units.mm           )))
+                         blob_radius           = 21 * units.mm             ,
+                         max_num_hits          = 10000                    )))
 
     cnt = esmeralda(**conf)
 
@@ -251,7 +255,7 @@ def test_esmeralda_exact_result_all_events(ICDATADIR, KrMC_hdst_filename, correc
 #test showing that all events that pass charge threshold are contained in hits output
 def test_esmeralda_bug_duplicate_hits(data_hdst, correction_map_filename, config_tmpdir):
     PATH_IN   = data_hdst
-    PATH_OUT  = os.path.join(config_tmpdir, "exact_tracks_esmeralda_drop_voxels.h5")
+    PATH_OUT  = os.path.join(config_tmpdir, "exact_tracks_esmeralda_drop_voxels_bug.h5")
     conf      = configure('dummy invisible_cities/config/esmeralda.conf'.split())
     nevt_req  = 1
     conf.update(dict(files_in                  = PATH_IN                ,
@@ -267,9 +271,11 @@ def test_esmeralda_bug_duplicate_hits(data_hdst, correction_map_filename, config
                      paolina_params            = dict(
                          vox_size              = [15 * units.mm] * 3    ,
                          strict_vox_size       = False                  ,
-                         energy_threshold      = 0 * units.keV         ,
+                         energy_threshold      = 0 * units.keV          ,
                          min_voxels            = 2                      ,
-                         blob_radius           = 21 * units.mm)        ))
+                         blob_radius           = 21 * units.mm          ,
+                         max_num_hits          = 10000                 )))
+
     cnt = esmeralda(**conf)
 
     df_tracks = dio.load_dst(PATH_OUT, 'Tracking', 'Tracks')
@@ -301,7 +307,8 @@ def test_esmeralda_all_hits_after_drop_voxels(data_hdst, esmeralda_tracks, corre
                          strict_vox_size       = False                  ,
                          energy_threshold      = 20 * units.keV         ,
                          min_voxels            = 2                      ,
-                         blob_radius           = 21 * units.mm)        ))
+                         blob_radius           = 21 * units.mm          ,
+                         max_num_hits          = 10000                 )))
     cnt = esmeralda(**conf)
 
     df_phits            =  dio.load_dst(PATH_OUT,   'CHITS' , 'highTh')

--- a/invisible_cities/config/esmeralda.conf
+++ b/invisible_cities/config/esmeralda.conf
@@ -21,4 +21,5 @@ paolina_params      = dict(
    strict_vox_size  = True,
    energy_threshold = 10 * keV,
    min_voxels       = 2,
-   blob_radius      = 21 * mm)
+   blob_radius      = 21 * mm,
+   max_num_hits     = 10000)


### PR DESCRIPTION
There are some nonphysical events that have more than 10s of thousands hits. This PR makes Esmeralda not run tracking functions on events that have too many hits.