### PR TITLE
Unique mc evtnumber

### DIFF
--- a/invisible_cities/cities/buffy.py
+++ b/invisible_cities/cities/buffy.py
@@ -78,6 +78,7 @@ def buffy(files_in     , file_out   , compression      , event_range,
 
     with tb.open_file(file_out, "w", filters=tbl.filters(compression)) as h5out:
         buffer_calculation = calculate_and_save_buffers(buffer_length    ,
+                                                        max_time         ,
                                                         pre_trigger      ,
                                                         pmt_wid          ,
                                                         sipm_wid         ,

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -11,9 +11,10 @@ from pytest import mark
 from pytest import raises
 from pytest import warns
 
-from .. core.configure  import EventRange as ER
-from .. core.exceptions import InvalidInputFileStructure
-from .. core            import system_of_units as units
+from .. core.configure     import EventRange as ER
+from .. core.exceptions    import InvalidInputFileStructure
+from .. core.testing_utils import    assert_tables_equality
+from .. core               import system_of_units as units
 
 from .  components import event_range
 from .  components import collect
@@ -188,6 +189,25 @@ def test_copy_mc_info_repeated_event_numbers(ICDATADIR, config_tmpdir):
         copy_mc_info([file_in, file_in], h5out, [0,1,0,9])
         events_in_h5out = h5out.root.MC.extents.cols.evt_number[:]
         assert events_in_h5out.tolist() == [0,1,0,9]
+
+
+def test_copy_mc_info_split_nexus_events(ICDATADIR, config_tmpdir):
+    file_in  = os.path.join(ICDATADIR                                       ,
+                            "nexus_new_kr83m_full.newformat.splitbuffers.h5")
+    file_out = os.path.join(config_tmpdir, "dummy_out.h5")
+
+    with tb.open_file(file_out, 'w') as h5out:
+        copy_mc_info([file_in], h5out, [0, 10, 11], 'new', -6400)
+
+    tables = ("MC/hits"        , "MC/particles", "MC/sns_positions",
+              "MC/sns_response", "Run/eventMap")
+    with tb.open_file(file_in) as h5in, tb.open_file(file_out) as h5out:
+        for table in tables:
+            assert hasattr(h5out.root, table)
+            got      = getattr(h5out.root, table)
+            expected = getattr(h5in .root, table)
+            assert_tables_equality(got, expected)
+
 
 
 def test_mcsensors_from_file_fast_returns_empty(ICDATADIR):

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -205,7 +205,7 @@ def test_mcsensors_from_file_correct_yield(ICDATADIR):
     total_pmthits  = 4303
     nsipms_hit     =  313
     total_sipmhits =  389
-    keys           = ['event_number', 'timestamp', 'pmt_resp', 'sipm_resp']
+    keys           = ['event_number', 'timestamp', 'pmt_resp' , 'sipm_resp']
 
     file_in   = os.path.join(ICDATADIR, "nexus_new_kr83m_full.newformat.sim.h5")
     sns_gen   = mcsensors_from_file([file_in], 'new', -7951)

--- a/invisible_cities/database/test_data/nexus_new_kr83m_full.newformat.buffers.h5
+++ b/invisible_cities/database/test_data/nexus_new_kr83m_full.newformat.buffers.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:abd0bf79d8bef816e95316f2f09d8e0f22974c66452e025ebb12530e46d5d824
-size 136289
+oid sha256:c069eb6999ee9ef3e70c13d8c9eb077561517ec8e63f033deb4b2f8c7fd71eb0
+size 140542

--- a/invisible_cities/database/test_data/nexus_new_kr83m_full.newformat.splitbuffers.h5
+++ b/invisible_cities/database/test_data/nexus_new_kr83m_full.newformat.splitbuffers.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1bbd3af70235024abdf5f755240640b0c85522320fb8734e23c943c53c55b16
+size 93133

--- a/invisible_cities/evm/nh5.py
+++ b/invisible_cities/evm/nh5.py
@@ -46,7 +46,7 @@ class MCExtentInfo(tb.IsDescription):
 class MCEventMap(tb.IsDescription):
     """Map between event index and original event."""
     evt_number = tb.Int32Col(shape=(), pos=0)
-    sub_evt    = tb.Int32Col(shape=(), pos=1)
+    nexus_evt  = tb.Int32Col(shape=(), pos=1)
 
 
 class MCHitInfo(tb.IsDescription):

--- a/invisible_cities/io/mcinfo_io_test.py
+++ b/invisible_cities/io/mcinfo_io_test.py
@@ -18,6 +18,7 @@ from .  mcinfo_io import load_mcsensor_positions
 from .  mcinfo_io import load_mcsensor_response_df
 from .  mcinfo_io import MCTableType
 from .  mcinfo_io import copy_mc_info
+from .  mcinfo_io import safe_copy_nexus_eventmap
 from .  mcinfo_io import read_mc_tables
 from .  mcinfo_io import mc_writer
 from .  mcinfo_io import _read_mchit_info
@@ -25,6 +26,7 @@ from .  mcinfo_io import _read_mchit_info
 from .. core               import system_of_units as units
 from .. core.testing_utils import assert_dataframes_equal
 from .. core.testing_utils import assert_MChit_equality
+from .. core.testing_utils import assert_tables_equality
 
 from pytest import fixture
 from pytest import mark
@@ -102,6 +104,36 @@ def test_is_oldformat_file(ICDATADIR):
 
     assert     is_oldformat_file(file_in_old)
     assert not is_oldformat_file(file_in_new)
+
+
+def test_safe_copy_nexus_eventmap(config_tmpdir, ICDATADIR):
+    file_in  = os.path.join(ICDATADIR                                  ,
+                            'nexus_new_kr83m_full.newformat.buffers.h5')
+    file_out = os.path.join(config_tmpdir, 'evtMapCopy.h5')
+
+    expected_evts = np.array([[0, 0], [13, 1]])
+    with tb.open_file(file_out, 'w') as h5out:
+        copied_evts = safe_copy_nexus_eventmap(h5out, expected_evts[:, 0],
+                                               file_in)
+
+        assert len(copied_evts) == len(expected_evts)
+        assert np.all(copied_evts['nexus_evt'] == expected_evts[:, 1])
+
+    with tb.open_file(file_in) as h5orig, tb.open_file(file_out) as h5out:
+        assert hasattr(h5out.root.Run, 'eventMap')
+        assert_tables_equality(h5out .root.Run.eventMap,
+                               h5orig.root.Run.eventMap)
+
+
+def test_safe_copy_nexus_eventmap_notable(config_tmpdir, ICDATADIR):
+    file_in  = os.path.join(ICDATADIR, 'electrons_40keV_z250_MCRD.h5')
+    file_out = os.path.join(config_tmpdir, 'noEventMap.h5')
+
+    evts = [1, 3, 4, 5]
+    with tb.open_file(file_out, 'w') as h5out:
+        event_numbers = safe_copy_nexus_eventmap(h5out, evts, file_in)
+
+        assert np.all(event_numbers['nexus_evt'] == evts)
 
 
 def test_copy_mc_info_which_events_is_none(ICDATADIR, config_tmpdir):

--- a/invisible_cities/io/rwf_io_test.py
+++ b/invisible_cities/io/rwf_io_test.py
@@ -3,7 +3,6 @@ import os
 import numpy  as np
 import tables as tb
 
-from pytest   import       fixture
 from pytest   import          mark
 
 from . rwf_io import    rwf_writer


### PR DESCRIPTION
Adds functions to generate unique event numbers for MC to allow for safe processing of split nexus events and simplify MC event mixing.

In need of more tests and a file number reader but ready for discussion.

Discussion continues from issue #715 