### PR TITLE
Update Flex100DB to fix SiPM numbering

### DIFF
--- a/invisible_cities/conftest.py
+++ b/invisible_cities/conftest.py
@@ -675,7 +675,7 @@ def dbflex100():
                 params=[db_data('demopp' ,  3,  256, 3, 79),
                         db_data('new'    , 12, 1792, 3, 79),
                         db_data('next100', 60, 3584, 0, 0),
-                        db_data('flex100', 60, 3062, 0, 0)],
+                        db_data('flex100', 60, 3093, 0, 0)],
                ids=["demo", "new", "next100", "flex100"])
 def db(request):
     return request.param

--- a/invisible_cities/database/localdb.Flex100DB.sqlite3
+++ b/invisible_cities/database/localdb.Flex100DB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3c96cb7c1cf0bba0a7512dc1dd35b9caa7ee497fa824ad024a635f1902815823
-size 29052928
+oid sha256:e334127d9284f7dd8bfbf7a884682c6ad7a1a47658b9a059de78d558d09d1b1d
+size 29347840


### PR DESCRIPTION
This MR updates the IC tables related with Flex100 geometry to fix a little bug in TP SiPMs affecting their numbering.

The corresponding test has been updated too.