### PR TITLE
Upload DB with the lastest calibrations in NEW

### DIFF
--- a/invisible_cities/database/localdb.NEWDB.sqlite3
+++ b/invisible_cities/database/localdb.NEWDB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:05dca8bbd4a17c3bf4118ec9ccd4dacf559352085abf55409ccf74162946af29
-size 382033920
+oid sha256:719bb95497f9e388900480bfd2b2d8f2b8b5971286e55b56c109b2fe098929ca
+size 402411520


### PR DESCRIPTION
This PR includes the latest sensor calibrations from run 8151. Database has been uploaded with the PMT and SiPMs gains and the pdf values. Apparently sensor 15060 is dead, so it has been masked.

![pmt_comparison_with_previous_runs](https://user-images.githubusercontent.com/32193826/94586061-1584e600-0281-11eb-9f2d-2a5e1fab5973.png)

![sipmRunDifferencePlots_test](https://user-images.githubusercontent.com/32193826/94586033-0bfb7e00-0281-11eb-88ae-458cd9cb4ea1.png)
