### PR TITLE
Change assert

### DIFF
--- a/invisible_cities/cities/beersheba_test.py
+++ b/invisible_cities/cities/beersheba_test.py
@@ -27,7 +27,7 @@ def test_create_deconvolution_df(ICDATADIR):
                                                   CutType.abs, ecut, 3) for _, t in true_dst.groupby('event')])
     true_dst = true_dst.loc[true_dst.E > ecut, :].reset_index(drop=True)
 
-    assert_dataframes_close(new_dst, true_dst)
+    assert_dataframes_close(new_dst .reset_index(drop=True), true_dst.reset_index(drop=True))
 
 
 @mark.parametrize("cut_type", CutType.__members__)

--- a/invisible_cities/cities/esmeralda_test.py
+++ b/invisible_cities/cities/esmeralda_test.py
@@ -163,7 +163,9 @@ def test_esmeralda_tracks_exact(data_hdst, esmeralda_tracks, correction_map_file
     #some events are not in df_tracks_exact
     events = df_tracks_exact.event.unique()
     df_tracks_cut  = df_tracks[df_tracks.event.isin(events)]
-    assert_dataframes_close (df_tracks_cut[columns2], df_tracks_exact[columns2])
+
+    assert_dataframes_close (df_tracks_cut[columns2]  .reset_index(drop=True),
+                             df_tracks_exact[columns2].reset_index(drop=True))
     #make sure out_of_map is true for events not in df_tracks_exact
     diff_events = list(set(df_tracks.event.unique()).difference(events))
     df_summary  = dio.load_dst(PATH_OUT, 'Summary', 'Events')

--- a/invisible_cities/core/testing_utils.py
+++ b/invisible_cities/core/testing_utils.py
@@ -1,4 +1,5 @@
 import numpy  as np
+import pandas as pd
 
 from pytest                 import approx
 from numpy.testing          import assert_array_equal
@@ -106,11 +107,18 @@ def _compare_dataframes(assertion, df1, df2, check_types=True, **kwargs):
 
 
 def assert_dataframes_equal(df1, df2, check_types=True, **kwargs):
-    _compare_dataframes(assert_array_equal, df1, df2, check_types, **kwargs)
+    pd.testing.assert_frame_equal(df1.sort_index(axis=1), df2.sort_index(axis=1), check_names=True, check_dtype=check_types, check_exact=True, **kwargs)
 
+def assert_dataframes_close(df1, df2, check_types=True, rtol=None, atol=None, **kwargs):
+    if rtol:
+        check_less_precise = int(np.log10(1./rtol))
+    elif atol:
+        check_less_precise = int(np.log10(atol))
+    else:
+        check_less_precise = True
 
-def assert_dataframes_close(df1, df2, check_types=True, **kwargs):
-    _compare_dataframes(assert_allclose, df1, df2, check_types, **kwargs)
+    pd.testing.assert_frame_equal(df1.sort_index(axis=1), df2.sort_index(axis=1), 
+    check_names=True, check_dtype=check_types, check_less_precise = check_less_precise)
 
 
 def assert_SensorResponses_equality(sr0, sr1):


### PR DESCRIPTION
After replacing the _compare_dataframes IC function with the pandas.testing function assert_frame_equal (with @mmkekic help) there are 3 test that fail. These are beersheba_test.py (not clear), esmeralda_test.py (it fails because the index of the compared dataframes is different) and corrections_test.py (not clear to me either, but apparently not related to the changes I made). 
@mmkekic suggested to open this PR  so we can discuss what approach to take @andLaing @gonzaponte 