### PR TITLE
Removing hard-coded parameters in irene

### DIFF
--- a/invisible_cities/cities/irene.py
+++ b/invisible_cities/cities/irene.py
@@ -22,6 +22,7 @@ import tables as tb
 from .. types.ic_types import minmax
 from .. database       import load_db
 
+from .. core.system_of_units_c import units
 from .. reco                  import tbl_functions        as tbl
 from .. reco                  import  peak_functions      as pkf
 from .. core.random_sampling  import NoiseSampler         as SiPMsNoiseSampler
@@ -51,7 +52,8 @@ from .  components import wf_from_files
 def irene(files_in, file_out, compression, event_range, print_mod, detector_db, run_number,
           n_baseline, n_mau, thr_mau, thr_sipm, thr_sipm_type,
           s1_lmin, s1_lmax, s1_tmin, s1_tmax, s1_rebin_stride, s1_stride, thr_csum_s1,
-          s2_lmin, s2_lmax, s2_tmin, s2_tmax, s2_rebin_stride, s2_stride, thr_csum_s2, thr_sipm_s2):
+          s2_lmin, s2_lmax, s2_tmin, s2_tmax, s2_rebin_stride, s2_stride, thr_csum_s2, thr_sipm_s2,
+          pmt_sample_f=25*units.ns, sipm_sample_f=1*units.mus):
     if   thr_sipm_type.lower() == "common":
         # In this case, the threshold is a value in pes
         sipm_thr = thr_sipm
@@ -87,7 +89,7 @@ def irene(files_in, file_out, compression, event_range, print_mod, detector_db, 
                               item = "sipm")
 
     # Build the PMap
-    compute_pmap     = fl.map(build_pmap(detector_db, run_number,
+    compute_pmap     = fl.map(build_pmap(detector_db, run_number, pmt_sample_f, sipm_sample_f,
                                          s1_lmax, s1_lmin, s1_rebin_stride, s1_stride, s1_tmax, s1_tmin,
                                          s2_lmax, s2_lmin, s2_rebin_stride, s2_stride, s2_tmax, s2_tmin, thr_sipm_s2),
                               args = ("ccwfs", "s1_indices", "s2_indices", "sipm"),
@@ -152,7 +154,7 @@ def irene(files_in, file_out, compression, event_range, print_mod, detector_db, 
 
 
 
-def build_pmap(detector_db, run_number,
+def build_pmap(detector_db, run_number, pmt_sample_f, sipm_sample_f,
                s1_lmax, s1_lmin, s1_rebin_stride, s1_stride, s1_tmax, s1_tmin,
                s2_lmax, s2_lmin, s2_rebin_stride, s2_stride, s2_tmax, s2_tmin, thr_sipm_s2):
     s1_params = dict(time        = minmax(min = s1_tmin,
@@ -174,7 +176,8 @@ def build_pmap(detector_db, run_number,
 
     def build_pmap(ccwf, s1_indx, s2_indx, sipmzs): # -> PMap
         return pkf.get_pmap(ccwf, s1_indx, s2_indx, sipmzs,
-                            s1_params, s2_params, thr_sipm_s2, pmt_ids)
+                            s1_params, s2_params, thr_sipm_s2, pmt_ids,
+                            pmt_sample_f, sipm_sample_f)
 
     return build_pmap
 

--- a/invisible_cities/cities/irene.py
+++ b/invisible_cities/cities/irene.py
@@ -22,15 +22,15 @@ import tables as tb
 from .. types.ic_types import minmax
 from .. database       import load_db
 
+from .. reco                   import tbl_functions        as tbl
+from .. reco                   import peak_functions       as pkf
+from .. core.random_sampling   import NoiseSampler         as SiPMsNoiseSampler
 from .. core.system_of_units_c import units
-from .. reco                  import tbl_functions        as tbl
-from .. reco                  import  peak_functions      as pkf
-from .. core.random_sampling  import NoiseSampler         as SiPMsNoiseSampler
-from .. io  .        pmaps_io import          pmap_writer
-from .. io.        mcinfo_io  import       mc_info_writer
-from .. io  .run_and_event_io import run_and_event_writer
-from .. io  .trigger_io       import       trigger_writer
-from .. io  .event_filter_io  import  event_filter_writer
+from .. io  .pmaps_io          import          pmap_writer
+from .. io  .mcinfo_io         import       mc_info_writer
+from .. io  .run_and_event_io  import run_and_event_writer
+from .. io  .trigger_io        import       trigger_writer
+from .. io  .event_filter_io   import  event_filter_writer
 
 from .. dataflow            import dataflow as fl
 from .. dataflow.dataflow   import push
@@ -53,7 +53,7 @@ def irene(files_in, file_out, compression, event_range, print_mod, detector_db, 
           n_baseline, n_mau, thr_mau, thr_sipm, thr_sipm_type,
           s1_lmin, s1_lmax, s1_tmin, s1_tmax, s1_rebin_stride, s1_stride, thr_csum_s1,
           s2_lmin, s2_lmax, s2_tmin, s2_tmax, s2_rebin_stride, s2_stride, thr_csum_s2, thr_sipm_s2,
-          pmt_sample_f=25*units.ns, sipm_sample_f=1*units.mus):
+          pmt_samp_wid=25*units.ns, sipm_samp_wid=1*units.mus):
     if   thr_sipm_type.lower() == "common":
         # In this case, the threshold is a value in pes
         sipm_thr = thr_sipm
@@ -89,7 +89,7 @@ def irene(files_in, file_out, compression, event_range, print_mod, detector_db, 
                               item = "sipm")
 
     # Build the PMap
-    compute_pmap     = fl.map(build_pmap(detector_db, run_number, pmt_sample_f, sipm_sample_f,
+    compute_pmap     = fl.map(build_pmap(detector_db, run_number, pmt_samp_wid, sipm_samp_wid,
                                          s1_lmax, s1_lmin, s1_rebin_stride, s1_stride, s1_tmax, s1_tmin,
                                          s2_lmax, s2_lmin, s2_rebin_stride, s2_stride, s2_tmax, s2_tmin, thr_sipm_s2),
                               args = ("ccwfs", "s1_indices", "s2_indices", "sipm"),
@@ -154,7 +154,7 @@ def irene(files_in, file_out, compression, event_range, print_mod, detector_db, 
 
 
 
-def build_pmap(detector_db, run_number, pmt_sample_f, sipm_sample_f,
+def build_pmap(detector_db, run_number, pmt_samp_wid, sipm_samp_wid,
                s1_lmax, s1_lmin, s1_rebin_stride, s1_stride, s1_tmax, s1_tmin,
                s2_lmax, s2_lmin, s2_rebin_stride, s2_stride, s2_tmax, s2_tmin, thr_sipm_s2):
     s1_params = dict(time        = minmax(min = s1_tmin,
@@ -177,7 +177,7 @@ def build_pmap(detector_db, run_number, pmt_sample_f, sipm_sample_f,
     def build_pmap(ccwf, s1_indx, s2_indx, sipmzs): # -> PMap
         return pkf.get_pmap(ccwf, s1_indx, s2_indx, sipmzs,
                             s1_params, s2_params, thr_sipm_s2, pmt_ids,
-                            pmt_sample_f, sipm_sample_f)
+                            pmt_samp_wid, sipm_samp_wid)
 
     return build_pmap
 

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 import tables as tb
 import numpy  as np
 
+import pytest
 from pytest import mark
 from pytest import fixture
 
@@ -389,6 +390,7 @@ def test_irene_empty_input_file(config_tmpdir, ICDATADIR):
     irene(**conf)
 
 
+
 def test_irene_sequential_times(config_tmpdir, ICDATADIR):
 
     PATH_IN  = os.path.join(ICDATADIR    , 'single_evt_nonseqtime_rwf.h5')
@@ -415,3 +417,59 @@ def test_irene_sequential_times(config_tmpdir, ICDATADIR):
     pmaps_out = load_pmaps(PATH_OUT)
 
     assert np.all(np.diff(pmaps_out[3348].s2s[1].times) > 0)
+
+def test_error_when_different_sample_frequency(ICDATADIR, config_tmpdir):
+    ## Tests that ValueError message is correct
+    PATH_IN  = os.path.join(ICDATADIR,                   'run_2983.h5')
+    PATH_OUT = os.path.join(config_tmpdir, 'r2983_pmaps_diffparams.h5')
+    conf = configure('dummy invisible_cities/config/irene.conf'.split())
+
+    pmt_sample_f  = 25 * units.ns
+    sipm_sample_f =  2 * units.mus
+    conf.update(dict(run_number    = 2983,
+                 files_in      = PATH_IN,
+                 file_out      = PATH_OUT,
+                 pmt_sample_f  = pmt_sample_f,
+                 sipm_sample_f = sipm_sample_f))
+
+    msg  = "Shapes don't match!\n"
+    msg += "times has length 6\n"
+    msg += "pmts  has length 6 \n"
+    msg += "sipms has length 3\n"
+
+    with pytest.raises(ValueError) as error:
+        assert irene(**conf)
+    assert str(error.value) == msg
+
+
+def test_irene_other_sample_frequencies(ICDATADIR, config_tmpdir):
+    ## Tests irene works when running with other sample frequencies
+    file_in     = os.path.join(ICDATADIR,               'run_2983.h5')
+    file_out    = os.path.join(config_tmpdir, 'r2983_pmaps_output.h5')
+    true_output = os.path.join(ICDATADIR, 'run_2983_pmaps_2evts_sfreq_5ns_200ns.h5')
+    conf = configure('dummy invisible_cities/config/irene.conf'.split())
+
+    pmt_sample_f  = 5  * units.ns
+    sipm_sample_f = 0.2 * units.mus
+    n_events = 2
+
+    conf.update(dict(run_number    = 2983,
+                     files_in      = file_in,
+                     file_out      = file_out,
+                     event_range   = (0, n_events),
+                     pmt_sample_f  = pmt_sample_f,
+                     sipm_sample_f = sipm_sample_f))
+    irene(**conf)
+
+    tables = (  "PMAPS/S1"         ,   "PMAPS/S2"        , "PMAPS/S2Si"     ,
+                "PMAPS/S1Pmt"      ,   "PMAPS/S2Pmt"     ,
+                  "Run/events"     ,     "Run/runInfo"   ,
+              "Trigger/events"     , "Trigger/trigger"   ,
+              "Filters/s12_indices", "Filters/empty_pmap")
+    with tb.open_file(true_output)  as true_output_file:
+        with tb.open_file(file_out) as      output_file:
+            for table in tables:
+                got      = getattr(     output_file.root, table)
+                expected = getattr(true_output_file.root, table)
+                assert_tables_equality(got, expected)
+

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 import tables as tb
 import numpy  as np
 
-import pytest
+from pytest import raises
 from pytest import mark
 from pytest import fixture
 
@@ -418,47 +418,47 @@ def test_irene_sequential_times(config_tmpdir, ICDATADIR):
 
     assert np.all(np.diff(pmaps_out[3348].s2s[1].times) > 0)
 
-def test_error_when_different_sample_frequency(ICDATADIR, config_tmpdir):
+def test_error_when_different_sample_widths(ICDATADIR, config_tmpdir):
     ## Tests that ValueError message is correct
     PATH_IN  = os.path.join(ICDATADIR,                   'run_2983.h5')
     PATH_OUT = os.path.join(config_tmpdir, 'r2983_pmaps_diffparams.h5')
     conf = configure('dummy invisible_cities/config/irene.conf'.split())
 
-    pmt_sample_f  = 25 * units.ns
-    sipm_sample_f =  2 * units.mus
+    pmt_samp_wid  = 25 * units.ns
+    sipm_samp_wid =  2 * units.mus
     conf.update(dict(run_number    = 2983,
-                 files_in      = PATH_IN,
-                 file_out      = PATH_OUT,
-                 pmt_sample_f  = pmt_sample_f,
-                 sipm_sample_f = sipm_sample_f))
+                     files_in      = PATH_IN,
+                     file_out      = PATH_OUT,
+                     pmt_samp_wid  = pmt_samp_wid,
+                     sipm_samp_wid = sipm_samp_wid))
 
     msg  = "Shapes don't match!\n"
     msg += "times has length 6\n"
     msg += "pmts  has length 6 \n"
     msg += "sipms has length 3\n"
 
-    with pytest.raises(ValueError) as error:
-        assert irene(**conf)
+    with raises(ValueError) as error:
+        irene(**conf)
     assert str(error.value) == msg
 
 
-def test_irene_other_sample_frequencies(ICDATADIR, config_tmpdir):
+def test_irene_other_sample_widths(ICDATADIR, config_tmpdir):
     ## Tests irene works when running with other sample frequencies
     file_in     = os.path.join(ICDATADIR,               'run_2983.h5')
     file_out    = os.path.join(config_tmpdir, 'r2983_pmaps_output.h5')
     true_output = os.path.join(ICDATADIR, 'run_2983_pmaps_2evts_sfreq_5ns_200ns.h5')
     conf = configure('dummy invisible_cities/config/irene.conf'.split())
 
-    pmt_sample_f  = 5  * units.ns
-    sipm_sample_f = 0.2 * units.mus
+    pmt_samp_wid  = 5  * units.ns
+    sipm_samp_wid = 0.2 * units.mus
     n_events = 2
 
     conf.update(dict(run_number    = 2983,
                      files_in      = file_in,
                      file_out      = file_out,
                      event_range   = (0, n_events),
-                     pmt_sample_f  = pmt_sample_f,
-                     sipm_sample_f = sipm_sample_f))
+                     pmt_samp_wid  = pmt_samp_wid,
+                     sipm_samp_wid = sipm_samp_wid))
     irene(**conf)
 
     tables = (  "PMAPS/S1"         ,   "PMAPS/S2"        , "PMAPS/S2Si"     ,

--- a/invisible_cities/config/irene.conf
+++ b/invisible_cities/config/irene.conf
@@ -30,7 +30,6 @@ thr_csum_s2 = 1.0 * pes
 thr_sipm      = 3.5 * pes
 thr_sipm_type = "common"
 
-
 # Set parameters to search for S1
 # Notice that in MC file S1 is in t=100 mus
 s1_tmin       =  99 * mus # position of S1 in MC files at 100 mus

--- a/invisible_cities/database/test_data/run_2983_pmaps_2evts_sfreq_5ns_200ns.h5
+++ b/invisible_cities/database/test_data/run_2983_pmaps_2evts_sfreq_5ns_200ns.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4bb3cbcb78833133174e30a93a60215dfe8143451f98ebc1364ba946686b796
+size 87877

--- a/invisible_cities/reco/peak_functions.py
+++ b/invisible_cities/reco/peak_functions.py
@@ -36,10 +36,10 @@ def split_in_peaks(indices, stride):
     return np.split(indices, where + 1)
 
 
-def select_peaks(peaks, time, length, pmt_sample_f=25*units.ns):
+def select_peaks(peaks, time, length, pmt_samp_wid=25*units.ns):
     def is_valid(indices):
-        return (time  .contains(indices[ 0] * pmt_sample_f) and
-                time  .contains(indices[-1] * pmt_sample_f) and
+        return (time  .contains(indices[ 0] * pmt_samp_wid) and
+                time  .contains(indices[-1] * pmt_samp_wid) and
                 length.contains(indices[-1] + 1 - indices[0]))
     return tuple(filter(is_valid, peaks))
 
@@ -90,11 +90,11 @@ def build_peak(indices, times,
                widths, ccwf, pmt_ids,
                rebin_stride,
                with_sipms, Pk,
-               pmt_sample_f  = 25 * units.ns,
-               sipm_sample_f =  1 * units.mus,
+               pmt_samp_wid  = 25 * units.ns,
+               sipm_samp_wid =  1 * units.mus,
                sipm_wfs      = None,
                thr_sipm_s2   = 0):
-    sipm_pmt_bin_ratio = int(sipm_sample_f/pmt_sample_f)
+    sipm_pmt_bin_ratio = int(sipm_samp_wid/pmt_samp_wid)
     (pk_times ,
      pk_widths,
      pmt_r    ) = build_pmt_responses(indices, times, widths,
@@ -118,16 +118,16 @@ def find_peaks(ccwfs, index,
                time, length,
                stride, rebin_stride,
                Pk, pmt_ids,
-               pmt_sample_f =25*units.ns,
-               sipm_sample_f= 1*units.mus,
+               pmt_samp_wid = 25*units.ns,
+               sipm_samp_wid = 1*units.mus,
                sipm_wfs=None, thr_sipm_s2=0):
     ccwfs = np.array(ccwfs, ndmin=2)
 
     peaks           = []
-    times           = np.arange     (ccwfs.shape[1]) * pmt_sample_f
-    widths          = np.full       (ccwfs.shape[1],   pmt_sample_f)
+    times           = np.arange     (ccwfs.shape[1]) * pmt_samp_wid
+    widths          = np.full       (ccwfs.shape[1],   pmt_samp_wid)
     indices_split   = split_in_peaks(index, stride)
-    selected_splits = select_peaks  (indices_split, time, length, pmt_sample_f)
+    selected_splits = select_peaks  (indices_split, time, length, pmt_samp_wid)
     with_sipms      = Pk is S2 and sipm_wfs is not None
 
     for indices in selected_splits:
@@ -135,7 +135,7 @@ def find_peaks(ccwfs, index,
                         widths, ccwfs, pmt_ids,
                         rebin_stride,
                         with_sipms, Pk,
-                        pmt_sample_f, sipm_sample_f,
+                        pmt_samp_wid, sipm_samp_wid,
                         sipm_wfs, thr_sipm_s2)
         peaks.append(pk)
     return peaks
@@ -143,15 +143,15 @@ def find_peaks(ccwfs, index,
 
 def get_pmap(ccwf, s1_indx, s2_indx, sipm_zs_wf,
              s1_params, s2_params, thr_sipm_s2, pmt_ids,
-             pmt_sample_f, sipm_sample_f):
+             pmt_samp_wid, sipm_samp_wid):
     return PMap(find_peaks(ccwf, s1_indx, Pk=S1, pmt_ids=pmt_ids,
-                           pmt_sample_f=pmt_sample_f,
+                           pmt_samp_wid=pmt_samp_wid,
                            **s1_params),
                 find_peaks(ccwf, s2_indx, Pk=S2, pmt_ids=pmt_ids,
-                           sipm_wfs    = sipm_zs_wf,
-                           thr_sipm_s2 = thr_sipm_s2,
-                           pmt_sample_f  = pmt_sample_f,
-                           sipm_sample_f = sipm_sample_f,
+                           sipm_wfs      = sipm_zs_wf,
+                           thr_sipm_s2   = thr_sipm_s2,
+                           pmt_samp_wid  = pmt_samp_wid,
+                           sipm_samp_wid = sipm_samp_wid,
                            **s2_params))
 
 

--- a/invisible_cities/reco/peak_functions_test.py
+++ b/invisible_cities/reco/peak_functions_test.py
@@ -498,14 +498,14 @@ def test_get_pmap(s1_and_s2_with_indices):
     pmt_ids  = np.arange( pmt_wfs.shape[0])
     sipm_ids = np.arange(sipm_wfs.shape[0])
 
-    pmt_sample_f  = 25 * units.ns
-    sipm_sample_f = 1  * units.mus
+    pmt_samp_wid  = 25 * units.ns
+    sipm_samp_wid = 1  * units.mus
     pmap = pf.get_pmap(pmt_wfs, s1_indx, s2_indx, sipm_wfs,
                        s1_params, s2_params,
                        thr_sipm_s2 = -1,
                        pmt_ids     = pmt_ids,
-                       pmt_sample_f  = pmt_sample_f ,
-                       sipm_sample_f = sipm_sample_f)
+                       pmt_samp_wid  = pmt_samp_wid ,
+                       sipm_samp_wid = sipm_samp_wid)
 
     (rebinned_times ,
      rebinned_widths,

--- a/invisible_cities/reco/peak_functions_test.py
+++ b/invisible_cities/reco/peak_functions_test.py
@@ -337,7 +337,7 @@ def test_build_pmt_responses(wf_with_indices):
     times, widths, wfs, indices = wf_with_indices
     ids = np.arange(wfs.shape[0])
     ts, wid, pmt_r = pf.build_pmt_responses(indices, times, widths,
-                                            wfs, ids, 1, False)
+                                            wfs, ids, 1, False, 40)
     assert ts                  == approx (times[indices])
     assert wid                 == approx (widths[indices])
     assert pmt_r.ids           == exactly(ids)
@@ -498,11 +498,14 @@ def test_get_pmap(s1_and_s2_with_indices):
     pmt_ids  = np.arange( pmt_wfs.shape[0])
     sipm_ids = np.arange(sipm_wfs.shape[0])
 
-
+    pmt_sample_f  = 25 * units.ns
+    sipm_sample_f = 1  * units.mus
     pmap = pf.get_pmap(pmt_wfs, s1_indx, s2_indx, sipm_wfs,
                        s1_params, s2_params,
                        thr_sipm_s2 = -1,
-                       pmt_ids     = pmt_ids)
+                       pmt_ids     = pmt_ids,
+                       pmt_sample_f  = pmt_sample_f ,
+                       sipm_sample_f = sipm_sample_f)
 
     (rebinned_times ,
      rebinned_widths,


### PR DESCRIPTION
The purpose of this PR is to remove some parameters (pmt_sample_frequency=25 ns, sipm_sample_frequency=1 mus, and ratio=40) that were hard-coded in some functions of `peak_functions.py`. Now, they are defined in the input of the city (since they should not change their values), and could be specified in config file.