### PR TITLE
Update url of miniconda repository

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -60,10 +60,11 @@ function install_conda {
         echo Conda already installed. Skipping conda installation.
     else
         echo Installing conda for $CONDA_OS
+        CONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-py${PYTHON_VERSION//.}_4.8.2-${CONDA_OS}-x86_64.sh"
         if which wget; then
-            wget https://repo.continuum.io/miniconda/Miniconda3-py${PYTHON_VERSION//.}_4.8.2-${CONDA_OS}-x86_64.sh -O miniconda.sh
+            wget ${CONDA_URL} -O miniconda.sh
         else
-            curl https://repo.continuum.io/miniconda/Miniconda3-py${PYTHON_VERSION//.}_4.8.2-${CONDA_OS}-x86_64.sh -o miniconda.sh
+            curl ${CONDA_URL} -o miniconda.sh
         fi
         bash miniconda.sh -b -p $HOME/miniconda
         CONDA_SH=$HOME/miniconda/etc/profile.d/conda.sh


### PR DESCRIPTION
This PR fixes the installation process in macOS and, most likely, in any other system using `curl` to download the miniconda installer.

The url used until now (continuum.io) had been redirected to a new one (anaconda.com). While `wget` appears to accept the redirection by default, `curl` does not. This can be fixed with the `-L` flag, but I decided that it was probably simpler to avoid the redirect altogether updating the url.