### PR TITLE
Detsim electron simulation functions

### DIFF
--- a/invisible_cities/detsim/simulate_electrons.py
+++ b/invisible_cities/detsim/simulate_electrons.py
@@ -1,0 +1,101 @@
+import numpy as np
+
+from typing import Tuple
+
+from .. core import system_of_units as units
+
+def generate_ionization_electrons(energies    : np.ndarray,
+                                  wi          : float = 22.4 * units.eV,
+                                  fano_factor : float = 0.15) -> np.ndarray:
+    """ Generate secondary ionization electrons from energy deposits
+
+    Parameters:
+        :wi: float
+            Mean ionization energy
+        :fano_factor: float
+            Fano-factor. related with the deviation in ionization electrons
+        :energies: np.ndarray
+            Energy hits
+    Returns:
+        :nes: np.ndarray
+            The ionization electrons per hit
+
+    Comment:
+        The quotient energy/wi gives the mean value of the ionization electrons produced
+        in a hit (N).
+        The number ionization electrons produced in a hit (N) are assumed to be normally
+        distributed with mean N and variance (N*F). (Being F the fano_factor).
+        If the variance is such that <1, the electrons are assumed to be poisson distributed.
+    """
+    nes = energies / wi
+    var = nes * fano_factor
+    pois = var < 1      #See docstring for explanation
+    nes[ pois] = np.random.poisson(nes[pois])
+    nes[~pois] = np.round(np.random.normal(nes[~pois], np.sqrt(var[~pois])))
+    nes[nes<0] = 0
+    return nes.astype(int)
+
+
+def drift_electrons(zs             : np.ndarray,
+                    n_electrons    : np.ndarray,
+                    lifetime       : float = 12 * units.ms,
+                    drift_velocity : float = 1  * units.mm / units.mus) -> np.ndarray:
+    """ Returns number of electrons due to lifetime losses from secondary electrons
+
+    Parameters:
+        :lifetime: float
+            Electron lifetime
+        :drift_velocity: float
+            Drift velocity at the active volume of the detector
+        :zs:
+            z coordinate of the ionization hits
+        :electrons:
+            Number of ionization electrons in each hit
+    Returns:
+        :nes: np.ndarray
+            Number of ionization electrons that reach the EL gap
+    """
+    @np.vectorize
+    def attachment(n_ie, t):
+        return np.count_nonzero(-lifetime * np.log(np.random.uniform(size=n_ie)) > t)
+
+    ts  = zs / drift_velocity
+    return attachment(n_electrons, ts)
+
+
+def diffuse_electrons(xs                     : np.ndarray,
+                      ys                     : np.ndarray,
+                      zs                     : np.ndarray,
+                      n_electrons            : np.ndarray,
+                      transverse_diffusion   : float = 1.0 * units.mm / units.cm**0.5,
+                      longitudinal_diffusion : float = 0.2 * units.mm / units.cm**0.5)\
+                      -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Starting from hits with positions xs, ys, zs, and number of electrons,
+    apply diffusion and return diffused positions xs, ys, zs for each electron.
+
+    Paramters:
+        :transverse_diffusion: float
+        :longitudinal_diffusion: float
+        :xs, ys, zs: np.ndarray (1D of size: #hits)
+            Postions of initial hits
+        :electrons:
+            Number of ionization electrons per hit before drifting
+    Returns:
+        :dxs, dys, dzs: np.ndarray (1D of size: #hits x #electrons-per-hit)
+            Diffused positions at the EL
+    """
+    xs = np.repeat(xs, n_electrons)
+    ys = np.repeat(ys, n_electrons)
+    zs = np.repeat(zs, n_electrons)
+
+    # substitute z<0 to z=0
+    sel = zs<0
+    zs[sel] = 0
+
+    sqrtz = zs ** 0.5
+    dxs  = np.random.normal(xs, sqrtz *   transverse_diffusion)
+    dys  = np.random.normal(ys, sqrtz *   transverse_diffusion)
+    dzs  = np.random.normal(zs, sqrtz * longitudinal_diffusion)
+
+    return (dxs, dys, dzs)

--- a/invisible_cities/detsim/simulate_electrons_test.py
+++ b/invisible_cities/detsim/simulate_electrons_test.py
@@ -1,0 +1,143 @@
+import numpy  as np
+
+from collections import namedtuple
+from operator    import itemgetter
+
+from pytest import fixture
+
+from .. core         import system_of_units as units
+from .. io.mcinfo_io import load_mchits_df
+
+from . simulate_electrons import generate_ionization_electrons
+from . simulate_electrons import drift_electrons
+from . simulate_electrons import diffuse_electrons
+
+@fixture(scope="session")
+def MChits_and_detsim_params(krypton_MCRD_file):
+
+    #hits
+    hits_df    = load_mchits_df(krypton_MCRD_file)
+    #choose event
+    evt = 0
+    hits = hits_df.loc[evt]
+
+    xs = hits["x"].values
+    ys = hits["y"].values
+    zs = hits["z"].values
+    energies = hits["energy"].values
+
+    # electron simulation parameters
+    wi = 22.4 * units.eV
+    fano_factor = 0.15
+    drift_velocity = 1.00 * units.mm / units.mus
+    lifetime       = 7.00 * units.ms
+
+    transverse_diffusion   = 1.00 * units.mm / units.cm**0.5
+    longitudinal_diffusion = 0.30 * units.mm / units.cm**0.5
+
+    nt = namedtuple(typename    = "MChits_and_detsim_params",
+                    field_names = """xs ys zs energies
+                                     wi fano_factor
+                                     lifetime drift_velocity
+                                     transverse_diffusion longitudinal_diffusion""")
+
+    return nt(*itemgetter(*nt._fields)(locals()))
+
+
+def test_generate_ionization_electrons(MChits_and_detsim_params):
+
+    f = MChits_and_detsim_params
+
+    n_electrons = generate_ionization_electrons(f.energies, f.wi, f.fano_factor)
+
+    # test same lengths and all positive
+    assert len(n_electrons) == len(f.energies)
+    assert np.all(n_electrons >= 0)
+
+    # test is integer
+    assert issubclass(n_electrons.dtype.type, (np.integer, int))
+
+
+def test_generate_ionization_electrons_null_energies(MChits_and_detsim_params):
+
+    f = MChits_and_detsim_params
+
+    # test for null energies
+    n_electrons = generate_ionization_electrons(np.zeros(10), f.wi, f.fano_factor)
+    assert np.all(n_electrons == np.zeros(10))
+
+
+def test_drift_electrons(MChits_and_detsim_params):
+
+    f = MChits_and_detsim_params
+
+    n_ie = np.mean(f.energies / f.wi)
+    n_electrons = np.clip(np.random.normal(n_ie, n_ie**0.5, size=len(f.zs)), 0, None).astype(int)
+    drifted_electrons = drift_electrons(f.zs, n_electrons, f.lifetime, f.drift_velocity)
+
+    # test all >= 0 and <= n_electrons
+    assert np.all(drifted_electrons >= 0)
+    assert np.all(drifted_electrons <= n_electrons)
+
+    # test is integer
+    assert issubclass(drifted_electrons.dtype.type, (np.integer, int))
+
+
+def test_drift_electrons_extreme_lifetimes(MChits_and_detsim_params):
+
+    f = MChits_and_detsim_params
+
+    n_ie = np.mean(f.energies / f.wi)
+    n_electrons = np.clip(np.random.normal(n_ie, n_ie**0.5, size=len(f.zs)), 0, None).astype(int)
+
+    # test lifetime = 0
+    drifted_electrons = drift_electrons(f.zs, n_electrons, 0, f.drift_velocity)
+    assert np.all(drifted_electrons == 0)
+
+    # test lifetime = inf
+    drifted_electrons = drift_electrons(f.zs, n_electrons, np.inf, f.drift_velocity)
+    assert np.all(drifted_electrons == n_electrons)
+
+
+def test_diffuse_electrons(MChits_and_detsim_params):
+
+    f = MChits_and_detsim_params
+
+    n_ie = np.mean(f.energies / f.wi)
+    n_electrons = np.clip(np.random.normal(n_ie, n_ie**0.5, size=len(f.zs)), 0, None).astype(int)
+
+    (dxs, dys, dzs) = diffuse_electrons(f.xs, f.ys, f.zs, n_electrons, f.transverse_diffusion, f.longitudinal_diffusion)
+
+    # test same lengths
+    assert len(dxs) == len(dys) == len(dzs) == np.sum(n_electrons)
+
+
+def test_diffuse_electrons_negative_z(MChits_and_detsim_params):
+
+    f = MChits_and_detsim_params
+
+    n_ie = np.mean(f.energies / f.wi)
+    n_electrons = np.clip(np.random.normal(n_ie, n_ie**0.5, size=len(f.zs)), 0, None).astype(int)
+
+    # test z<0 clip
+    zs = np.copy(f.zs)
+    sel = [0, 2, 5]
+    zs[sel] = -1
+    (_, _, dzs) = diffuse_electrons(f.xs, f.ys, zs, n_electrons, f.transverse_diffusion, f.longitudinal_diffusion)
+    assert np.all(dzs >= 0)
+
+
+def test_diffuse_electrons_null_diffusions(MChits_and_detsim_params):
+
+    f = MChits_and_detsim_params
+
+    n_ie = np.mean(f.energies / f.wi)
+    n_electrons = np.clip(np.random.normal(n_ie, n_ie**0.5, size=len(f.zs)), 0, None).astype(int)
+
+    # test null diffusions
+    (dxs, dys, _) = diffuse_electrons(f.xs, f.ys, f.zs, n_electrons, 0, f.longitudinal_diffusion)
+    assert np.all(dxs == np.repeat(f.xs, n_electrons))
+    assert np.all(dys == np.repeat(f.ys, n_electrons))
+
+    (_, _, dzs) = diffuse_electrons(f.xs, f.ys, f.zs, n_electrons, f.transverse_diffusion, 0)
+    assert np.all(dzs == np.repeat(f.zs, n_electrons))


### PR DESCRIPTION
Following issue #691:
4. upload functions to simulate electron drift (diffusion/attachment etc) in invisible_cities/cities/detsim_simulate_electrons.py

This module contains three functions, that generate, drift and diffuse the secondary electrons produced by the energy hits.