### PR TITLE
Update NEXT100 DB and related tests

### DIFF
--- a/invisible_cities/conftest.py
+++ b/invisible_cities/conftest.py
@@ -670,7 +670,7 @@ def dbnext100():
 @pytest.fixture(scope='session',
                 params=[db_data('demopp' ,  3,  256, 3, 79),
                         db_data('new'    , 12, 1792, 3, 79),
-                        db_data('next100', 60, 6848, 8, 79)],
+                        db_data('next100', 60, 3584, 0, 0)],
                ids=["demo", "new", "next100"])
 def db(request):
     return request.param

--- a/invisible_cities/database/load_db_test.py
+++ b/invisible_cities/database/load_db_test.py
@@ -1,5 +1,6 @@
 import time
 import sqlite3
+import pytest
 
 from os.path import join
 
@@ -145,6 +146,8 @@ def test_database_is_being_cached(db_fun, db):
 
 def test_frontend_mapping(db):
     """ Check the mapping has the expected shape etc """
+    if db.detector == "next100":
+        pytest.skip("NEXT100 not implemented yet")
 
     run_number = 6000
     fe_mapping, _ = DB.PMTLowFrequencyNoise(db.detector, run_number)
@@ -159,6 +162,8 @@ def test_frontend_mapping(db):
 def test_pmt_noise_frequencies(db):
     """ Check the magnitudes and frequencies
     are of the expected length """
+    if db.detector == "next100":
+        pytest.skip("NEXT100 not implemented yet")
     run_number = 5000
     _, frequencies = DB.PMTLowFrequencyNoise(db.detector, run_number)
 

--- a/invisible_cities/database/localdb.NEXT100DB.sqlite3
+++ b/invisible_cities/database/localdb.NEXT100DB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:547946098896f85df290d49b6df3abd5f8c37ec974e3b3a4cb6fe1f8db8780c0
-size 67399680
+oid sha256:498400e1707f02bdf0f47e522e4ab584c89410fcae000eb4c1017fc7d7dce106
+size 34594816

--- a/invisible_cities/database/localdb.NEXT100DB.sqlite3
+++ b/invisible_cities/database/localdb.NEXT100DB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:498400e1707f02bdf0f47e522e4ab584c89410fcae000eb4c1017fc7d7dce106
-size 34594816
+oid sha256:dc08bc015f6dff0d5103957527dd95974178fa110090d68005b3b9abfce3ac12
+size 34603008


### PR DESCRIPTION
In this PR, the NEXT100 database has been updated according to the current design of the detector. Some tables are empty, since we don't have information about electronics yet, therefore, two tests have been marked to be skipped in the case of the NEXT100 detector.

Also, the previous NEXT100DB database has been renamed to NEXT100DB_old.