### PR TITLE
Modify 'load_dst' and 'load_dsts' to accept an event list.

### DIFF
--- a/invisible_cities/io/dst_io_test.py
+++ b/invisible_cities/io/dst_io_test.py
@@ -54,11 +54,31 @@ def test_load_dst(KrMC_kdst):
                             False  , rtol=1e-5)
 
 
+def test_load_dst_event_list(KrMC_kdst):
+    event_list = [0, 4, 7]
+    df_read    = load_dst(*KrMC_kdst[0].file_info, evt_list=event_list)
+    df_check   = KrMC_kdst[0].true
+    df_check   = df_check[df_check.event.isin(event_list)].reset_index(drop=True)
+    assert_dataframes_close(df_read, df_check,
+                            False  , rtol=1e-5)
+
+
 def test_load_dsts_single_file(KrMC_kdst):
     tbl     = KrMC_kdst[0].file_info
     df_read = load_dsts([tbl.filename], tbl.group, tbl.node)
 
     assert_dataframes_close(df_read, KrMC_kdst[0].true,
+                            False  , rtol=1e-5)
+
+
+def test_load_dsts_single_file_event_list(KrMC_kdst):
+    event_list = [0, 4, 7]
+    tbl        = KrMC_kdst[0].file_info
+    df_read    = load_dsts([tbl.filename], tbl.group, tbl.node, evt_list=event_list)
+    df_check   = KrMC_kdst[0].true
+    df_check   = df_check[df_check.event.isin(event_list)].reset_index(drop=True)
+
+    assert_dataframes_close(df_read, df_check,
                             False  , rtol=1e-5)
 
 


### PR DESCRIPTION
Added argument to the usual load dst functions to just load events in
a given list. Usually loading several hdsts (and the alike) is a
memory heavy process as the full dst needs to be loaded and user does
not always need the full dst. This option allows for much faster and
lighter loading in such cases. If the new argument is not passed, the
function will behave as usual.