### PR TITLE
Bufferization city

### DIFF
--- a/invisible_cities/cities/buffy.py
+++ b/invisible_cities/cities/buffy.py
@@ -1,0 +1,126 @@
+"""
+-----------------------------------------------------------------------
+                                Buffy
+-----------------------------------------------------------------------
+
+ -- Sorts MC sensor info into buffers, slays vampires etc
+
+This city reads nexus Monte Carlo Sensor information and sorts the
+information into data-like buffers without the addition of
+electronics noise.
+
+Uses a configured buffer length, pretrigger and threshold for the
+positioning of trigger like signal. If more than one trigger is found
+separated from each other by more than a buffer width the nexus event
+can be split into multiple data-like triggers.
+"""
+
+import numpy  as np
+import tables as tb
+
+from .. detsim.buffer_functions import      buffer_calculator
+from .. detsim.sensor_utils     import   first_and_last_times
+from .. detsim.sensor_utils     import          get_n_sensors
+from .. detsim.sensor_utils     import           sensor_order
+from .. detsim.sensor_utils     import pmt_and_sipm_bin_width
+from .. detsim.sensor_utils     import          trigger_times
+from .. io    .rwf_io           import          buffer_writer
+from .. reco                    import          tbl_functions as tbl
+
+from .. dataflow   import            dataflow as fl
+
+from .  components import                city
+from .  components import             collect
+from .  components import        copy_mc_info
+from .  components import mcsensors_from_file
+from .  components import         print_every
+from .  components import       signal_finder
+from .  components import           wf_binner
+
+
+@city
+def buffy(files_in     , file_out   , compression      , event_range,
+          print_mod    , detector_db, run_number       , max_time   ,
+          buffer_length, pre_trigger, trigger_threshold):
+
+    npmt, nsipm       = get_n_sensors(detector_db, run_number)
+    pmt_wid, sipm_wid = pmt_and_sipm_bin_width(files_in[0])
+    nsamp_pmt         = int(buffer_length /  pmt_wid)
+    nsamp_sipm        = int(buffer_length / sipm_wid)
+
+    extract_tminmax   = fl.map(first_and_last_times                ,
+                               args = ("pmt_resp"   ,  "sipm_resp",
+                                       "pmt_binwid", "sipm_binwid"),
+                               out  = ("min_time", "max_time"))
+
+    bin_calculation   = wf_binner(max_time)
+    bin_pmt_wf        = fl.map(bin_calculation                   ,
+                               args = ("pmt_resp",  "pmt_binwid",
+                                       "min_time",    "max_time"),
+                               out  = ("pmt_bins", "pmt_bin_wfs"))
+
+    bin_sipm_wf       = fl.map(bin_calculation                    ,
+                               args = ("sipm_resp", "sipm_binwid",
+                                       "min_time" ,    "max_time"),
+                               out  = ("sipm_bins", "sipm_bin_wfs"))
+
+    find_signal       = fl.map(signal_finder(buffer_length, pmt_wid,
+                                             trigger_threshold     ),
+                               args = "pmt_bin_wfs"                 ,
+                               out  = "pulses"                      )
+
+    event_times       = fl.map(trigger_times                             ,
+                               args = ("pulses", "timestamp", "pmt_bins"),
+                               out  = "evt_times"                        )
+
+    calculate_buffers = fl.map(buffer_calculator(buffer_length, pre_trigger,
+                                                  pmt_wid      ,    sipm_wid),
+                                args = ("pulses",
+                                        "pmt_bins" ,  "pmt_bin_wfs",
+                                        "sipm_bins", "sipm_bin_wfs"),
+                                out  = "buffers")
+
+    order_sensors     = fl.map(sensor_order(detector_db, run_number,
+                                            nsamp_pmt  , nsamp_sipm) ,
+                               args = ("pmt_bin_wfs", "sipm_bin_wfs",
+                                       "buffers")                    ,
+                               out  = "ordered_buffers"              )
+
+    with tb.open_file(file_out, "w", filters=tbl.filters(compression)) as h5out:
+        buffer_writer_ = fl.sink(buffer_writer(h5out                  ,
+                                               run_number = run_number,
+                                               n_sens_eng = npmt      ,
+                                               n_sens_trk = nsipm     ,
+                                               length_eng = nsamp_pmt ,
+                                               length_trk = nsamp_sipm),
+                                 args = ("event_number", "evt_times"  ,
+                                         "ordered_buffers"            ))
+
+        event_count_in = fl.spy_count()
+
+        evtnum_collect = collect()
+
+        result = fl.push(source = mcsensors_from_file(files_in   ,
+                                                      detector_db,
+                                                      run_number )         ,
+                         pipe   = fl.pipe(fl.slice(*event_range  ,
+                                                   close_all=True)      ,
+                                          event_count_in.spy            ,
+                                          print_every(print_mod)        ,
+                                          extract_tminmax               ,
+                                          bin_pmt_wf                    ,
+                                          bin_sipm_wf                   ,
+                                          find_signal                   ,
+                                          event_times                   ,
+                                          calculate_buffers             ,
+                                          order_sensors                 ,
+                                          fl.branch("event_number"      ,
+                                                    evtnum_collect.sink),
+                                          buffer_writer_                )  ,
+                         result = dict(events_in   = event_count_in.future,
+                                       evtnum_list = evtnum_collect.future))
+
+        copy_mc_info(files_in, h5out, result.evtnum_list,
+                     detector_db, run_number)
+
+        return result

--- a/invisible_cities/cities/buffy_test.py
+++ b/invisible_cities/cities/buffy_test.py
@@ -1,0 +1,127 @@
+import os
+
+import numpy  as np
+import tables as tb
+
+from .. core                    import           system_of_units as units
+from .. core    .configure      import                 configure
+from .. core    .testing_utils  import    assert_tables_equality
+from .. database                import                   load_db
+from .. io      .mcinfo_io      import load_mcsensor_response_df
+
+from .  buffy import buffy
+
+
+def test_buffy_kr(config_tmpdir, full_sim_file):
+    file_in  = full_sim_file
+    file_out = os.path.join(config_tmpdir, 'Kr_fullsim.buffers.h5')
+
+    buffer_length =  800 * units.mus
+    pmt_samp_wid  =  100 * units.ns
+    sipm_samp_wid =    1 * units.mus
+    n_pmt         =   12
+    n_sipm        = 1792
+
+    sipm_ids      = load_db.DataSiPM('new', -6400).SensorID.values
+
+    conf     = configure('buffy invisible_cities/config/buffy.conf'.split())
+    conf.update(dict(files_in      = file_in      ,
+                     file_out      = file_out     ,
+                     buffer_length = buffer_length))
+
+    buffy(**conf)
+    with tb.open_file(file_out, mode='r') as h5out:
+        assert hasattr(h5out.root    ,           'MC')
+        assert hasattr(h5out.root    ,          'Run')
+        assert hasattr(h5out.root    ,        'pmtrd')
+        assert hasattr(h5out.root    ,       'sipmrd')
+        assert hasattr(h5out.root.MC ,         'hits')
+        assert hasattr(h5out.root.MC ,    'particles')
+        assert hasattr(h5out.root.MC , 'sns_response')
+        assert hasattr(h5out.root.Run,      'runInfo')
+        assert hasattr(h5out.root.Run,       'events')
+        assert hasattr(h5out.root.Run,     'eventMap')
+
+        sns_resp     = load_mcsensor_response_df(file_in        ,
+                                                 db_file = 'new',
+                                                 run_no  = -6400)
+        sns_sums      = sns_resp.loc[0].groupby('sensor_id').charge.sum()
+        pmt_sum_indx  = sns_sums.index[sns_sums.index < 12]
+        sipm_sum_indx = sns_sums.index[sns_sums.index > 12]
+        pmt_buffers   = h5out.root.pmtrd [:]
+        sipm_buffers  = h5out.root.sipmrd[:]
+
+        assert pmt_buffers .shape[0] == len(sns_resp.index.levels[0])
+        assert pmt_buffers .shape[1] == n_pmt
+        assert pmt_buffers .shape[2] == int(buffer_length //  pmt_samp_wid)
+
+        assert sipm_buffers.shape[0] == len(sns_resp.index.levels[0])
+        assert sipm_buffers.shape[1] == n_sipm
+        assert sipm_buffers.shape[2] == int(buffer_length // sipm_samp_wid)
+
+        pmt_integ   = pmt_buffers[0].sum(axis=1)
+        pmt_nonzero = np.argwhere(pmt_integ != 0).flatten()
+        assert np.all(pmt_nonzero            ==                  pmt_sum_indx)
+        assert np.all(pmt_integ[pmt_nonzero] == sns_sums[sns_sums.index < 12])
+
+        sipm_integ   = sipm_buffers[0].sum(axis=1)
+        sipm_nonzero = np.argwhere(sipm_integ != 0).flatten()
+        assert np.all(sipm_ids  [sipm_nonzero] ==                 sipm_sum_indx)
+        assert np.all(sipm_integ[sipm_nonzero] == sns_sums[sns_sums.index > 12])
+
+
+def test_buffy_exact_result(config_tmpdir, ICDATADIR):
+    file_in     = os.path.join(ICDATADIR                              ,
+                               'nexus_new_kr83m_full.newformat.sim.h5')
+    file_out    = os.path.join(config_tmpdir, 'exact_result.buffers.h5')
+    true_output = os.path.join(ICDATADIR                                  ,
+                               'nexus_new_kr83m_full.newformat.buffers.h5')
+
+    conf = configure('buffy invisible_cities/config/buffy.conf'.split())
+    conf.update(dict(files_in=file_in, file_out=file_out))
+
+    buffy(**conf)
+
+    tables = ("MC/hits"        , "MC/particles", "MC/sns_positions",
+              "MC/sns_response", "pmtrd"       , "sipmrd"          )
+    with tb.open_file(true_output)  as true_output_file:
+        with tb.open_file(file_out) as      output_file:
+            for table in tables:
+                assert hasattr(output_file.root, table)
+                got      = getattr(     output_file.root, table)
+                expected = getattr(true_output_file.root, table)
+                assert_tables_equality(got, expected)
+
+
+def test_buffy_splits_event(config_tmpdir, ICDATADIR):
+    file_in  = os.path.join(ICDATADIR                              ,
+                            'nexus_new_kr83m_full.newformat.sim.h5')
+    file_out = os.path.join(config_tmpdir,   'split_evt.buffers.h5')
+
+    evt = 1
+    conf = configure('buffy invisible_cities/config/buffy.conf'.split())
+    conf.update(dict(files_in      = file_in        ,
+                     file_out      = file_out       ,
+                     event_range   = (evt, evt + 1) ,
+                     buffer_length = 100 * units.mus,
+                     pre_trigger   =  10 * units.mus))
+
+    buffy(**conf)
+
+    sns_resp   = load_mcsensor_response_df(file_in).loc[evt]
+    sns_sums   = sns_resp.groupby('sensor_id').charge.sum()
+    pmt_integ  = sns_sums[sns_sums.index < 12].values
+    sipm_integ = sns_sums[sns_sums.index > 12].values
+    with tb.open_file(file_in) as h5in, tb.open_file(file_out) as h5out:
+        assert len(h5out.root.Run.events[:]) == 2
+        assert np.all(h5out.root.Run.events.cols.evt_number[:] == evt)
+
+        assert len(h5out.root.pmtrd [:]) == 2
+        assert len(h5out.root.sipmrd[:]) == 2
+
+        pmtout_sum  = h5out.root.pmtrd [:].sum(axis=0).sum(axis=1)
+        assert np.all(pmtout_sum == pmt_integ)
+
+        sipmout_sum = h5out.root.sipmrd[:].sum(axis=0).sum(axis=1)
+        non_zero    = np.argwhere(sipmout_sum != 0).flatten()
+        assert np.all(sipmout_sum[non_zero] == sipm_integ)

--- a/invisible_cities/cities/command_line_execution_test.py
+++ b/invisible_cities/cities/command_line_execution_test.py
@@ -12,7 +12,7 @@ from pytest import mark
 #                   'diomira isidora irene dorothea zaira penthesilea'.split())
 # TODO understand what's wrong with isidora (in Travis)
 @mark.parametrize('city',
-                  'diomira isidora irene dorothea penthesilea berenice phyllis trude esmeralda beersheba hypathia'.split())
+                  'diomira isidora irene dorothea penthesilea berenice phyllis trude esmeralda beersheba hypathia buffy'.split())
 
 def test_command_line_run(city, tmpdir_factory):
     ICTDIR = getenv('ICTDIR')

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -369,17 +369,21 @@ def mcsensors_from_file(paths     : List[str],
         ## Only in case of evt splitting will be non zero
         timestamp = 0
 
-        for evt in sns_resp.index.levels[0]:
-            pmt_indx  = sns_resp.loc[evt].index.isin(pmt_ids)
-            pmt_resp  = sns_resp.loc[evt][ pmt_indx]
-            sipm_resp = sns_resp.loc[evt][~pmt_indx]
+        for evt in mcinfo_io.get_event_numbers_in_file(file_name):
+            try:
+                ## Assumes two types of sensor, all non pmt
+                ## assumed to be sipms. NEW, NEXT100 and DEMOPP safe
+                ## Flex with this structure too.
+                pmt_indx  = sns_resp.loc[evt].index.isin(pmt_ids)
+                pmt_resp  = sns_resp.loc[evt][ pmt_indx]
+                sipm_resp = sns_resp.loc[evt][~pmt_indx]
+            except KeyError:
+                pmt_resp = sipm_resp = pd.DataFrame(columns=sns_resp.columns)
 
-            yield dict(event_number = evt                ,
-                       timestamp    = timestamp          ,
-                       pmt_binwid   = pmt_binwid .iloc[0],
-                       sipm_binwid  = sipm_binwid.iloc[0],
-                       pmt_resp     = pmt_resp           ,
-                       sipm_resp    = sipm_resp          )
+            yield dict(event_number = evt      ,
+                       timestamp    = timestamp,
+                       pmt_resp     = pmt_resp ,
+                       sipm_resp    = sipm_resp)
 
 
 def wf_from_files(paths, wf_type):

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -385,12 +385,12 @@ def mcsensors_from_file(paths     : List[str],
             pmt_resp  = sns_resp.loc[evt][ pmt_indx]
             sipm_resp = sns_resp.loc[evt][~pmt_indx]
 
-            yield dict(evt         = evt                ,
-                       timestamp   = timestamp          ,
-                       pmt_binwid  = pmt_binwid .iloc[0],
-                       sipm_binwid = sipm_binwid.iloc[0],
-                       pmt_resp    = pmt_resp           ,
-                       sipm_resp   = sipm_resp          )
+            yield dict(event_number = evt                ,
+                       timestamp    = timestamp          ,
+                       pmt_binwid   = pmt_binwid .iloc[0],
+                       sipm_binwid  = sipm_binwid.iloc[0],
+                       pmt_resp     = pmt_resp           ,
+                       sipm_resp    = sipm_resp          )
 
 
 def wf_from_files(paths, wf_type):

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -357,24 +357,13 @@ def mcsensors_from_file(paths     : List[str],
                  Run number for database
     """
 
-    pmt_ids  = load_db.DataPMT (db_file, run_number).SensorID
+    pmt_ids  = load_db.DataPMT(db_file, run_number).SensorID
 
     for file_name in paths:
         sns_resp = mcinfo_io.load_mcsensor_response_df(file_name              ,
                                                        return_raw = False     ,
                                                        db_file    = db_file   ,
                                                        run_no     = run_number)
-        sns_bins = mcinfo_io.get_sensor_binning(file_name)
-        if sns_resp.empty or sns_bins.empty:
-            raise MCEventNotFound(f'Sensor response info not in file {file_name}')
-        elif sns_bins.shape[0] != 2:
-          warnings.warn(f' File contains wrong number (not 2) of sensor types.\
-          Simulation should be for NEW, NEXT100 or DEMOPP', UserWarning)
-        ## Source only valid for NEW, NEXT100 & DEMOPP
-        ## and for flexible geometries with Pmt/SiPM separation of sensors
-        PMT_name_indx = sns_bins.index.str.contains('Pmt')
-        pmt_binwid    = sns_bins.bin_width[ PMT_name_indx]
-        sipm_binwid   = sns_bins.bin_width[~PMT_name_indx]
 
         ## MC uses dummy timestamp for now
         ## Only in case of evt splitting will be non zero

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -191,20 +191,12 @@ def test_copy_mc_info_repeated_event_numbers(ICDATADIR, config_tmpdir):
         assert events_in_h5out.tolist() == [0,1,0,9]
 
 
-def test_mcsensors_from_file_invalid_input_raises(ICDATADIR):
-    file_in = os.path.join(ICDATADIR, "nexus_new_kr83m_fast.oldformat.sim.h5")
-
-    s = mcsensors_from_file((file_in,), db_file='new', run_number=-6400)
-    with raises(MCEventNotFound):
-        next(s)
-
-
-def test_mcsensors_from_file_raises_warning_flex3type(ICDATADIR):
-    file_in = os.path.join(ICDATADIR, "NextFlex_mc_sensors.h5")
-
-    s = mcsensors_from_file((file_in,), db_file='new', run_number=-6400)
-    with warns(UserWarning):
-        next(s)
+def test_mcsensors_from_file_fast_returns_empty(ICDATADIR):
+    file_in = os.path.join(ICDATADIR, "nexus_new_kr83m_fast.newformat.sim.h5")
+    sns_gen = mcsensors_from_file([file_in], 'new', -7951)
+    first_evt = next(sns_gen)
+    assert first_evt[ 'pmt_resp'].empty
+    assert first_evt['sipm_resp'].empty
 
 
 def test_mcsensors_from_file_correct_yield(ICDATADIR):

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -216,8 +216,8 @@ def test_mcsensors_from_file_correct_yield(ICDATADIR):
     total_pmthits  = 4303
     nsipms_hit     =  313
     total_sipmhits =  389
-    keys           = ['evt'        , 'timestamp', 'pmt_binwid',
-                      'sipm_binwid', 'pmt_resp' ,  'sipm_resp']
+    keys           = ['event_number', 'timestamp', 'pmt_binwid',
+                      'sipm_binwid' , 'pmt_resp' ,  'sipm_resp']
     
     file_in   = os.path.join(ICDATADIR, "nexus_new_kr83m_full.newformat.sim.h5")
     sns_gen   = mcsensors_from_file([file_in], 'new', -7951)
@@ -225,14 +225,14 @@ def test_mcsensors_from_file_correct_yield(ICDATADIR):
     
     assert set(keys) == set(first_evt.keys())
     
-    assert      first_evt[        'evt']                 == evt_no
-    assert      first_evt[  'timestamp']                 == timestamp
-    assert      first_evt[ 'pmt_binwid']                 == pmt_binwid
-    assert      first_evt['sipm_binwid']                 == sipm_binwid
-    assert type(first_evt[   'pmt_resp'])                == pd.DataFrame
-    assert type(first_evt[  'sipm_resp'])                == pd.DataFrame
-    assert  len(first_evt[   'pmt_resp'].index.unique()) == npmts_hit
-    assert      first_evt[   'pmt_resp'].shape[0]        == total_pmthits
-    assert  len(first_evt[  'sipm_resp'].index.unique()) == nsipms_hit
-    assert      first_evt[  'sipm_resp'].shape[0]        == total_sipmhits
+    assert      first_evt['event_number']                 == evt_no
+    assert      first_evt[   'timestamp']                 == timestamp
+    assert      first_evt[  'pmt_binwid']                 == pmt_binwid
+    assert      first_evt[ 'sipm_binwid']                 == sipm_binwid
+    assert type(first_evt[    'pmt_resp'])                == pd.DataFrame
+    assert type(first_evt[   'sipm_resp'])                == pd.DataFrame
+    assert  len(first_evt[    'pmt_resp'].index.unique()) == npmts_hit
+    assert      first_evt[    'pmt_resp'].shape[0]        == total_pmthits
+    assert  len(first_evt[   'sipm_resp'].index.unique()) == nsipms_hit
+    assert      first_evt[   'sipm_resp'].shape[0]        == total_sipmhits
     

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -13,7 +13,6 @@ from pytest import warns
 
 from .. core.configure  import EventRange as ER
 from .. core.exceptions import InvalidInputFileStructure
-from .. core.exceptions import           MCEventNotFound
 from .. core            import system_of_units as units
 
 from .  components import event_range

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -210,29 +210,23 @@ def test_mcsensors_from_file_raises_warning_flex3type(ICDATADIR):
 def test_mcsensors_from_file_correct_yield(ICDATADIR):
     evt_no         =    0
     timestamp      =    0
-    pmt_binwid     =    1 * units.ns
-    sipm_binwid    =    1 * units.mus
     npmts_hit      =   12
     total_pmthits  = 4303
     nsipms_hit     =  313
     total_sipmhits =  389
-    keys           = ['event_number', 'timestamp', 'pmt_binwid',
-                      'sipm_binwid' , 'pmt_resp' ,  'sipm_resp']
-    
+    keys           = ['event_number', 'timestamp', 'pmt_resp', 'sipm_resp']
+
     file_in   = os.path.join(ICDATADIR, "nexus_new_kr83m_full.newformat.sim.h5")
     sns_gen   = mcsensors_from_file([file_in], 'new', -7951)
     first_evt = next(sns_gen)
-    
+
     assert set(keys) == set(first_evt.keys())
-    
+
     assert      first_evt['event_number']                 == evt_no
     assert      first_evt[   'timestamp']                 == timestamp
-    assert      first_evt[  'pmt_binwid']                 == pmt_binwid
-    assert      first_evt[ 'sipm_binwid']                 == sipm_binwid
     assert type(first_evt[    'pmt_resp'])                == pd.DataFrame
     assert type(first_evt[   'sipm_resp'])                == pd.DataFrame
     assert  len(first_evt[    'pmt_resp'].index.unique()) == npmts_hit
     assert      first_evt[    'pmt_resp'].shape[0]        == total_pmthits
     assert  len(first_evt[   'sipm_resp'].index.unique()) == nsipms_hit
     assert      first_evt[   'sipm_resp'].shape[0]        == total_sipmhits
-    

--- a/invisible_cities/config/buffy.conf
+++ b/invisible_cities/config/buffy.conf
@@ -1,0 +1,17 @@
+# Buffy is a nexus full simulation bufferization city
+
+# override the default input/output files:
+files_in          = '$ICDIR/database/test_data/Kr83_full_nexus_v5_03_01_ACTIVE_7bar_1evt.sim.h5'
+file_out          = '/tmp/fullsim_buffers.h5'
+compression       = 'ZLIB4'
+event_range       = all
+
+print_mod         = 1
+
+detector_db       = 'new'
+run_number        = -6400
+
+max_time          =  10 * ms
+buffer_length     = 800 * mus
+pre_trigger       = 100 * mus
+trigger_threshold =   0

--- a/invisible_cities/database/test_data/nexus_new_kr83m_full.newformat.buffers.h5
+++ b/invisible_cities/database/test_data/nexus_new_kr83m_full.newformat.buffers.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abd0bf79d8bef816e95316f2f09d8e0f22974c66452e025ebb12530e46d5d824
+size 136289

--- a/invisible_cities/detsim/sensor_utils.py
+++ b/invisible_cities/detsim/sensor_utils.py
@@ -1,4 +1,5 @@
 import numpy  as np
+import tables as tb
 import pandas as pd
 
 from typing import Callable
@@ -89,8 +90,13 @@ def get_n_sensors(detector_db: str, run_number: int) -> Tuple[int, int]:
 
 
 def pmt_and_sipm_bin_width(file_name: str) -> Tuple[float, float]:
-    """returns pmt and sipm bin widths as set in nexus"""
+    """
+    returns pmt and sipm bin widths as set in nexus.
+    Assumes Pmt + SiPM as in NEW, NEXT100 & DEMO.
+    """
     sns_bins = get_sensor_binning(file_name)
+    if sns_bins.empty or np.any(sns_bins.bin_width <= 0):
+        raise tb.NoSuchNodeError('No useful binning info found')
     pmt_wid  = sns_bins.bin_width[sns_bins.index.str.contains( 'Pmt')].iloc[0]
     sipm_wid = sns_bins.bin_width[sns_bins.index.str.contains('SiPM')].iloc[0]
     return pmt_wid, sipm_wid


### PR DESCRIPTION
Adds a new dataflow city which takes in sensor information from the nexus output and sorts them into buffers for each sensor type.

According to configurable pretrigger and trigger threshold the sensor signal can be positioned as an S1-like triggered event or an S2-like triggered event.