### PR TITLE
Fix non-integer sensor position in beersheba.

### DIFF
--- a/invisible_cities/cities/beersheba_test.py
+++ b/invisible_cities/cities/beersheba_test.py
@@ -17,6 +17,7 @@ from .. reco.deconv_functions  import InterpolationMethod
 from .. evm .event_model       import HitEnergy
 from .. core.testing_utils     import assert_dataframes_close
 from .. core.testing_utils     import assert_tables_equality
+from .. database.load_db       import DataSiPM
 
 
 def test_create_deconvolution_df(ICDATADIR):
@@ -139,7 +140,7 @@ def test_deconvolve_signal_enums(deconvolution_config, param_name):
     conf_dict[param_name]     = param_name
 
     with raises(ValueError):
-        deconvolve_signal(**conf_dict)
+        deconvolve_signal(DataSiPM('new'), **conf_dict)
 
 
 def test_beersheba_expandvar(deconvolution_config):

--- a/invisible_cities/reco/deconv_functions.py
+++ b/invisible_cities/reco/deconv_functions.py
@@ -7,12 +7,13 @@ from typing  import Callable
 
 from enum    import auto
 
-from scipy        import interpolate
-from scipy.signal import fftconvolve
-from scipy.signal import convolve
+from scipy                  import interpolate
+from scipy.signal           import fftconvolve
+from scipy.signal           import convolve
 from scipy.spatial.distance import cdist
 
 from ..core .core_functions import shift_to_bin_centers
+from ..core .core_functions import in_range
 
 from .. types.ic_types      import AutoNameEnumBase
 
@@ -98,8 +99,8 @@ def drop_isolated_sensors(distance  : List[float]=[10., 10.],
     return drop_isolated_sensors
 
 
-def deconvolution_input(sample_width : List[float],
-                        bin_size     : List[float],
+def deconvolution_input(sample_width : List[float     ],
+                        det_grid     : List[np.ndarray],
                         inter_method : InterpolationMethod = InterpolationMethod.cubic
                        ) -> Callable:
     """
@@ -113,7 +114,7 @@ def deconvolution_input(sample_width : List[float],
 
     Initialization parameters:
         sample_width : Sampling size of the sensors.
-        bin_size     : Size of the interpolated bins.
+        det_grid     : xy-coordinates of the detector grid, to interpolate on them
         inter_method : Interpolation method.
 
     Returns
@@ -128,14 +129,13 @@ def deconvolution_input(sample_width : List[float],
                             weight      : np.ndarray
                            ) -> Tuple[np.ndarray, Tuple[np.ndarray, ...]]:
 
-        ranges = [[coord.min() - 1.5 * sw, coord.max() + 1.5 * sw]     for coord,   sw in zip(data      , sample_width)]
-        nbin   = [np.ceil(np.diff(rang)/bs).astype('int')[0]           for bs   , rang in zip(bin_size  ,       ranges)]
-
+        ranges = [[coord.min() - 1.5 * sw, coord.max() + 1.5 * sw] for coord, sw in zip(data, sample_width)]
         if inter_method in (InterpolationMethod.linear, InterpolationMethod.cubic, InterpolationMethod.nearest):
-            allbins = [np.linspace(*rang, np.int(np.ceil(np.diff(rang)/sw)+1)) for rang ,   sw in zip(ranges[:2], sample_width)]
+            allbins   = [np.arange(rang[0], rang[1] + np.finfo(np.float32).eps, sw) for rang, sw in zip(ranges, sample_width)]
             Hs, edges = np.histogramdd(data, bins=allbins, normed=False, weights=weight)
         elif inter_method is InterpolationMethod.none:
-            Hs, edges = np.histogramdd(data, bins=nbin   , normed=False, weights=weight, range=ranges)
+            allbins   = [grid[in_range(grid, *rang)] for rang, grid in zip(ranges, det_grid)]
+            Hs, edges = np.histogramdd(data, bins=allbins, normed=False, weights=weight)
         else:
             raise ValueError(f'inter_method {inter_method} is not a valid interpolatin mode.')
 
@@ -143,7 +143,7 @@ def deconvolution_input(sample_width : List[float],
         inter_points = tuple      (inter_p.flatten() for inter_p in inter_points)
 
         if inter_method in (InterpolationMethod.linear, InterpolationMethod.cubic, InterpolationMethod.nearest):
-            Hs, inter_points = interpolate_signal(Hs, inter_points, edges, nbin, inter_method)
+            Hs, inter_points = interpolate_signal(Hs, inter_points, ranges, det_grid, inter_method)
 
         return Hs, inter_points
 
@@ -152,8 +152,8 @@ def deconvolution_input(sample_width : List[float],
 
 def interpolate_signal(Hs           : np.ndarray,
                        inter_points : Tuple[np.ndarray, ...],
-                       edges        : Tuple[np.ndarray, ...],
-                       nbin         : List[int],
+                       edges        : List [np.ndarray     ],
+                       det_grid     : List [np.ndarray     ],
                        inter_method : InterpolationMethod = InterpolationMethod.cubic
                        ) -> Tuple[np.ndarray, Tuple[np.ndarray, ...]]:
     """
@@ -165,7 +165,7 @@ def interpolate_signal(Hs           : np.ndarray,
     Hs           : Distribution weights to be interpolated.
     inter_points : Distribution coordinates to be interpolated.
     edges        : Edges of the coordinates.
-    nbin         : Number of points to be interpolated in each dimension.
+    det_grid     : xy-coordinates of the detector grid, to interpolate on them
     inter_method : Interpolation method.
 
     Returns
@@ -173,13 +173,11 @@ def interpolate_signal(Hs           : np.ndarray,
     H1         : Interpolated distribution weights.
     new_points : Interpolated coordinates.
     """
-    coords = (shift_to_bin_centers(np.linspace(np.min(edge), np.max(edge), n + 1))
-              for n, edge in zip(nbin, edges))
+    coords       = [grid[in_range(grid, *edge)] for edge, grid in zip(edges, det_grid)]
     new_points   = np.meshgrid(*coords, indexing='ij')
     new_points   = tuple      (new_p.flatten() for new_p in new_points)
-
     H1 = interpolate.griddata(inter_points, Hs.flatten(), new_points, method=inter_method.value)
-    H1 = np.nan_to_num       (H1.reshape(nbin))
+    H1 = np.nan_to_num       (H1.reshape([len(c) for c in coords]))
     H1 = np.clip             (H1, 0, None)
 
     return H1, new_points
@@ -208,7 +206,7 @@ def find_nearest(array : np.ndarray,
 def deconvolve(n_iterations  : int,
                iteration_tol : float,
                sample_width  : List[float],
-               bin_size      : List[float],
+               det_grid      : List[np.ndarray],
                inter_method  : InterpolationMethod = InterpolationMethod.cubic
                ) -> Callable:
     """
@@ -225,6 +223,7 @@ def deconvolve(n_iterations  : int,
         n_iterations : Number of Lucy-Richardson iterations
         sample_width : Sampling size of the sensors.
         bin_size     : Size of the interpolated bins.
+        det_grid     : xy-coordinates of the detector grid, to interpolate on them
         inter_method : Interpolation method.
 
     Returns
@@ -233,7 +232,7 @@ def deconvolve(n_iterations  : int,
     inter_pos     : Coordinates of the deconvolved image.
     """
     var_name     = np.array(['xr', 'yr', 'zr'])
-    deconv_input = deconvolution_input(sample_width, bin_size, inter_method)
+    deconv_input = deconvolution_input(sample_width, det_grid, inter_method)
 
     def deconvolve(data   : Tuple[np.ndarray, ...],
                    weight : np.ndarray,

--- a/invisible_cities/reco/deconv_functions.py
+++ b/invisible_cities/reco/deconv_functions.py
@@ -220,11 +220,11 @@ def deconvolve(n_iterations  : int,
     psf         : Point-spread function.
 
     Initialization parameters:
-        n_iterations : Number of Lucy-Richardson iterations
-        sample_width : Sampling size of the sensors.
-        bin_size     : Size of the interpolated bins.
-        det_grid     : xy-coordinates of the detector grid, to interpolate on them
-        inter_method : Interpolation method.
+        n_iterations  : Number of Lucy-Richardson iterations
+        iteration_tol : Stopping threshold (difference between iterations).
+        sample_width  : Sampling size of the sensors.
+        det_grid      : xy-coordinates of the detector grid, to interpolate on them
+        inter_method  : Interpolation method.
 
     Returns
     ----------

--- a/invisible_cities/reco/deconv_functions_test.py
+++ b/invisible_cities/reco/deconv_functions_test.py
@@ -232,8 +232,11 @@ def test_nonexact_binning(data_hdst, data_hdst_deconvolved):
     h      = h.groupby(['X', 'Y']).Q.sum().reset_index()
     h      = h[h.Q > 40]
 
-    deconvolutor = deconvolve(15, 0.01, [10., 10.], [9., 9.], inter_method=InterpolationMethod.cubic)
+    det_db   = DataSiPM('new', 0)
+    det_grid = [np.arange(det_db[var].min() + bs/2, det_db[var].max() - bs/2 + np.finfo(np.float32).eps, bs)
+               for var, bs in zip(['X', 'Y'], [9., 9.])]
 
+    deconvolutor = deconvolve(15, 0.01, [10., 10.], det_grid, inter_method=InterpolationMethod.cubic)
     x, y   = np.linspace(-49.5, 49.5, 100), np.linspace(-49.5, 49.5, 100)
     xx, yy = np.meshgrid(x, y)
     xx, yy = xx.flatten(), yy.flatten()

--- a/invisible_cities/reco/deconv_functions_test.py
+++ b/invisible_cities/reco/deconv_functions_test.py
@@ -2,30 +2,32 @@ import random
 import numpy  as np
 import pandas as pd
 
-from pytest                  import mark
-from pytest                  import raises
+from pytest                       import mark
+from pytest                       import raises
 
-from hypothesis              import given
-from hypothesis.strategies   import floats
-from hypothesis.extra.pandas import data_frames
-from hypothesis.extra.pandas import column
-from hypothesis.extra.pandas import range_indexes
+from hypothesis                   import given
+from hypothesis.strategies        import floats
+from hypothesis.extra.pandas      import data_frames
+from hypothesis.extra.pandas      import column
+from hypothesis.extra.pandas      import range_indexes
 
-from .. reco.deconv_functions import cut_and_redistribute_df
-from .. reco.deconv_functions import drop_isolated_sensors
-from .. reco.deconv_functions import interpolate_signal
-from .. reco.deconv_functions import deconvolution_input
-from .. reco.deconv_functions import deconvolve
-from .. reco.deconv_functions import richardson_lucy
-from .. reco.deconv_functions import InterpolationMethod
+from .. reco    .deconv_functions import cut_and_redistribute_df
+from .. reco    .deconv_functions import drop_isolated_sensors
+from .. reco    .deconv_functions import interpolate_signal
+from .. reco    .deconv_functions import deconvolution_input
+from .. reco    .deconv_functions import deconvolve
+from .. reco    .deconv_functions import richardson_lucy
+from .. reco    .deconv_functions import InterpolationMethod
 
-from .. core.core_functions   import in_range
-from .. core.core_functions   import shift_to_bin_centers
-from .. core.testing_utils    import assert_dataframes_close
+from .. core    .core_functions   import in_range
+from .. core    .core_functions   import shift_to_bin_centers
+from .. core    .testing_utils    import assert_dataframes_close
 
-from ..   io.dst_io           import load_dst
+from .. io      .dst_io           import load_dst
 
-from scipy.stats              import multivariate_normal
+from .. database.load_db          import DataSiPM
+
+from scipy.stats                  import multivariate_normal
 
 
 @given(data_frames(columns=[column('A', dtype=float, elements=floats(1, 1e3)),
@@ -84,34 +86,37 @@ def test_interpolate_signal():
 
     g = multivariate_normal((0.5, 0.5), (0.05, 0.5))
 
-    grid_x, grid_y  = np.mgrid[0:1:12j, 0:1:12j] # Grid for interpolation
     points          = np.meshgrid(np.linspace(0, 1, 6), np.linspace(0, 1, 6)) # Coordinates where g is known
     points          = (points[0].flatten(), points[1].flatten())
     values          = g.pdf(list(zip(points[0], points[1]))) # Value of g at the known coordinates.
     n_interpolation = 12 # How many points to interpolate
+    grid            = shift_to_bin_centers(np.linspace(-0.05, 1.05, n_interpolation + 1))# Grid for interpolation
 
     out_interpolation = interpolate_signal(values, points,
-                                           (np.linspace(-0.05, 1.05, 6), np.linspace(-0.05, 1.05, 6)),
-                                           [n_interpolation, n_interpolation],
+                                           [[-0.05, 1.05], [-0.05, 1.05]],
+                                           [grid, grid],
                                            InterpolationMethod.cubic)
     inter_charge      = out_interpolation[0].flatten()
     inter_position    = out_interpolation[1]
     ref_position      = shift_to_bin_centers(np.linspace(-0.05, 1.05, n_interpolation + 1))
 
     assert np.allclose(ref_interpolation, np.around(inter_charge, decimals=3))
-    assert np.allclose(ref_position     , sorted(set(inter_position[0])))
-    assert np.allclose(ref_position     , sorted(set(inter_position[1])))
+    assert np.allclose(grid             , sorted(set(inter_position[0])))
+    assert np.allclose(grid             , sorted(set(inter_position[1])))
 
 
 def test_deconvolution_input(data_hdst, data_hdst_deconvolved):
     ref_interpolation = np.load(data_hdst_deconvolved)
-    hdst              = load_dst(data_hdst, 'RECO', 'Events')
 
-    h = hdst[(hdst.event == 3021916) & (hdst.npeak == 0)]
-    h = h.groupby(['X', 'Y']).Q.sum().reset_index()
-    h = h[h.Q > 40]
+    hdst   = load_dst(data_hdst, 'RECO', 'Events')
+    h      = hdst[(hdst.event == 3021916) & (hdst.npeak == 0)]
+    h      = h.groupby(['X', 'Y']).Q.sum().reset_index()
+    h      = h[h.Q > 40]
 
-    interpolator = deconvolution_input([10., 10.], [1., 1.], InterpolationMethod.cubic)
+    det_db   = DataSiPM('new', 0)
+    det_grid = [np.arange(det_db[var].min() + bs/2, det_db[var].max() - bs/2 + np.finfo(np.float32).eps, bs)
+               for var, bs in zip(['X', 'Y'], [1., 1.])]
+    interpolator = deconvolution_input([10., 10.], det_grid, InterpolationMethod.cubic)
     inter        = interpolator((h.X, h.Y), h.Q)
 
     assert np.allclose(ref_interpolation['e_inter'], inter[0])
@@ -127,14 +132,17 @@ def test_deconvolution_input_interpolation_method(data_hdst, data_hdst_deconvolv
 
 def test_deconvolve(data_hdst, data_hdst_deconvolved):
     ref_interpolation = np.load (data_hdst_deconvolved)
-    hdst              = load_dst(data_hdst, 'RECO', 'Events')
 
-    h = hdst[(hdst.event == 3021916) & (hdst.npeak == 0)]
-    z = h.Z.mean()
-    h = h.groupby(['X', 'Y']).Q.sum().reset_index()
-    h = h[h.Q > 40]
+    hdst   = load_dst(data_hdst, 'RECO', 'Events')
+    h      = hdst[(hdst.event == 3021916) & (hdst.npeak == 0)]
+    z      = h.Z.mean()
+    h      = h.groupby(['X', 'Y']).Q.sum().reset_index()
+    h      = h[h.Q > 40]
 
-    deconvolutor = deconvolve(15, 0.01, [10., 10.], [1., 1.], inter_method=InterpolationMethod.cubic)
+    det_db   = DataSiPM('new', 0)
+    det_grid = [np.arange(det_db[var].min() + bs/2, det_db[var].max() - bs/2 + np.finfo(np.float32).eps, bs)
+               for var, bs in zip(['X', 'Y'], [1., 1.])]
+    deconvolutor = deconvolve(15, 0.01, [10., 10.], det_grid, inter_method=InterpolationMethod.cubic)
 
     x, y   = np.linspace(-49.5, 49.5, 100), np.linspace(-49.5, 49.5, 100)
     xx, yy = np.meshgrid(x, y)
@@ -156,15 +164,19 @@ def test_deconvolve(data_hdst, data_hdst_deconvolved):
 
 def test_richardson_lucy(data_hdst, data_hdst_deconvolved):
     ref_interpolation = np.load (data_hdst_deconvolved)
-    hdst              = load_dst(data_hdst, 'RECO', 'Events')
 
-    h = hdst[(hdst.event == 3021916) & (hdst.npeak == 0)]
-    z = h.Z.mean()
-    h = h.groupby(['X', 'Y']).Q.sum().reset_index()
-    h = h[h.Q>40]
+    hdst   = load_dst(data_hdst, 'RECO', 'Events')
+    h      = hdst[(hdst.event == 3021916) & (hdst.npeak == 0)]
+    z      = h.Z.mean()
+    h      = h.groupby(['X', 'Y']).Q.sum().reset_index()
+    h      = h[h.Q>40]
 
-    interpolator = deconvolution_input([10., 10.], [1., 1.], InterpolationMethod.cubic)
-    inter = interpolator((h.X, h.Y), h.Q)
+    det_db   = DataSiPM('new', 0)
+    det_grid = [np.arange(det_db[var].min() + bs/2, det_db[var].max() - bs/2 + np.finfo(np.float32).eps, bs)
+               for var, bs in zip(['X', 'Y'], [1., 1.])]
+
+    interpolator = deconvolution_input([10., 10.], det_grid, InterpolationMethod.cubic)
+    inter        = interpolator((h.X, h.Y), h.Q)
 
     x , y  = np.linspace(-49.5, 49.5, 100), np.linspace(-49.5, 49.5, 100)
     xx, yy = np.meshgrid(x, y)
@@ -181,6 +193,36 @@ def test_richardson_lucy(data_hdst, data_hdst_deconvolved):
                            iterations=15, iter_thr=0.0001)
 
     assert np.allclose(ref_interpolation['e_deco'], deco.flatten())
+
+
+def test_grid_binning(data_hdst, data_hdst_deconvolved):
+    hdst   = load_dst(data_hdst, 'RECO', 'Events')
+    h      = hdst[(hdst.event == 3021916) & (hdst.npeak == 0)]
+    z      = h.Z.mean()
+    h      = h.groupby(['X', 'Y']).Q.sum().reset_index()
+    h      = h[h.Q > 40]
+
+    det_db   = DataSiPM('new', 0)
+    det_grid = [np.arange(det_db[var].min() + bs/2, det_db[var].max() - bs/2 + np.finfo(np.float32).eps, bs)
+               for var, bs in zip(['X', 'Y'], [9., 9.])]
+
+    deconvolutor = deconvolve(15, 0.01, [10., 10.], det_grid, inter_method=InterpolationMethod.cubic)
+
+    x, y   = np.linspace(-49.5, 49.5, 100), np.linspace(-49.5, 49.5, 100)
+    xx, yy = np.meshgrid(x, y)
+    xx, yy = xx.flatten(), yy.flatten()
+
+    psf           = {}
+    psf['factor'] = multivariate_normal([0., 0.], [1.027 * np.sqrt(z/10)] * 2).pdf(list(zip(xx, yy)))
+    psf['xr']     = xx
+    psf['yr']     = yy
+    psf['zr']     = [z] * len(xx)
+    psf           = pd.DataFrame(psf)
+
+    deco          = deconvolutor((h.X, h.Y), h.Q, psf)
+
+    assert np.all((deco[1][0] - det_db['X'].min() + 9/2) % 9 == 0)
+    assert np.all((deco[1][1] - det_db['Y'].min() + 9/2) % 9 == 0)
 
 
 def test_nonexact_binning(data_hdst, data_hdst_deconvolved):


### PR DESCRIPTION
To accommodate for NEXT100 geommetry (15.55 mm pitch) we have had to modify the input to the interpolation function as well as the interpolation points themselves. The main issue was that the float precission was all over the place, and the ranges, min and max functions were returning values with tiny deviations. This, when acting slice by slice, caused a missmatch between slices. After discussing with @gonzaponte we have failed to see any other solution that add some rounding. In a real-life situation, the result is a fixed grid at n + 0.5 mm (n= 1, 2, etc.) when running at 1 mm deconvolution.

The code has already been used by @paolafer in NEXT100 reconstruction, I tested it with NEW. The only test that required some change, as the performance changed, was the `interpolate_signal` function as the grid that the test used is not the same as the grid coming from the modified function.

UPDATE:

After discussion with @mmkekic, we thought that the best solution to the problem was to generate a detector grid at the beginning of the process and then apply a range selection on a slice by slice basis before interpolation. This way a common reference point is guaranteed no matter the chosen deconvolution bin size. As a result, the general grid is now an argument needed in most of the deconvolution functions and is loaded in beersheba.