### PR TITLE
Update demoppdb

### DIFF
--- a/invisible_cities/database/localdb.DEMOPPDB.sqlite3
+++ b/invisible_cities/database/localdb.DEMOPPDB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:32cc72d86f9511ef8901191acfa531bf3e7e19ffbd5ae5581bd60b3e9c5ca26c
+oid sha256:245f25b7b874a6996041ee0cfd93e8b47abaef767e0728462f6f35c3987bbed0
 size 8167424


### PR DESCRIPTION
The ratios in gains for demopp database have been fixed from min run = 1008744 according to these numbers:
- DB2/DB1 = 0.897
- DB3/DB1 = 0.949
- DB4/DB1 = 1.005