### PR TITLE
Update DEMOPPDB

### DIFF
--- a/invisible_cities/database/localdb.DEMOPPDB.sqlite3
+++ b/invisible_cities/database/localdb.DEMOPPDB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:40277a1a23c5ca699e0ed21fe15b59612ae5c86cd1b31f19470620f92ba22310
+oid sha256:02c882d33ed6d6ffb413ae955453c336615df845fb95bdd4cec16d5b0237a6fc
 size 8167424

--- a/invisible_cities/database/localdb.DEMOPPDB.sqlite3
+++ b/invisible_cities/database/localdb.DEMOPPDB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:16fcb6eb5b8b35dc9f2e8547abe4f1af8760e7cd2a3f4a7624ba17f6cf0bf8ec
+oid sha256:40277a1a23c5ca699e0ed21fe15b59612ae5c86cd1b31f19470620f92ba22310
 size 8167424


### PR DESCRIPTION
This PR increases the maximum run number of the sensors up to 1999999 for the ChannelMapping and ChannelPosition tables of the database.