### PR TITLE
Add Flex100 to the list of available detectors

### DIFF
--- a/invisible_cities/conftest.py
+++ b/invisible_cities/conftest.py
@@ -667,11 +667,16 @@ def dbnew():
 def dbnext100():
     return 'next100'
 
+@pytest.fixture(scope='session')
+def dbflex100():
+    return 'flex100'
+
 @pytest.fixture(scope='session',
                 params=[db_data('demopp' ,  3,  256, 3, 79),
                         db_data('new'    , 12, 1792, 3, 79),
-                        db_data('next100', 60, 3584, 0, 0)],
-               ids=["demo", "new", "next100"])
+                        db_data('next100', 60, 3584, 0, 0),
+                        db_data('flex100', 60, 3062, 0, 0)],
+               ids=["demo", "new", "next100", "flex100"])
 def db(request):
     return request.param
 

--- a/invisible_cities/database/download.py
+++ b/invisible_cities/database/download.py
@@ -76,7 +76,7 @@ def loadDB(dbname : str):
 
 
 if __name__ == '__main__':
-    dbname = ['NEWDB', 'DEMOPPDB', 'NEXT100DB']
+    dbname = ['NEWDB', 'DEMOPPDB', 'NEXT100DB', 'Flex100DB']
     if len(sys.argv) > 1:
         dbname = sys.argv[1]
         loadDB(dbname)

--- a/invisible_cities/database/download_test.py
+++ b/invisible_cities/database/download_test.py
@@ -8,7 +8,7 @@ from pytest import mark
 
 from . import download as db
 
-@mark.parametrize('dbname', 'DEMOPPDB NEWDB NEXT100DB'.split())
+@mark.parametrize('dbname', 'DEMOPPDB NEWDB NEXT100DB Flex100DB'.split())
 def test_create_table_sqlite(dbname, output_tmpdir):
     dbfile = os.path.join(output_tmpdir, 'db.sqlite3')
 

--- a/invisible_cities/database/load_db.py
+++ b/invisible_cities/database/load_db.py
@@ -10,6 +10,7 @@ class DetDB:
     new     = os.environ['ICTDIR'] + '/invisible_cities/database/localdb.NEWDB.sqlite3'
     demopp  = os.environ['ICTDIR'] + '/invisible_cities/database/localdb.DEMOPPDB.sqlite3'
     next100 = os.environ['ICTDIR'] + '/invisible_cities/database/localdb.NEXT100DB.sqlite3'
+    flex100 = os.environ['ICTDIR'] + '/invisible_cities/database/localdb.Flex100DB.sqlite3'
 
 def tmap(*args):
     return tuple(map(*args))

--- a/invisible_cities/database/load_db_test.py
+++ b/invisible_cities/database/load_db_test.py
@@ -148,6 +148,8 @@ def test_frontend_mapping(db):
     """ Check the mapping has the expected shape etc """
     if db.detector == "next100":
         pytest.skip("NEXT100 not implemented yet")
+    if db.detector == "flex100":
+        pytest.skip("Flex100 not implemented yet")
 
     run_number = 6000
     fe_mapping, _ = DB.PMTLowFrequencyNoise(db.detector, run_number)
@@ -164,6 +166,9 @@ def test_pmt_noise_frequencies(db):
     are of the expected length """
     if db.detector == "next100":
         pytest.skip("NEXT100 not implemented yet")
+    if db.detector == "flex100":
+        pytest.skip("Flex100 not implemented yet")
+
     run_number = 5000
     _, frequencies = DB.PMTLowFrequencyNoise(db.detector, run_number)
 

--- a/invisible_cities/database/localdb.Flex100DB.sqlite3
+++ b/invisible_cities/database/localdb.Flex100DB.sqlite3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c96cb7c1cf0bba0a7512dc1dd35b9caa7ee497fa824ad024a635f1902815823
+size 29052928


### PR DESCRIPTION
Flex100 corresponds to the theoretical NextFlex detector configured to emulate the actual Next100 detector.
This MR adds Flex100 to the list of detectors that can be analyzed with IC.
