### PR TITLE
Negative charge filtering

### DIFF
--- a/invisible_cities/database/test_data/Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts.PMP.h5
+++ b/invisible_cities/database/test_data/Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts.PMP.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e9c5b40c16295bcbd25ac4b1be1021b10a3b63e2d9b37a6dbd7437ac88766aa1
+oid sha256:7284c833efc80b2879bffae58fdeb85804f0c2665ff54595ecbe659b383b8625
 size 130492

--- a/invisible_cities/reco/peak_functions.py
+++ b/invisible_cities/reco/peak_functions.py
@@ -142,7 +142,7 @@ def rebin_times_and_waveforms(times, widths, waveforms,
                               rebin_stride=2, slices=None):
     if rebin_stride < 2: return times, widths, waveforms
 
-    if not slices:
+    if slices is None:
         n_bins = int(np.ceil(len(times) / rebin_stride))
         reb    = rebin_stride
         slices = [slice(reb * i, reb * (i + 1)) for i in range(n_bins)]
@@ -153,9 +153,9 @@ def rebin_times_and_waveforms(times, widths, waveforms,
     rebinned_wfs    = np.zeros((n_sensors, len(slices)))
 
     for i, s in enumerate(slices):
-        t  = times    [   s]
-        e  = waveforms[:, s]
-        w  = np.sum(e, axis=0) if np.any(e) else None
+        t = times    [   s]
+        e = waveforms[:, s]
+        w = np.sum(e, axis=0).clip(0) if np.any(e) else None
         rebinned_times [   i] = np.average(t, weights=w)
         rebinned_widths[   i] = np.sum    (   widths[s])
         rebinned_wfs   [:, i] = np.sum    (e,    axis=1)

--- a/invisible_cities/reco/peak_functions.py
+++ b/invisible_cities/reco/peak_functions.py
@@ -102,6 +102,9 @@ def build_peak(indices, times,
      pmt_r    ) = build_pmt_responses(indices, times, widths,
                                      ccwf, pmt_ids,
                                      rebin_stride, pad_zeros = with_sipms)
+    if not np.any(mask):
+        return None
+
     if with_sipms:
         sipm_r = build_sipm_responses(indices // 40, times // 40,
                                       widths * 40, sipm_wfs,
@@ -133,7 +136,8 @@ def find_peaks(ccwfs, index,
                         rebin_stride,
                         with_sipms, Pk,
                         sipm_wfs, thr_sipm_s2)
-        peaks.append(pk)
+        if pk is not None:
+            peaks.append(pk)
     return peaks
 
 

--- a/invisible_cities/reco/peak_functions_test.py
+++ b/invisible_cities/reco/peak_functions_test.py
@@ -359,6 +359,18 @@ def test_build_sipm_responses(wf_with_indices):
     assert sipm_r.all_waveforms == approx (expected_wfs)
 
 
+def test_build_sipm_responses_mask(wf_with_indices):
+    times, widths, wfs, indices = wf_with_indices
+    ids       = np.arange(wfs.shape[0])
+    wfs_slice = wfs[:, indices]
+    mask      = np.full(indices.shape, True)
+    mask[-1]  = False
+    sipm_r    = pf.build_sipm_responses(indices, times, widths,
+                                        wfs, 1, 0.1, mask)
+
+    assert sipm_r.all_waveforms == approx(wfs_slice[:, mask])
+
+
 @mark.parametrize("Pk rebin with_sipms".split(),
                   ((S1,  1, False),
                    (S2,  1, False),
@@ -588,7 +600,7 @@ def test_rebin_times_and_waveforms_times_are_consistent(t_and_wf, stride):
     widths      = [1]
     if len(times) > 1:
         widths = np.append(np.diff(times), max(np.diff(times)))
-    
+
     # The samples falling in the last bin cannot be so easily
     # compared as the other ones so I remove them.
     remain = times.size - times.size % stride

--- a/invisible_cities/reco/peak_functions_test.py
+++ b/invisible_cities/reco/peak_functions_test.py
@@ -333,8 +333,8 @@ def test_pick_slice_and_rebin(wfs_slice_data):
 def test_build_pmt_responses(wf_with_indices):
     times, widths, wfs, indices = wf_with_indices
     ids = np.arange(wfs.shape[0])
-    ts, wid, pmt_r = pf.build_pmt_responses(indices, times, widths,
-                                            wfs, ids, 1, False)
+    _, ts, wid, pmt_r = pf.build_pmt_responses(indices, times, widths,
+                                               wfs, ids, 1, False)
     assert ts                  == approx (times[indices])
     assert wid                 == approx (widths[indices])
     assert pmt_r.ids           == exactly(ids)
@@ -349,8 +349,9 @@ def test_build_sipm_responses(wf_with_indices):
     below_thr_index = np.argmin (peak_integrals)
     # next_float doesn't work here
     thr             = peak_integrals[below_thr_index] * 1.000001
+    mask            = np.full(indices.shape, True)
     sipm_r          = pf.build_sipm_responses(indices, times, widths,
-                                              wfs, 1, thr)
+                                              wfs, 1, thr, mask)
 
     expected_ids = np.delete(      ids, below_thr_index)
     expected_wfs = np.delete(wfs_slice, below_thr_index, axis=0)


### PR DESCRIPTION
Adds to PR  #658 addressing some of the issues mentioned in issue #606 

Adds a filtering mask in PMap construction to avoid negative bins in accepted peaks.