### PR TITLE
Change rwf file isidora

### DIFF
--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -68,8 +68,8 @@ def job_info_missing_pmts(config_tmpdir, ICDATADIR):
     pmt_active  = list(filter(lambda x: x not in pmt_missing, range(12)))
 
 
-    ifilename = os.path.join(ICDATADIR    , 'electrons_40keV_z250_RWF.h5')
-    ofilename = os.path.join(config_tmpdir, 'electrons_40keV_z250_pmaps_missing_PMT.h5')
+    ifilename = os.path.join(ICDATADIR    , 'electrons_40keV_z25_RWF.h5')
+    ofilename = os.path.join(config_tmpdir, 'electrons_40keV_z25_pmaps_missing_PMT.h5')
 
     return job_info(run_number, pmt_missing, pmt_active, ifilename, ofilename)
 

--- a/invisible_cities/cities/isidora_test.py
+++ b/invisible_cities/cities/isidora_test.py
@@ -19,8 +19,8 @@ def test_isidora_electrons_40keV(config_tmpdir, ICDATADIR):
     # since they are in general test-specific
     # NB: avoid taking defaults for run number (test-specific)
 
-    PATH_IN  = os.path.join(ICDATADIR    , 'electrons_40keV_z250_RWF.h5')
-    PATH_OUT = os.path.join(config_tmpdir, 'electrons_40keV_z250_CWF.h5')
+    PATH_IN  = os.path.join(ICDATADIR    , 'electrons_40keV_z25_RWF.h5')
+    PATH_OUT = os.path.join(config_tmpdir, 'electrons_40keV_z25_CWF.h5')
 
     nrequired  = 2
 

--- a/invisible_cities/config/berenice.conf
+++ b/invisible_cities/config/berenice.conf
@@ -1,5 +1,5 @@
-files_in    = '$ICDIR/database/test_data/electrons_40keV_z250_RWF.h5'
-file_out    = '/tmp/electrons_40keV_z250_sipmPDF.h5'
+files_in    = '$ICDIR/database/test_data/electrons_40keV_z25_RWF.h5'
+file_out    = '/tmp/electrons_40keV_z25_sipmPDF.h5'
 compression = 'ZLIB4'
 print_mod   = 1
 event_range = 1

--- a/invisible_cities/config/irene.conf
+++ b/invisible_cities/config/irene.conf
@@ -1,7 +1,7 @@
-files_in = '$ICDIR/database/test_data/electrons_40keV_z250_RWF.h5'
+files_in = '$ICDIR/database/test_data/electrons_40keV_z25_RWF.h5'
 
 # REPLACE /tmp with your output directory
-file_out = '/tmp/electrons_40keV_z250_PMP.h5'
+file_out = '/tmp/electrons_40keV_z25_PMP.h5'
 
 # compression library
 compression = 'ZLIB4'

--- a/invisible_cities/config/isidora.conf
+++ b/invisible_cities/config/isidora.conf
@@ -1,8 +1,8 @@
 # set_input_files
-files_in = '$ICDIR/database/test_data/electrons_40keV_z250_RWF.h5'
+files_in = '$ICDIR/database/test_data/electrons_40keV_z25_RWF.h5'
 
 # REPLACE /tmp with your output directory
-file_out = '/tmp/electrons_40keV_z250_PMP.h5'
+file_out = '/tmp/electrons_40keV_z25_PMP.h5'
 
 # compression library
 compression = 'ZLIB4'

--- a/invisible_cities/config/phyllis.conf
+++ b/invisible_cities/config/phyllis.conf
@@ -1,5 +1,5 @@
-files_in    = '$ICDIR/database/test_data/electrons_40keV_z250_RWF.h5'
-file_out    = '/tmp/electrons_40keV_z250_sipmPDF.h5'
+files_in    = '$ICDIR/database/test_data/electrons_40keV_z25_RWF.h5'
+file_out    = '/tmp/electrons_40keV_z25_sipmPDF.h5'
 compression = 'ZLIB4'
 print_mod   = 1
 event_range = 1

--- a/invisible_cities/config/trude.conf
+++ b/invisible_cities/config/trude.conf
@@ -1,5 +1,5 @@
-files_in    = '$ICDIR/database/test_data/electrons_40keV_z250_RWF.h5'
-file_out    = '/tmp/electrons_40keV_z250_sipmPDF.h5'
+files_in    = '$ICDIR/database/test_data/electrons_40keV_z25_RWF.h5'
+file_out    = '/tmp/electrons_40keV_z25_sipmPDF.h5'
 compression = 'ZLIB4'
 print_mod   = 1
 event_range = 1

--- a/invisible_cities/conftest.py
+++ b/invisible_cities/conftest.py
@@ -59,7 +59,7 @@ def example_blr_wfs_filename(ICDATADIR):
 
 
 @pytest.fixture(scope  = 'session',
-                params = ['electrons_40keV_z250_RWF.h5',
+                params = ['electrons_40keV_z25_RWF.h5',
                           'electrons_511keV_z250_RWF.h5',
                           'electrons_1250keV_z250_RWF.h5',
                           'electrons_2500keV_z250_RWF.h5'])

--- a/invisible_cities/core/configure_test.py
+++ b/invisible_cities/core/configure_test.py
@@ -66,8 +66,8 @@ event_range = {event_range}
 """
 
 # The values that will be fed into the above.
-config_file_spec = dict(files_in    = 'electrons_40keV_z250_RWF.h5',
-                        file_out    = 'electrons_40keV_z250_PMP.h5',
+config_file_spec = dict(files_in    = 'electrons_40keV_z25_RWF.h5',
+                        file_out    = 'electrons_40keV_z25_PMP.h5',
                         compression = 'ZLIB4',
                         run_number  = 23,
                         nprint      = 24,

--- a/invisible_cities/database/test_data/electrons_40keV_z250_RWF.h5
+++ b/invisible_cities/database/test_data/electrons_40keV_z250_RWF.h5
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:be13b302fad35ff701dc4a9056861e43221c0d3663394d61cdd90ac1aa11f4f1
-size 2912536

--- a/invisible_cities/reco/wfm_functions_test.py
+++ b/invisible_cities/reco/wfm_functions_test.py
@@ -31,7 +31,7 @@ def test_compare_cwf_blr(dbnew):
     2) Computes the difference between CWF and BLR (compare_cwf_blr())
     3) Asserts that the differences are small.
     For 10 events and 12 PMTs per event, all differences are less than 0.1 %
-    Input file (needed in repository): electrons_40keV_z250_RWF.h5
+    Input file (needed in repository): electrons_40keV_z25_RWF.h5
     """
 
     RWF_file = path.join(os.environ['ICDIR'],


### PR DESCRIPTION
Removes the use of the file electrons_40keV_z250_RWF.h5 in
the isidora tests and in the commandline tests for isidora
and irene.

This file was found to have badly written MC info in PR #693 