### PR TITLE
Install and initialize git lfs on Travis OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,11 @@ install:
 
 script:
   - HYPOTHESIS_PROFILE=travis-ci bash manage.sh run_tests_par
+
+
+before_install:
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install git-lfs; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then git lfs install;      fi
+
+before_script:
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then git lfs pull; fi


### PR DESCRIPTION
Travis has been failing on OSX since we enabled Git LFS.

This is becasue Travis enables LFS on its Linux images but not on the OSX ones.

This PR fixes the problem by using `brew` to install Git LFS on the OSX image.

Closes #552.