### PR TITLE
Blr pedestal and performance

### DIFF
--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -258,7 +258,7 @@ def signal_finder(buffer_len   : float,
 
 # TODO: consider caching database
 def deconv_pmt(dbfile, run_number, n_baseline,
-               selection=None, pedestal_function = csf.means):
+               selection=None, pedestal_function=csf.means):
     DataPMT    = load_db.DataPMT(dbfile, run_number = run_number)
     pmt_active = np.nonzero(DataPMT.Active.values)[0].tolist() if selection is None else selection
     coeff_c    = DataPMT.coeff_c  .values.astype(np.double)

--- a/invisible_cities/sierpe/blr.pxd
+++ b/invisible_cities/sierpe/blr.pxd
@@ -29,16 +29,7 @@ import numpy as np
 cimport numpy as np
 
 cpdef deconvolve_signal(double [:] signal_daq,
-                        int        n_baseline      = *,
                         double     coeff_clean     = *,
                         double     coeff_blr       = *,
                         double     thr_trigger     = *,
                         int accum_discharge_length = *)
-
-cpdef deconv_pmt(np.ndarray[np.int16_t, ndim=2] pmtrwf,
-                 double [:]                     coeff_c,
-                 double [:]                     coeff_blr,
-                 list                           pmt_active             = *,
-                 int                            n_baseline             = *,
-                 double                         thr_trigger            = *,
-                 int                            accum_discharge_length = *)


### PR DESCRIPTION
Refactorises the blr function removing the baseline calculation to be done outside the cythonised functions. In this way alternate functions can be tested.

Also changes the cythonised PMT loop for a standard map to improve performance. Per event time reduced from ~200 ms to ~25 ms on local machine.