### PR TITLE
Improve df to tables writer

### DIFF
--- a/invisible_cities/cities/beersheba.py
+++ b/invisible_cities/cities/beersheba.py
@@ -47,7 +47,7 @@ from .. reco.deconv_functions  import InterpolationMethod
 
 from .. io.       mcinfo_io    import mc_info_writer
 from .. io.run_and_event_io    import run_and_event_writer
-from .. io.          dst_io    import _store_pandas_as_tables
+from .. io.          dst_io    import store_pandas_as_tables
 
 from .. evm.event_model        import HitEnergy
 
@@ -294,12 +294,12 @@ def deconv_writer(h5out, compression='ZLIB4'):
     For a given open table returns a writer for deconvolution hits dataframe
     """
     def write_deconv(df):
-        return _store_pandas_as_tables(h5out              = h5out             ,
-                                       df                 = df                ,
-                                       compression        = compression       ,
-                                       group_name         = 'DECO'            ,
-                                       table_name         = 'Events'          ,
-                                       descriptive_string = 'Deconvolved hits')
+        return store_pandas_as_tables(h5out              = h5out             ,
+                                      df                 = df                ,
+                                      compression        = compression       ,
+                                      group_name         = 'DECO'            ,
+                                      table_name         = 'Events'          ,
+                                      descriptive_string = 'Deconvolved hits')
     return write_deconv
 
 

--- a/invisible_cities/cities/esmeralda.py
+++ b/invisible_cities/cities/esmeralda.py
@@ -46,7 +46,7 @@ from .. types.      ic_types import xy
 from .. io.         hits_io import hits_writer
 from .. io.run_and_event_io import run_and_event_writer
 from .. io. event_filter_io import event_filter_writer
-from .. io.          dst_io import _store_pandas_as_tables
+from .. io.          dst_io import store_pandas_as_tables
 
 
 types_dict_summary = OrderedDict({'event'     : np.int32  , 'evt_energy' : np.float64, 'evt_charge'    : np.float64,
@@ -310,7 +310,7 @@ def track_writer(h5out, compression='ZLIB4', group_name='Tracking', table_name='
     For a given open table returns a writer for topology info dataframe
     """
     def write_tracks(df):
-        return _store_pandas_as_tables(h5out=h5out, df=df, compression=compression, group_name=group_name, table_name=table_name, descriptive_string=descriptive_string, str_col_length=str_col_length)
+        return store_pandas_as_tables(h5out=h5out, df=df, compression=compression, group_name=group_name, table_name=table_name, descriptive_string=descriptive_string, str_col_length=str_col_length)
     return write_tracks
 
 
@@ -319,7 +319,7 @@ def summary_writer(h5out, compression='ZLIB4', group_name='Summary', table_name=
     For a given open table returns a writer for summary info dataframe
     """
     def write_summary(df):
-        return _store_pandas_as_tables(h5out=h5out, df=df, compression=compression, group_name=group_name, table_name=table_name, descriptive_string=descriptive_string, str_col_length=str_col_length)
+        return store_pandas_as_tables(h5out=h5out, df=df, compression=compression, group_name=group_name, table_name=table_name, descriptive_string=descriptive_string, str_col_length=str_col_length)
     return write_summary
 
 def kdst_from_df_writer(h5out, compression='ZLIB4', group_name='DST', table_name='Events', descriptive_string='KDST Events', str_col_length=32):
@@ -327,7 +327,7 @@ def kdst_from_df_writer(h5out, compression='ZLIB4', group_name='DST', table_name
     For a given open table returns a writer for KDST dataframe info
     """
     def write_kdst(df):
-        return _store_pandas_as_tables(h5out=h5out, df=df, compression=compression, group_name=group_name, table_name=table_name, descriptive_string=descriptive_string, str_col_length=str_col_length)
+        return store_pandas_as_tables(h5out=h5out, df=df, compression=compression, group_name=group_name, table_name=table_name, descriptive_string=descriptive_string, str_col_length=str_col_length)
     return write_kdst
 
 

--- a/invisible_cities/io/dst_io.py
+++ b/invisible_cities/io/dst_io.py
@@ -39,9 +39,14 @@ def _make_tabledef(column_types : pd.Series, str_col_length : int=32) -> dict:
             tabledef[colname] = tb.Col.from_type(coltype, pos=indx)
     return tabledef
 
-def _store_pandas_as_tables(h5out : tb.file.File, df : pd.DataFrame, group_name : str, table_name : str, compression : str='ZLIB4', descriptive_string : [str]="", str_col_length : int=32) -> None:
-    if len(df) == 0:
-        warnings.warn(f'dataframe is empty', UserWarning)
+def store_pandas_as_tables(h5out              : tb.file.File ,
+                           df                 : pd.DataFrame ,
+                           group_name         : str          ,
+                           table_name         : str          ,
+                           compression        : str = 'ZLIB4',
+                           descriptive_string : str = ""     ,
+                           str_col_length     : int = 32
+                           ) -> None:
     if group_name not in h5out.root:
         group = h5out.create_group(h5out.root, group_name)
 

--- a/invisible_cities/io/dst_io.py
+++ b/invisible_cities/io/dst_io.py
@@ -85,6 +85,7 @@ def store_pandas_as_tables(h5out              : tb.file.File ,
         warnings.warn(f'dataframe is empty', UserWarning)
     else:
         _check_castability(arr, data_types)
-        arr = arr.astype(data_types)
+        columns = list(data_types.names)
+        arr = arr[columns].astype(data_types)
         table.append(arr)
         table.flush()

--- a/invisible_cities/io/dst_io_test.py
+++ b/invisible_cities/io/dst_io_test.py
@@ -8,7 +8,7 @@ from ..core.testing_utils import assert_dataframes_equal
 from ..core.exceptions    import TableMismatch
 from . dst_io             import load_dst
 from . dst_io             import load_dsts
-from . dst_io             import _store_pandas_as_tables
+from . dst_io             import store_pandas_as_tables
 from . dst_io             import _make_tabledef
 
 import warnings
@@ -104,7 +104,7 @@ def test_store_pandas_as_tables_exact(config_tmpdir, df):
     group_name = 'test_group'
     table_name = 'table_name_1'
     with tb.open_file(filename, 'w') as h5out:
-        _store_pandas_as_tables(h5out, df, group_name, table_name)
+        store_pandas_as_tables(h5out, df, group_name, table_name)
     df_read = load_dst(filename, group_name, table_name)
     assert_dataframes_close(df_read, df, False, rtol=1e-5)
 
@@ -114,8 +114,8 @@ def test_store_pandas_as_tables_2df(config_tmpdir, df1, df2):
     group_name = 'test_group'
     table_name = 'table_name_2'
     with tb.open_file(filename, 'w') as h5out:
-        _store_pandas_as_tables(h5out, df1, group_name, table_name)
-        _store_pandas_as_tables(h5out, df2, group_name, table_name)
+        store_pandas_as_tables(h5out, df1, group_name, table_name)
+        store_pandas_as_tables(h5out, df2, group_name, table_name)
     df_read = load_dst(filename, group_name, table_name)
     assert_dataframes_close(df_read, pd.concat([df1, df2]).reset_index(drop=True), False, rtol=1e-5)
 
@@ -125,9 +125,9 @@ def test_store_pandas_as_tables_raises_exception(config_tmpdir, df1, df2):
     group_name = 'test_group'
     table_name = 'table_name_2'
     with tb.open_file(filename, 'w') as h5out:
-        _store_pandas_as_tables(h5out, df1, group_name, table_name)
+        store_pandas_as_tables(h5out, df1, group_name, table_name)
         with raises(TableMismatch):
-            _store_pandas_as_tables(h5out, df2, group_name, table_name)
+            store_pandas_as_tables(h5out, df2, group_name, table_name)
 
 @given(df=strings_dataframe)
 def test_strings_store_pandas_as_tables(config_tmpdir, df):
@@ -135,7 +135,7 @@ def test_strings_store_pandas_as_tables(config_tmpdir, df):
     group_name = 'test_group'
     table_name = 'table_name_str'
     with tb.open_file(filename, 'w') as h5out:
-        _store_pandas_as_tables(h5out, df, group_name, table_name)
+        store_pandas_as_tables(h5out, df, group_name, table_name)
     df_read    = load_dst(filename, group_name, table_name)
     #we have to cast from byte strings to compare with original dataframe
     df_read.str_val = df_read.str_val.str.decode('utf-8')
@@ -155,4 +155,4 @@ def test_store_pandas_as_tables_raises_warning_empty_dataframe(config_tmpdir, em
     table_name = 'table_name_3'
     with tb.open_file(filename, 'w') as h5out:
         with pytest.warns(UserWarning, match='dataframe is empty'):
-            _store_pandas_as_tables(h5out, empty_dataframe, group_name, table_name)
+            store_pandas_as_tables(h5out, empty_dataframe, group_name, table_name)

--- a/invisible_cities/io/dst_io_test.py
+++ b/invisible_cities/io/dst_io_test.py
@@ -106,7 +106,7 @@ def test_store_pandas_as_tables_exact(config_tmpdir, df):
     with tb.open_file(filename, 'w') as h5out:
         store_pandas_as_tables(h5out, df, group_name, table_name)
     df_read = load_dst(filename, group_name, table_name)
-    assert_dataframes_close(df_read, df, False, rtol=1e-5)
+    assert_dataframes_close(df_read, df)
 
 @given(df1=dataframe, df2=dataframe)
 def test_store_pandas_as_tables_2df(config_tmpdir, df1, df2):
@@ -117,7 +117,7 @@ def test_store_pandas_as_tables_2df(config_tmpdir, df1, df2):
         store_pandas_as_tables(h5out, df1, group_name, table_name)
         store_pandas_as_tables(h5out, df2, group_name, table_name)
     df_read = load_dst(filename, group_name, table_name)
-    assert_dataframes_close(df_read, pd.concat([df1, df2]).reset_index(drop=True), False, rtol=1e-5)
+    assert_dataframes_close(df_read, pd.concat([df1, df2]).reset_index(drop=True))
 
 @given(df1=dataframe, df2=dataframe_diff)
 def test_store_pandas_as_tables_raises_exception(config_tmpdir, df1, df2):
@@ -139,10 +139,10 @@ def test_strings_store_pandas_as_tables(config_tmpdir, df):
     df_read    = load_dst(filename, group_name, table_name)
     #we have to cast from byte strings to compare with original dataframe
     df_read.str_val = df_read.str_val.str.decode('utf-8')
-    assert_dataframes_equal(df_read, df, False)
+    assert_dataframes_equal(df_read, df)
 
 def test_make_tabledef(empty_dataframe):
-    tabledef = _make_tabledef(empty_dataframe.dtypes)
+    tabledef = _make_tabledef(empty_dataframe.to_records(index=False).dtype, 32)
     expected_tabledef = {'int_value'   : tb.Int32Col  (             shape=(), dflt=0    , pos=0),
                          'float_value' : tb.Float32Col(             shape=(), dflt=0    , pos=1),
                          'bool_value'  : tb.BoolCol   (             shape=(), dflt=False, pos=2),

--- a/invisible_cities/io/dst_io_test.py
+++ b/invisible_cities/io/dst_io_test.py
@@ -176,3 +176,15 @@ def test_store_pandas_as_tables_raises_TableMismatch_inconsistent_types(config_t
         store_pandas_as_tables(h5out, df, group_name, table_name)
         with raises(TableMismatch, match='dataframe numeric types not consistent with the table existing ones'):
             store_pandas_as_tables(h5out, df.astype(float), group_name, table_name)
+
+@given(df1=dataframe, df2=dataframe)
+def test_store_pandas_as_tables_unordered_df(config_tmpdir, df1, df2):
+    filename   = config_tmpdir + 'dataframe_to_table_exact.h5'
+    group_name = 'test_group'
+    table_name = 'table_name_unordered'
+    with tb.open_file(filename, 'w') as h5out:
+        store_pandas_as_tables(h5out, df1, group_name, table_name)
+        df2 = df2[['bool_value', 'int_value', 'float_val']]
+        store_pandas_as_tables(h5out, df2, group_name, table_name)
+    df_read = load_dst(filename, group_name, table_name)
+    assert_dataframes_equal(df_read, pd.concat([df1, df2], sort=True).reset_index(drop=True))


### PR DESCRIPTION
This PR removes underscore in front of store_pandas_as_tables writer since the method is being used outside the module. It also modifies the method to improve speed when writing large dataframes, no tests needed because it is just internal change.