### PR TITLE
Protect rebin

### DIFF
--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -16,8 +16,9 @@ from .. types.ic_types      import minmax
 from .. io.run_and_event_io import read_run_and_event
 from .. evm.ic_containers   import S12Params as S12P
 
-from .. database       import load_db
-from .. database.load_db       import DetDB
+from .. database            import load_db
+from .. database.load_db    import DetDB
+from .. io      .pmaps_io   import load_pmaps
 
 from .  irene import irene
 
@@ -386,3 +387,31 @@ def test_irene_empty_input_file(config_tmpdir, ICDATADIR):
                      file_out      = PATH_OUT))
 
     irene(**conf)
+
+
+def test_irene_sequential_times(config_tmpdir, ICDATADIR):
+
+    PATH_IN  = os.path.join(ICDATADIR    , 'single_evt_nonseqtime_rwf.h5')
+    PATH_OUT = os.path.join(config_tmpdir, 'test_pmaps.h5')
+
+    conf = configure('dummy invisible_cities/config/irene.conf'.split())
+    conf.update(dict(files_in    = PATH_IN           ,
+                     file_out    = PATH_OUT          ,
+                     run_number  =   6351            ,
+                     n_baseline  =  48000            ,
+                     thr_sipm    =      1 * units.pes,
+                     s1_tmin     =      0 * units.mus,
+                     s1_tmax     =    640 * units.mus,
+                     s1_lmin     =      5            ,
+                     s1_lmax     =     30            ,
+                     s2_tmin     =    645 * units.mus,
+                     s2_tmax     =   1300 * units.mus,
+                     s2_lmin     =     80            ,
+                     s2_lmax     = 200000            ,
+                     thr_sipm_s2 =      5 * units.pes))
+
+    irene(**conf)
+
+    pmaps_out = load_pmaps(PATH_OUT)
+
+    assert np.all(np.diff(pmaps_out[3348].s2s[1].times) > 0)

--- a/invisible_cities/database/test_data/Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts.PMP.h5
+++ b/invisible_cities/database/test_data/Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts.PMP.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e9c5b40c16295bcbd25ac4b1be1021b10a3b63e2d9b37a6dbd7437ac88766aa1
+oid sha256:7284c833efc80b2879bffae58fdeb85804f0c2665ff54595ecbe659b383b8625
 size 130492

--- a/invisible_cities/database/test_data/pmaps_negative_bins.h5
+++ b/invisible_cities/database/test_data/pmaps_negative_bins.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72b66655b67d3c542c931686745ae7dca70326b87bd96648aaf17a247c90733b
+size 141417

--- a/invisible_cities/database/test_data/single_evt_nonseqtime_rwf.h5
+++ b/invisible_cities/database/test_data/single_evt_nonseqtime_rwf.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8fcd19eab10e9a298eb60110b0f96b616934f6183293fc87c8cb74e5ab6a61f0
+size 591126

--- a/invisible_cities/reco/peak_functions.py
+++ b/invisible_cities/reco/peak_functions.py
@@ -142,7 +142,7 @@ def rebin_times_and_waveforms(times, widths, waveforms,
                               rebin_stride=2, slices=None):
     if rebin_stride < 2: return times, widths, waveforms
 
-    if not slices:
+    if slices is None:
         n_bins = int(np.ceil(len(times) / rebin_stride))
         reb    = rebin_stride
         slices = [slice(reb * i, reb * (i + 1)) for i in range(n_bins)]
@@ -153,9 +153,9 @@ def rebin_times_and_waveforms(times, widths, waveforms,
     rebinned_wfs    = np.zeros((n_sensors, len(slices)))
 
     for i, s in enumerate(slices):
-        t  = times    [   s]
-        e  = waveforms[:, s]
-        w  = np.sum(e, axis=0) if np.any(e) else None
+        t = times    [   s]
+        e = waveforms[:, s]
+        w = np.sum(e, axis=0).clip(0) if np.any(e) else None
         rebinned_times [   i] = np.average(t, weights=w)
         rebinned_widths[   i] = np.sum    (   widths[s])
         rebinned_wfs   [:, i] = np.sum    (e,    axis=1)

--- a/invisible_cities/reco/peak_functions.py
+++ b/invisible_cities/reco/peak_functions.py
@@ -156,6 +156,7 @@ def rebin_times_and_waveforms(times, widths, waveforms,
         t = times    [   s]
         e = waveforms[:, s]
         w = np.sum(e, axis=0).clip(0) if np.any(e) else None
+        if not np.any(w): w = None
         rebinned_times [   i] = np.average(t, weights=w)
         rebinned_widths[   i] = np.sum    (   widths[s])
         rebinned_wfs   [:, i] = np.sum    (e,    axis=1)

--- a/invisible_cities/reco/peak_functions.py
+++ b/invisible_cities/reco/peak_functions.py
@@ -152,12 +152,15 @@ def rebin_times_and_waveforms(times, widths, waveforms,
     rebinned_widths = np.zeros(            len(slices) )
     rebinned_wfs    = np.zeros((n_sensors, len(slices)))
 
-    for i, s in enumerate(slices):
-        t = times    [   s]
-        e = waveforms[:, s]
-        w = np.sum(e, axis=0).clip(0) if np.any(e) else None
-        if not np.any(w): w = None
+    for i, sl in enumerate(slices):
+        t = times    [   sl]
+        e = waveforms[:, sl]
+        ## Weight with the charge sum per slice
+        ## if positive and unweighted if all
+        ## negative.
+        s = np.sum(e, axis=0).clip(0)
+        w = s if np.any(s) else None
         rebinned_times [   i] = np.average(t, weights=w)
-        rebinned_widths[   i] = np.sum    (   widths[s])
+        rebinned_widths[   i] = np.sum    (  widths[sl])
         rebinned_wfs   [:, i] = np.sum    (e,    axis=1)
     return rebinned_times, rebinned_widths, rebinned_wfs

--- a/invisible_cities/reco/peak_functions_test.py
+++ b/invisible_cities/reco/peak_functions_test.py
@@ -603,6 +603,8 @@ def test_rebin_times_and_waveforms_times_are_consistent(t_and_wf, stride):
 
 
 def test_rebin_times_and_waveforms_negative_bins(ICDATADIR):
+    # Tests that rebin doesn't raise an error
+    # even with multiple adjacent negative bins
     pmap_file = os.path.join(ICDATADIR, 'pmaps_negative_bins.h5')
     pmaps     = load_pmaps(pmap_file)
     s2        = pmaps[48490].s2s[0]

--- a/invisible_cities/reco/peak_functions_test.py
+++ b/invisible_cities/reco/peak_functions_test.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 
 from pytest import approx
@@ -22,6 +24,7 @@ from ..evm .pmaps             import SiPMResponses
 from ..evm .pmaps             import S1
 from ..evm .pmaps             import S2
 from ..evm .pmaps             import PMap
+from ..io  .pmaps_io          import load_pmaps
 from ..types.ic_types_c       import minmax
 from .                        import peak_functions as pf
 
@@ -597,3 +600,12 @@ def test_rebin_times_and_waveforms_times_are_consistent(t_and_wf, stride):
                                                   np.ones_like(wfs), stride)
 
     assert np.sum(rb_times) * stride == approx(np.sum(times))
+
+
+def test_rebin_times_and_waveforms_negative_bins(ICDATADIR):
+    pmap_file = os.path.join(ICDATADIR, 'pmaps_negative_bins.h5')
+    pmaps     = load_pmaps(pmap_file)
+    s2        = pmaps[48490].s2s[0]
+    rebinned_info = pf.rebin_times_and_waveforms(s2.times             ,
+                                                 s2.bin_widths        ,
+                                                 s2.pmts.all_waveforms)


### PR DESCRIPTION
This PR reopens #658 with an added patch to protect
against attempts to rebin using only negative charge bins.

Tests are added to demonstrate the problems and their
solution.