### PR TITLE
New tracking city

### DIFF
--- a/invisible_cities/cities/beersheba.py
+++ b/invisible_cities/cities/beersheba.py
@@ -30,8 +30,7 @@ from .  components import collect
 from .  components import copy_mc_info
 from .  components import print_every
 from .  components import cdst_from_files
-
-from .  esmeralda  import summary_writer
+from .  components import summary_writer
 
 from .. reco                   import tbl_functions           as tbl
 from .. dataflow               import dataflow                as fl

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -1009,18 +1009,21 @@ def calculate_and_save_buffers(buffer_length    : float        ,
     buffer_definition = pipe(*filter(None, find_signal_and_write_buffers))
     return buffer_definition
 
-
-def copy_Ec_to_Ep_hit_attribute_(hitc : HitCollection) -> HitCollection:
-    """
-    The functions copies values of Ec attributes into Ep attributes. Takes as input HitCollection and returns a copy.
-    """
-    mod_hits = []
-    for hit in hitc.hits:
-        hit = Hit(hit.npeak, Cluster(hit.Q, xy(hit.X, hit.Y), hit.var, hit.nsipm),
-                  hit.Z, hit.E, xy(hit.Xpeak, hit.Ypeak), s2_energy_c=hit.Ec, Ep=hit.Ec)
-        mod_hits.append(hit)
-    mod_hitc = HitCollection(hitc.event, hitc.time, hits=mod_hits)
-    return mod_hitc
+def Efield_copier(energy_type: HitEnergy):
+    def copy_Efield(hitc : HitCollection) -> HitCollection:
+        mod_hits = []
+        for hit in hitc.hits:
+            hit = Hit(hit.npeak,
+                      Cluster(hit.Q, xy(hit.X, hit.Y), hit.var, hit.nsipm),
+                      hit.Z,
+                      hit.E,
+                      xy(hit.Xpeak, hit.Ypeak),
+                      s2_energy_c=getattr(hit, energy_type.value),
+                      Ep=getattr(hit, energy_type.value))
+            mod_hits.append(hit)
+        mod_hitc = HitCollection(hitc.event, hitc.time, hits=mod_hits)
+        return mod_hitc
+    return copy_Efield
 
 
 def make_event_summary(event_number  : int              ,

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -30,6 +30,7 @@ from .. evm    .event_model       import                   KrEvent
 from .. evm    .event_model       import                       Hit
 from .. evm    .event_model       import                   Cluster
 from .. evm    .event_model       import             HitCollection
+from .. evm    .event_model       import                 HitEnergy
 from .. evm    .event_model       import                    MCInfo
 from .. evm    .pmaps             import                SiPMCharge
 from .. core                      import           system_of_units as units
@@ -50,6 +51,7 @@ from .. reco                      import            peak_functions as pkf
 from .. reco                      import           pmaps_functions as pmf
 from .. reco                      import            hits_functions as hif
 from .. reco                      import             wfm_functions as wfm
+from .. reco                      import         paolina_functions as plf
 from .. reco   .xy_algorithms     import                    corona
 from .. filters.s1s2_filter       import               S12Selector
 from .. filters.s1s2_filter       import               pmap_filter
@@ -63,10 +65,14 @@ from .. io     .event_filter_io   import       event_filter_writer
 from .. io     .pmaps_io          import               pmap_writer
 from .. io     .rwf_io            import             buffer_writer
 from .. io     .mcinfo_io         import            load_mchits_df
+from .. io     .dst_io            import                 df_writer
+from .. io     .hits_io           import               hits_writer
 from .. types  .ic_types          import                        xy
 from .. types  .ic_types          import                        NN
 from .. types  .ic_types          import                       NNN
 from .. types  .ic_types          import                    minmax
+from .. types  .ic_types          import        types_dict_summary
+from .. types  .ic_types          import         types_dict_tracks
 
 NoneType = type(None)
 
@@ -1002,3 +1008,248 @@ def calculate_and_save_buffers(buffer_length    : float        ,
     # Filter out order_sensors if it is not set
     buffer_definition = pipe(*filter(None, find_signal_and_write_buffers))
     return buffer_definition
+
+
+def copy_Ec_to_Ep_hit_attribute_(hitc : HitCollection) -> HitCollection:
+    """
+    The functions copies values of Ec attributes into Ep attributes. Takes as input HitCollection and returns a copy.
+    """
+    mod_hits = []
+    for hit in hitc.hits:
+        hit = Hit(hit.npeak, Cluster(hit.Q, xy(hit.X, hit.Y), hit.var, hit.nsipm),
+                  hit.Z, hit.E, xy(hit.Xpeak, hit.Ypeak), s2_energy_c=hit.Ec, Ep=hit.Ec)
+        mod_hits.append(hit)
+    mod_hitc = HitCollection(hitc.event, hitc.time, hits=mod_hits)
+    return mod_hitc
+
+
+def make_event_summary(event_number  : int              ,
+                       topology_info : pd.DataFrame     ,
+                       paolina_hits  : HitCollection,
+                       out_of_map    : bool
+                       ) -> pd.DataFrame:
+    """
+    For a given event number, timestamp, topology info dataframe, paolina hits and kdst information returns a
+    dataframe with the whole event summary.
+
+    Parameters
+    ----------
+    event_number  : int
+    timestamp     : long int
+    topology_info : DataFrame
+        Dataframe containing track information,
+        output of track_blob_info_creator_extractor
+    paolina_hits  : HitCollection
+        Hits table passed through paolina functions,
+        output of track_blob_info_creator_extractor
+    kdst          : DataFrame
+        Kdst information read from penthesilea output
+
+
+    Returns
+    ----------
+    DataFrame containing relevant per event information.
+    """
+    es = pd.DataFrame(columns=list(types_dict_summary.keys()))
+
+    ntrks = len(topology_info.index)
+    nhits = len(paolina_hits.hits)
+
+    S2ec = sum(h.Ec for h in paolina_hits.hits)
+    S2qc = -1 #not implemented yet
+
+    pos   = [h.pos for h in paolina_hits.hits]
+    x, y, z = map(np.array, zip(*pos))
+    r = np.sqrt(x**2 + y**2)
+
+    e     = [h.Ec  for h in paolina_hits.hits]
+    ave_pos = np.average(pos, weights=e, axis=0)
+    ave_r   = np.average(r  , weights=e, axis=0)
+
+
+    list_of_vars  = [event_number, S2ec, S2qc, ntrks, nhits,
+                     *ave_pos, ave_r,
+                     min(x), min(y), min(z), min(r), max(x), max(y), max(z), max(r),
+                     out_of_map]
+
+    es.loc[0] = list_of_vars
+    #change dtype of columns to match type of variables
+    es = es.apply(lambda x : x.astype(types_dict_summary[x.name]))
+    return es
+
+
+
+def track_writer(h5out, compression='ZLIB4'):
+    """
+    For a given open table returns a writer for topology info dataframe
+    """
+    def write_tracks(df):
+        return df_writer(h5out              = h5out              ,
+                         df                 = df                 ,
+                         compression        = compression        ,
+                         group_name         = 'Tracking'         ,
+                         table_name         = 'Tracks'           ,
+                         descriptive_string = 'Track information',
+                         columns_to_index   = ['event']          )
+    return write_tracks
+
+
+def summary_writer(h5out, compression='ZLIB4'):
+    """
+    For a given open table returns a writer for summary info dataframe
+    """
+    def write_summary(df):
+        return df_writer(h5out              = h5out                      ,
+                         df                 = df                         ,
+                         compression        = compression                ,
+                         group_name         = 'Summary'                  ,
+                         table_name         = 'Events'                   ,
+                         descriptive_string = 'Event summary information',
+                         columns_to_index   = ['event']                  )
+    return write_summary
+
+
+def track_blob_info_creator_extractor(vox_size         : [float, float, float],
+                                      strict_vox_size  : bool                 ,
+                                      energy_threshold : float                ,
+                                      min_voxels       : int                  ,
+                                      blob_radius      : float                ,
+                                      max_num_hits     : int
+                                     ) -> Callable:
+    """
+    For a given paolina parameters returns a function that extract tracks / blob information from a HitCollection.
+
+    Parameters
+    ----------
+    vox_size         : [float, float, float]
+        (maximum) size of voxels for track reconstruction
+    strict_vox_size  : bool
+        if False allows per event adaptive voxel size,
+        smaller of equal thatn vox_size
+    energy_threshold : float
+        if energy of end-point voxel is smaller
+        the voxel will be dropped and energy redistributed to the neighbours
+    min_voxels       : int
+        after min_voxel number of voxels is reached no dropping will happen.
+    blob_radius      : float
+        radius of blob
+
+    Returns
+    ----------
+    A function that from a given HitCollection returns a pandas DataFrame with per track information.
+    """
+    def create_extract_track_blob_info(hitc):
+        df = pd.DataFrame(columns=list(types_dict_tracks.keys()))
+        if len(hitc.hits) > max_num_hits:
+            return df, hitc, True
+        #track_hits is a new Hitcollection object that contains hits belonging to tracks, and hits that couldnt be corrected
+        track_hitc = HitCollection(hitc.event, hitc.time)
+        out_of_map = np.any(np.isnan([h.Ep for h in hitc.hits]))
+        if out_of_map:
+            #add nan hits to track_hits, the track_id will be -1
+            track_hitc.hits.extend  ([h for h in hitc.hits if np.isnan   (h.Ep)])
+            hits_without_nan       = [h for h in hitc.hits if np.isfinite(h.Ep)]
+            #create new Hitcollection object but keep the name hitc
+            hitc      = HitCollection(hitc.event, hitc.time)
+            hitc.hits = hits_without_nan
+
+        if len(hitc.hits) > 0:
+            voxels           = plf.voxelize_hits(hitc.hits, vox_size, strict_vox_size, HitEnergy.Ep)
+            (    mod_voxels,
+             dropped_voxels) = plf.drop_end_point_voxels(voxels, energy_threshold, min_voxels)
+            tracks           = plf.make_track_graphs(mod_voxels)
+
+            for v in dropped_voxels:
+                track_hitc.hits.extend(v.hits)
+
+            vox_size_x = voxels[0].size[0]
+            vox_size_y = voxels[0].size[1]
+            vox_size_z = voxels[0].size[2]
+            del(voxels)
+            #sort tracks in energy
+            tracks     = sorted(tracks, key=plf.get_track_energy, reverse=True)
+
+            track_hits = []
+            for c, t in enumerate(tracks, 0):
+                tID = c
+                energy = plf.get_track_energy(t)
+                length = plf.length(t)
+                numb_of_hits   = len([h for vox in t.nodes() for h in vox.hits])
+                numb_of_voxels = len(t.nodes())
+                numb_of_tracks = len(tracks   )
+                pos   = [h.pos for v in t.nodes() for h in v.hits]
+                x, y, z = map(np.array, zip(*pos))
+                r = np.sqrt(x**2 + y**2)
+
+                e     = [h.Ep for v in t.nodes() for h in v.hits]
+                ave_pos = np.average(pos, weights=e, axis=0)
+                ave_r   = np.average(r  , weights=e, axis=0)
+                extr1, extr2 = plf.find_extrema(t)
+                extr1_pos = extr1.XYZ
+                extr2_pos = extr2.XYZ
+
+                blob_pos1, blob_pos2 = plf.blob_centres(t, blob_radius)
+
+                e_blob1, e_blob2, hits_blob1, hits_blob2 = plf.blob_energies_and_hits(t, blob_radius)
+                overlap = float(sum(h.Ep for h in set(hits_blob1).intersection(set(hits_blob2))))
+                list_of_vars = [hitc.event, tID, energy, length, numb_of_voxels,
+                                numb_of_hits, numb_of_tracks,
+                                min(x), min(y), min(z), min(r), max(x), max(y), max(z), max(r),
+                                *ave_pos, ave_r, *extr1_pos,
+                                *extr2_pos, *blob_pos1, *blob_pos2,
+                                e_blob1, e_blob2, overlap,
+                                vox_size_x, vox_size_y, vox_size_z]
+
+                df.loc[c] = list_of_vars
+
+                for vox in t.nodes():
+                    for hit in vox.hits:
+                        hit.track_id = tID
+                        track_hits.append(hit)
+
+            #change dtype of columns to match type of variables
+            df = df.apply(lambda x : x.astype(types_dict_tracks[x.name]))
+            track_hitc.hits.extend(track_hits)
+        return df, track_hitc, out_of_map
+
+    return create_extract_track_blob_info
+
+
+def compute_and_write_tracks_info(paolina_params, h5out):
+
+    # Create tracks and compute topology-related information
+    create_extract_track_blob_info = fl.map(track_blob_info_creator_extractor(**paolina_params),
+                                            args = 'Ep_hits',
+                                            out  = ('topology_info', 'paolina_hits', 'out_of_map'))
+
+    # Filter empty topology events
+    filter_events_topology         = fl.map(lambda x : len(x) > 0,
+                                            args = 'topology_info',
+                                            out  = 'topology_passed')
+    events_passed_topology         = fl.count_filter(bool, args="topology_passed")
+
+    # Create table with summary information
+    make_final_summary             = fl.map(make_event_summary,
+                                            args = ('event_number', 'topology_info', 'paolina_hits', 'out_of_map'),
+                                            out  = 'event_info')
+
+
+    # Define writers and make them sinks
+    write_tracks          = fl.sink(   track_writer     (h5out=h5out)             , args="topology_info"      )
+    write_summary         = fl.sink( summary_writer     (h5out=h5out)             , args="event_info"         )
+    write_topology_filter = fl.sink( event_filter_writer(h5out, "topology_select"), args=("event_number", "topology_passed"    ))
+    write_hits_paolina    = fl.sink(    hits_writer     (h5out, group_name="CHITS", table_name="highTh")
+                                                                                  , args="paolina_hits"       )
+
+
+    fn_list = (create_extract_track_blob_info              ,
+               filter_events_topology                      ,
+               fl.branch(make_final_summary, write_summary),
+               fl.branch(write_topology_filter)            ,
+               fl.branch(write_hits_paolina)               ,
+               events_passed_topology.   filter            ,
+               fl.branch(write_tracks)                    ,)
+
+    compute_tracks = pipe(*fn_list)
+
+    return compute_tracks

--- a/invisible_cities/cities/esmeralda.py
+++ b/invisible_cities/cities/esmeralda.py
@@ -21,13 +21,10 @@ The city outputs :
 import os
 import tables as tb
 import numpy  as np
-import pandas as pd
 
-from collections import OrderedDict
 from typing      import Callable
 
 from .. reco                import tbl_functions        as tbl
-from .. reco                import paolina_functions    as plf
 from .. reco                import hits_functions       as hif
 from .. reco                import corrections          as cof
 from .. evm                 import event_model          as evm
@@ -40,35 +37,16 @@ from .  components import print_every
 from .  components import collect
 from .  components import copy_mc_info
 from .  components import hits_and_kdst_from_files
+from .  components import copy_Ec_to_Ep_hit_attribute_
+from .  components import compute_and_write_tracks_info
 
 from .. types.      ic_types import xy
 
 from .. io.         hits_io import hits_writer
+from .. io.         kdst_io import kdst_from_df_writer
 from .. io.run_and_event_io import run_and_event_writer
 from .. io. event_filter_io import event_filter_writer
-from .. io.          dst_io import df_writer
 
-
-types_dict_summary = OrderedDict({'event'     : np.int32  , 'evt_energy' : np.float64, 'evt_charge'    : np.float64,
-                                  'evt_ntrks' : np.int    , 'evt_nhits'  : np.int    , 'evt_x_avg'     : np.float64,
-                                  'evt_y_avg' : np.float64, 'evt_z_avg'  : np.float64, 'evt_r_avg'     : np.float64,
-                                  'evt_x_min' : np.float64, 'evt_y_min'  : np.float64, 'evt_z_min'     : np.float64,
-                                  'evt_r_min' : np.float64, 'evt_x_max'  : np.float64, 'evt_y_max'     : np.float64,
-                                  'evt_z_max' : np.float64, 'evt_r_max'  : np.float64, 'evt_out_of_map': bool      })
-
-types_dict_tracks = OrderedDict({'event'           : np.int32  , 'trackID'       : np.int    , 'energy'      : np.float64,
-                                 'length'          : np.float64, 'numb_of_voxels': np.int    , 'numb_of_hits': np.int    ,
-                                 'numb_of_tracks'  : np.int    , 'x_min'         : np.float64, 'y_min'       : np.float64,
-                                 'z_min'           : np.float64, 'r_min'         : np.float64, 'x_max'       : np.float64,
-                                 'y_max'           : np.float64, 'z_max'         : np.float64, 'r_max'       : np.float64,
-                                 'x_ave'           : np.float64, 'y_ave'         : np.float64, 'z_ave'       : np.float64,
-                                 'r_ave'           : np.float64, 'extreme1_x'    : np.float64, 'extreme1_y'  : np.float64,
-                                 'extreme1_z'      : np.float64, 'extreme2_x'    : np.float64, 'extreme2_y'  : np.float64,
-                                 'extreme2_z'      : np.float64, 'blob1_x'       : np.float64, 'blob1_y'     : np.float64,
-                                 'blob1_z'         : np.float64, 'blob2_x'       : np.float64, 'blob2_y'     : np.float64,
-                                 'blob2_z'         : np.float64, 'eblob1'        : np.float64, 'eblob2'      : np.float64,
-                                 'ovlp_blob_energy': np.float64,
-                                 'vox_size_x'      : np.float64, 'vox_size_y'    : np.float64, 'vox_size_z'  : np.float64})
 
 def hits_threshold_and_corrector(map_fname        : str  ,
                                  threshold_charge : float,
@@ -131,222 +109,6 @@ def hits_threshold_and_corrector(map_fname        : str  ,
         return new_hitc
     return threshold_and_correct_hits
 
-def copy_Ec_to_Ep_hit_attribute_(hitc : evm.HitCollection) -> evm.HitCollection:
-    """
-    The functions copies values of Ec attributes into Ep attributes. Takes as input HitCollection and returns a copy.
-    """
-    mod_hits = []
-    for hit in hitc.hits:
-        hit = evm.Hit(hit.npeak, evm.Cluster(hit.Q, xy(hit.X, hit.Y), hit.var, hit.nsipm),
-                      hit.Z, hit.E, xy(hit.Xpeak, hit.Ypeak), s2_energy_c=hit.Ec, Ep=hit.Ec)
-        mod_hits.append(hit)
-    mod_hitc = evm.HitCollection(hitc.event, hitc.time, hits=mod_hits)
-    return mod_hitc
-
-
-def track_blob_info_creator_extractor(vox_size         : [float, float, float],
-                                      strict_vox_size  : bool                 ,
-                                      energy_threshold : float                ,
-                                      min_voxels       : int                  ,
-                                      blob_radius      : float                ,
-                                      max_num_hits     : int
-                                     ) -> Callable:
-    """
-    For a given paolina parameters returns a function that extract tracks / blob information from a HitCollection.
-
-    Parameters
-    ----------
-    vox_size         : [float, float, float]
-        (maximum) size of voxels for track reconstruction
-    strict_vox_size  : bool
-        if False allows per event adaptive voxel size,
-        smaller of equal thatn vox_size
-    energy_threshold : float
-        if energy of end-point voxel is smaller
-        the voxel will be dropped and energy redistributed to the neighbours
-    min_voxels       : int
-        after min_voxel number of voxels is reached no dropping will happen.
-    blob_radius      : float
-        radius of blob
-
-    Returns
-    ----------
-    A function that from a given HitCollection returns a pandas DataFrame with per track information.
-    """
-    def create_extract_track_blob_info(hitc):
-        df = pd.DataFrame(columns=list(types_dict_tracks.keys()))
-        if len(hitc.hits) > max_num_hits:
-            return df, hitc, True
-        #track_hits is a new Hitcollection object that contains hits belonging to tracks, and hits that couldnt be corrected
-        track_hitc = evm.HitCollection(hitc.event, hitc.time)
-        out_of_map = np.any(np.isnan([h.Ep for h in hitc.hits]))
-        if out_of_map:
-            #add nan hits to track_hits, the track_id will be -1
-            track_hitc.hits.extend  ([h for h in hitc.hits if np.isnan   (h.Ep)])
-            hits_without_nan       = [h for h in hitc.hits if np.isfinite(h.Ep)]
-            #create new Hitcollection object but keep the name hitc
-            hitc      = evm.HitCollection(hitc.event, hitc.time)
-            hitc.hits = hits_without_nan
-
-        if len(hitc.hits) > 0:
-            voxels           = plf.voxelize_hits(hitc.hits, vox_size, strict_vox_size, evm.HitEnergy.Ep)
-            (    mod_voxels,
-             dropped_voxels) = plf.drop_end_point_voxels(voxels, energy_threshold, min_voxels)
-            tracks           = plf.make_track_graphs(mod_voxels)
-
-            for v in dropped_voxels:
-                track_hitc.hits.extend(v.hits)
-
-            vox_size_x = voxels[0].size[0]
-            vox_size_y = voxels[0].size[1]
-            vox_size_z = voxels[0].size[2]
-            del(voxels)
-            #sort tracks in energy
-            tracks     = sorted(tracks, key=plf.get_track_energy, reverse=True)
-
-            track_hits = []
-            for c, t in enumerate(tracks, 0):
-                tID = c
-                energy = plf.get_track_energy(t)
-                length = plf.length(t)
-                numb_of_hits   = len([h for vox in t.nodes() for h in vox.hits])
-                numb_of_voxels = len(t.nodes())
-                numb_of_tracks = len(tracks   )
-                pos   = [h.pos for v in t.nodes() for h in v.hits]
-                x, y, z = map(np.array, zip(*pos))
-                r = np.sqrt(x**2 + y**2)
-
-                e     = [h.Ep for v in t.nodes() for h in v.hits]
-                ave_pos = np.average(pos, weights=e, axis=0)
-                ave_r   = np.average(r  , weights=e, axis=0)
-                extr1, extr2 = plf.find_extrema(t)
-                extr1_pos = extr1.XYZ
-                extr2_pos = extr2.XYZ
-
-                blob_pos1, blob_pos2 = plf.blob_centres(t, blob_radius)
-
-                e_blob1, e_blob2, hits_blob1, hits_blob2 = plf.blob_energies_and_hits(t, blob_radius)
-                overlap = float(sum(h.Ep for h in set(hits_blob1).intersection(set(hits_blob2))))
-                list_of_vars = [hitc.event, tID, energy, length, numb_of_voxels,
-                                numb_of_hits, numb_of_tracks,
-                                min(x), min(y), min(z), min(r), max(x), max(y), max(z), max(r),
-                                *ave_pos, ave_r, *extr1_pos,
-                                *extr2_pos, *blob_pos1, *blob_pos2,
-                                e_blob1, e_blob2, overlap,
-                                vox_size_x, vox_size_y, vox_size_z]
-
-                df.loc[c] = list_of_vars
-
-                for vox in t.nodes():
-                    for hit in vox.hits:
-                        hit.track_id = tID
-                        track_hits.append(hit)
-
-            #change dtype of columns to match type of variables
-            df = df.apply(lambda x : x.astype(types_dict_tracks[x.name]))
-            track_hitc.hits.extend(track_hits)
-        return df, track_hitc, out_of_map
-
-    return create_extract_track_blob_info
-
-
-def make_event_summary(event_number  : int              ,
-                       topology_info : pd.DataFrame     ,
-                       paolina_hits  : evm.HitCollection,
-                       out_of_map    : bool
-                       ) -> pd.DataFrame:
-    """
-    For a given event number, timestamp, topology info dataframe, paolina hits and kdst information returns a
-    dataframe with the whole event summary.
-
-    Parameters
-    ----------
-    event_number  : int
-    timestamp     : long int
-    topology_info : DataFrame
-        Dataframe containing track information,
-        output of track_blob_info_creator_extractor
-    paolina_hits  : HitCollection
-        Hits table passed through paolina functions,
-        output of track_blob_info_creator_extractor
-    kdst          : DataFrame
-        Kdst information read from penthesilea output
-
-
-    Returns
-    ----------
-    DataFrame containing relevant per event information.
-    """
-    es = pd.DataFrame(columns=list(types_dict_summary.keys()))
-
-    ntrks = len(topology_info.index)
-    nhits = len(paolina_hits.hits)
-
-    S2ec = sum(h.Ec for h in paolina_hits.hits)
-    S2qc = -1 #not implemented yet
-
-    pos   = [h.pos for h in paolina_hits.hits]
-    x, y, z = map(np.array, zip(*pos))
-    r = np.sqrt(x**2 + y**2)
-
-    e     = [h.Ec  for h in paolina_hits.hits]
-    ave_pos = np.average(pos, weights=e, axis=0)
-    ave_r   = np.average(r  , weights=e, axis=0)
-
-
-    list_of_vars  = [event_number, S2ec, S2qc, ntrks, nhits,
-                     *ave_pos, ave_r,
-                     min(x), min(y), min(z), min(r), max(x), max(y), max(z), max(r),
-                     out_of_map]
-
-    es.loc[0] = list_of_vars
-    #change dtype of columns to match type of variables
-    es = es.apply(lambda x : x.astype(types_dict_summary[x.name]))
-    return es
-
-
-def track_writer(h5out, compression='ZLIB4'):
-    """
-    For a given open table returns a writer for topology info dataframe
-    """
-    def write_tracks(df):
-        return df_writer(h5out              = h5out              ,
-                         df                 = df                 ,
-                         compression        = compression        ,
-                         group_name         = 'Tracking'         ,
-                         table_name         = 'Tracks'           ,
-                         descriptive_string = 'Track information',
-                         columns_to_index   = ['event']          )
-    return write_tracks
-
-
-def summary_writer(h5out, compression='ZLIB4'):
-    """
-    For a given open table returns a writer for summary info dataframe
-    """
-    def write_summary(df):
-        return df_writer(h5out              = h5out                      ,
-                         df                 = df                         ,
-                         compression        = compression                ,
-                         group_name         = 'Summary'                  ,
-                         table_name         = 'Events'                   ,
-                         descriptive_string = 'Event summary information',
-                         columns_to_index   = ['event']                  )
-    return write_summary
-
-def kdst_from_df_writer(h5out, compression='ZLIB4'):
-    """
-    For a given open table returns a writer for KDST dataframe info
-    """
-    def write_kdst(df):
-        return df_writer(h5out              = h5out        ,
-                         df                 = df           ,
-                         compression        = compression  ,
-                         group_name         = 'DST'        ,
-                         table_name         = 'Events'     ,
-                         descriptive_string = 'KDST Events',
-                         columns_to_index   = ['event']    )
-    return write_kdst
 
 
 @city
@@ -444,22 +206,10 @@ def esmeralda(files_in, file_out, compression, event_range, print_mod,
 
     copy_Ec_to_Ep_hit_attribute     = fl.map(copy_Ec_to_Ep_hit_attribute_,
                                              args = 'cor_high_th_hits',
-                                             out  = 'cor_Ep_high_th_hits')
-
-    create_extract_track_blob_info  = fl.map(track_blob_info_creator_extractor(**paolina_params),
-                                             args = 'cor_Ep_high_th_hits',
-                                             out  = ('topology_info', 'paolina_hits', 'out_of_map'))
-    filter_events_topology          = fl.map(lambda x : len(x) > 0,
-                                             args = 'topology_info',
-                                             out  = 'topology_passed')
-    events_passed_topology          = fl.count_filter(bool, args="topology_passed")
-
-    make_final_summary              = fl.map(make_event_summary,
-                                             args = ('event_number', 'topology_info', 'paolina_hits', 'out_of_map'),
-                                             out  = 'event_info')
+                                             out  = 'Ep_hits')
 
     event_count_in  = fl.spy_count()
-    event_count_out = fl.spy_count()
+    event_count_out = fl.count()
 
     with tb.open_file(file_out, "w", filters=tbl.filters(compression)) as h5out:
 
@@ -468,15 +218,13 @@ def esmeralda(files_in, file_out, compression, event_range, print_mod,
 
         write_hits_low_th     = fl.sink(    hits_writer     (h5out, group_name='CHITS', table_name='lowTh'),
                                             args="cor_low_th_hits")
-        write_hits_paolina    = fl.sink(    hits_writer     (h5out, group_name='CHITS', table_name='highTh' ),
-                                            args="paolina_hits"   )
 
-        write_tracks          = fl.sink(   track_writer     (h5out=h5out)                , args="topology_info"      )
-        write_summary         = fl.sink( summary_writer     (h5out=h5out)                , args="event_info"         )
         write_high_th_filter  = fl.sink( event_filter_writer(h5out, "high_th_select" )   , args=("event_number", "high_th_hits_passed"))
         write_low_th_filter   = fl.sink( event_filter_writer(h5out, "low_th_select"  )   , args=("event_number", "low_th_hits_passed" ))
-        write_topology_filter = fl.sink( event_filter_writer(h5out, "topology_select")   , args=("event_number", "topology_passed"    ))
         write_kdst_table      = fl.sink( kdst_from_df_writer(h5out)                      , args="kdst"               )
+
+
+        compute_tracks = compute_and_write_tracks_info(paolina_params, h5out)
 
         evtnum_collect = collect()
 
@@ -497,14 +245,9 @@ def esmeralda(files_in, file_out, compression, event_range, print_mod,
                                     fl.branch(write_high_th_filter)               ,
                                     hits_passed_high_th   .filter                 ,
                                     copy_Ec_to_Ep_hit_attribute                   ,
-                                    create_extract_track_blob_info                ,
-                                    filter_events_topology                        ,
-                                    fl.branch(make_final_summary, write_summary)  ,
-                                    fl.branch(write_topology_filter)              ,
-                                    fl.branch(write_hits_paolina)                 ,
-                                    events_passed_topology.filter                 ,
-                                    event_count_out       .spy                    ,
-                                    write_tracks                                 ),
+                                    compute_tracks                                ,
+                                    "event_number"                                ,
+                                    event_count_out       .sink                   ),
                       result = dict(events_in  =event_count_in .future,
                                     events_out =event_count_out.future,
                                     evtnum_list=evtnum_collect .future))

--- a/invisible_cities/cities/esmeralda.py
+++ b/invisible_cities/cities/esmeralda.py
@@ -37,7 +37,7 @@ from .  components import print_every
 from .  components import collect
 from .  components import copy_mc_info
 from .  components import hits_and_kdst_from_files
-from .  components import copy_Ec_to_Ep_hit_attribute_
+from .  components import Efield_copier
 from .  components import compute_and_write_tracks_info
 
 from .. types.      ic_types import xy
@@ -204,7 +204,7 @@ def esmeralda(files_in, file_out, compression, event_range, print_mod,
     hits_passed_low_th              = fl.count_filter(bool, args="low_th_hits_passed")
     hits_passed_high_th             = fl.count_filter(bool, args="high_th_hits_passed")
 
-    copy_Ec_to_Ep_hit_attribute     = fl.map(copy_Ec_to_Ep_hit_attribute_,
+    copy_Efield                     = fl.map(Efield_copier(evm.HitEnergy.Ec),
                                              args = 'cor_high_th_hits',
                                              out  = 'Ep_hits')
 
@@ -244,7 +244,7 @@ def esmeralda(files_in, file_out, compression, event_range, print_mod,
                                     filter_events_high_th                         ,
                                     fl.branch(write_high_th_filter)               ,
                                     hits_passed_high_th   .filter                 ,
-                                    copy_Ec_to_Ep_hit_attribute                   ,
+                                    copy_Efield                                   ,
                                     compute_tracks                                ,
                                     "event_number"                                ,
                                     event_count_out       .sink                   ),

--- a/invisible_cities/cities/isaura.py
+++ b/invisible_cities/cities/isaura.py
@@ -24,12 +24,10 @@ from .  components import collect
 from .  components import copy_mc_info
 from .  components import dhits_from_files
 from .  components import compute_and_write_tracks_info
-from .  components import Efield_copier
 
 from ..  evm.event_model import HitEnergy
 
 from ..  io.run_and_event_io import run_and_event_writer
-from ..  io.event_filter_io  import  event_filter_writer
 
 
 
@@ -88,31 +86,16 @@ def isaura(files_in, file_out, compression, event_range, print_mod,
     with tb.open_file(file_out, "w", filters=tbl.filters(compression)) as h5out:
 
         write_event_info = fl.sink(run_and_event_writer(h5out), args=("run_number", "event_number", "timestamp"))
-        write_no_hits_filter  = fl.sink( event_filter_writer(h5out, "hits_select" )   , args=("event_number", "hits_passed"))
 
         evtnum_collect = collect()
 
-        filter_events_nohits = fl.map(lambda x : len(x.hits) > 0,
-                                      args = 'hits',
-                                      out  = 'hits_passed')
-        hits_passed          = fl.count_filter(bool, args="hits_passed")
-
-
-        copy_Efield          = fl.map(Efield_copier(HitEnergy.E),
-                                            args = 'hits',
-                                            out  = 'Ep_hits')
-
-        compute_tracks = compute_and_write_tracks_info(paolina_params, h5out)
+        compute_tracks = compute_and_write_tracks_info(paolina_params, h5out, hit_type=HitEnergy.E)
 
         result = push(source = dhits_from_files(files_in),
                       pipe   = pipe(fl.slice(*event_range, close_all=True)        ,
                                     print_every(print_mod)                        ,
                                     event_count_in        .spy                    ,
                                     fl.branch("event_number", evtnum_collect.sink),
-                                    filter_events_nohits                          ,
-                                    fl.branch(write_no_hits_filter)               ,
-                                    hits_passed.              filter              ,
-                                    copy_Efield                                   ,
                                     compute_tracks                                ,
                                     event_count_out       .spy                    ,
                                     write_event_info                              ),

--- a/invisible_cities/cities/isaura.py
+++ b/invisible_cities/cities/isaura.py
@@ -1,0 +1,128 @@
+"""
+-----------------------------------------------------------------------
+                              Isaura
+-----------------------------------------------------------------------
+From ancient greek, Ισαυρία: an ancient rugged region in Asia Minor.
+This city computes tracks and extracts topology information.
+The input is beersheba deconvoluted hits and mc info.
+The city outputs :
+    - MC info (if run number <=0)
+    - Tracking/Tracks - summary of per track information
+    - Summary/events  - summary of per event information
+"""
+
+import tables as tb
+
+from .. reco                import tbl_functions        as tbl
+from .. dataflow            import dataflow             as fl
+from .. dataflow.dataflow   import push
+from .. dataflow.dataflow   import pipe
+
+from .  components import city
+from .  components import print_every
+from .  components import collect
+from .  components import copy_mc_info
+from .  components import dhits_from_files
+from .  components import compute_and_write_tracks_info
+from .  components import Efield_copier
+
+from ..  evm.event_model import HitEnergy
+
+from ..  io.run_and_event_io import run_and_event_writer
+from ..  io.event_filter_io  import  event_filter_writer
+
+
+
+
+@city
+def isaura(files_in, file_out, compression, event_range, print_mod,
+              detector_db, run_number,
+              paolina_params = dict()):
+    """
+    The city extracts topology information.
+    ----------
+    Parameters
+    ----------
+    files_in  : str, filepath
+         input file
+    file_out  : str, filepath
+         output file
+    compression : str
+         Default  'ZLIB4'
+    event_range : int /'all_events'
+         number of events from files_in to process
+    print_mode : int
+         how frequently to print events
+    run_number : int
+         has to be negative for MC runs
+    paolina_params               :dict
+        vox_size                 : [float, float, float]
+            (maximum) size of voxels for track reconstruction
+        strict_vox_size          : bool
+            if False allows per event adaptive voxel size,
+            smaller of equal thatn vox_size
+        energy_threshold        : float
+            if energy of end-point voxel is smaller
+            the voxel will be dropped and energy redistributed to the neighbours
+        min_voxels              : int
+            after min_voxel number of voxels is reached no dropping will happen.
+        blob_radius             : float
+            radius of blob
+        max_num_hits            : int
+            maximum number of hits allowed per event to run paolina functions.
+    ----------
+    Input
+    ----------
+    Beersheba output
+    ----------
+    Output
+    ----------
+    - MC info (if run number <=0)
+    - Tracking/Tracks - summary of per track information
+    - Summary/events  - summary of per event information
+"""
+
+    event_count_in  = fl.spy_count()
+    event_count_out = fl.spy_count()
+
+    with tb.open_file(file_out, "w", filters=tbl.filters(compression)) as h5out:
+
+        write_event_info = fl.sink(run_and_event_writer(h5out), args=("run_number", "event_number", "timestamp"))
+        write_no_hits_filter  = fl.sink( event_filter_writer(h5out, "hits_select" )   , args=("event_number", "hits_passed"))
+
+        evtnum_collect = collect()
+
+        filter_events_nohits = fl.map(lambda x : len(x.hits) > 0,
+                                      args = 'hits',
+                                      out  = 'hits_passed')
+        hits_passed          = fl.count_filter(bool, args="hits_passed")
+
+
+        copy_Efield          = fl.map(Efield_copier(HitEnergy.E),
+                                            args = 'hits',
+                                            out  = 'Ep_hits')
+
+        compute_tracks = compute_and_write_tracks_info(paolina_params, h5out)
+
+        result = push(source = dhits_from_files(files_in),
+                      pipe   = pipe(fl.slice(*event_range, close_all=True)        ,
+                                    print_every(print_mod)                        ,
+                                    event_count_in        .spy                    ,
+                                    fl.branch("event_number", evtnum_collect.sink),
+                                    filter_events_nohits                          ,
+                                    fl.branch(write_no_hits_filter)               ,
+                                    hits_passed.              filter              ,
+                                    copy_Efield                                   ,
+                                    compute_tracks                                ,
+                                    event_count_out       .spy                    ,
+                                    write_event_info                              ),
+                      result = dict(events_in  =event_count_in .future,
+                                    events_out =event_count_out.future,
+                                    evtnum_list=evtnum_collect .future))
+
+
+        if run_number <= 0:
+            copy_mc_info(files_in, h5out, result.evtnum_list,
+                         detector_db, run_number)
+
+        return result

--- a/invisible_cities/cities/isaura_test.py
+++ b/invisible_cities/cities/isaura_test.py
@@ -1,0 +1,98 @@
+import os
+import numpy  as np
+import tables as tb
+
+from .  isaura         import isaura
+from .. core.configure import configure
+from .. core.configure import all             as all_events
+from .. io.dst_io      import load_dst
+
+from .. core.testing_utils   import assert_tables_equality
+
+
+def test_isaura_contains_all_tables(ICDATADIR, output_tmpdir):
+
+    PATH_IN  = os.path.join(ICDATADIR    , "test_Xe2nu_NEW_exact_deconvolution_joint.NEWMC.h5")
+    PATH_OUT = os.path.join(output_tmpdir, "contain_all_tables.isaura.h5")
+    conf = configure('isaura $ICTDIR/invisible_cities/config/isaura.conf'.split())
+    conf.update(dict(files_in      = PATH_IN ,
+                     file_out      = PATH_OUT))
+    isaura(**conf)
+
+    tables = ["Tracking/Tracks"    ,
+              "Summary/Events"     ,
+              "Run/events"         , "Run/runInfo"            ,
+              "MC/event_mapping"   , "MC/generators"          ,
+              "MC/hits"            ,  "MC/particles"          ,
+              "Filters/hits_select", "Filters/topology_select"]
+
+    with tb.open_file(PATH_OUT, mode="r") as h5out:
+        for table in tables:
+            assert hasattr(h5out.root, table)
+
+
+
+def test_isaura_empty_input_file(ICDATADIR, output_tmpdir):
+
+    PATH_IN  = os.path.join(ICDATADIR    , "empty_file.h5")
+    PATH_OUT = os.path.join(output_tmpdir, "empty_isaura.h5")
+    conf = configure('isaura $ICTDIR/invisible_cities/config/isaura.conf'.split())
+    conf.update(dict(files_in      = PATH_IN,
+                     file_out      = PATH_OUT,
+                     run_number    = 1,
+                     event_range   = all_events))
+    result = isaura(**conf)
+
+    assert result.events_in   == 0
+    assert result.evtnum_list == []
+
+def test_isaura_exact(ICDATADIR, output_tmpdir):
+
+    PATH_IN   = os.path.join(ICDATADIR    , "exact_Kr_deconvolution_with_MC.h5")
+    PATH_OUT  = os.path.join(output_tmpdir, "exact_tables.isaura.h5")
+    PATH_TRUE = os.path.join(ICDATADIR    , "exact_Kr_deco_tracks_with_MC.h5")
+    n_evts    = 5
+    conf = configure('isaura $ICTDIR/invisible_cities/config/isaura.conf'.split())
+    conf.update(dict(files_in      = PATH_IN ,
+                     file_out      = PATH_OUT,
+                     event_range   = n_evts  ))
+    np.random.seed(1234)
+    isaura(**conf)
+
+    tables = ["Tracking/Tracks"    ,
+              "Summary/Events"     ,
+              "Run/events"         , "Run/runInfo"            ,
+              "MC/event_mapping"   , "MC/generators"          ,
+              "MC/hits"            ,  "MC/particles"          ,
+              "Filters/hits_select", "Filters/topology_select"]
+
+    with tb.open_file(PATH_TRUE) as true_output_file:
+        with tb.open_file(PATH_OUT) as output_file:
+            for table in tables:
+                obtained = getattr(     output_file.root, table)
+                expected = getattr(true_output_file.root, table)
+                assert_tables_equality(obtained, expected)
+
+def test_isaura_conserves_energy(ICDATADIR, output_tmpdir):
+
+    PATH_IN  = os.path.join(ICDATADIR    , "exact_Kr_deconvolution_with_MC.h5")
+    PATH_OUT = os.path.join(output_tmpdir, "exact_tables.isaura.h5")
+    n_evts = 5
+    conf = configure('isaura $ICTDIR/invisible_cities/config/isaura.conf'.split())
+    conf.update(dict(files_in      = PATH_IN ,
+                     file_out      = PATH_OUT,
+                     event_range   = n_evts  ))
+    np.random.seed(1234)
+    isaura(**conf)
+
+    deco_hits   = load_dst(PATH_IN , 'DECO'    , 'Events')
+    deco_tracks = load_dst(PATH_OUT, 'Tracking', 'Tracks')
+    deco_events = load_dst(PATH_OUT, 'Summary' , 'Events')
+
+    deco_hits      = deco_hits[deco_hits.event.isin(range(n_evts))]
+    dhits_energy   = deco_hits  [['event', 'E'     ]].groupby(['event'])['E'     ].sum().values
+    dtracks_energy = deco_tracks[['event', 'energy']].groupby(['event'])['energy'].sum().values
+    devents_energy = deco_events.evt_energy.values
+
+    np.testing.assert_allclose(dhits_energy, dtracks_energy)
+    np.testing.assert_allclose(dhits_energy, devents_energy)

--- a/invisible_cities/config/isaura.conf
+++ b/invisible_cities/config/isaura.conf
@@ -1,0 +1,17 @@
+files_in = '$ICDIR/database/test_data/test_beersheba.h5'
+file_out = '/tmp/decoTopology.h5'
+compression = 'ZLIB4'
+event_range=1000
+# run number 0 is for MC
+run_number = 0
+
+# How frequently to print events
+print_mod = 100
+
+paolina_params      = dict(
+   vox_size         = [5 * mm, 5 * mm, 5 * mm],
+   strict_vox_size  = False,
+   energy_threshold = 10 * keV,
+   min_voxels       = 3,
+   blob_radius      = 18 * mm,
+   max_num_hits     = 10000)

--- a/invisible_cities/database/test_data/exact_Kr_deco_tracks_with_MC.h5
+++ b/invisible_cities/database/test_data/exact_Kr_deco_tracks_with_MC.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0a0c2c7a1491b7d7c90588d6acf8a182478ea882bac387e28972e4777672ace
+size 81884

--- a/invisible_cities/io/kdst_io.py
+++ b/invisible_cities/io/kdst_io.py
@@ -1,6 +1,8 @@
 from .  table_io import make_table
 from .. evm.nh5  import KrTable
 
+from .. io.dst_io import df_writer
+
 
 def kr_writer(hdf5_file, *, compression='ZLIB4'):
     kr_table = make_table(hdf5_file,
@@ -15,3 +17,18 @@ def kr_writer(hdf5_file, *, compression='ZLIB4'):
     def write_kr(kr_event):
         kr_event.store(kr_table)
     return write_kr
+
+
+def kdst_from_df_writer(h5out, compression='ZLIB4'):
+    """
+    For a given open table returns a writer for KDST dataframe info
+    """
+    def write_kdst(df):
+        return df_writer(h5out              = h5out        ,
+                         df                 = df           ,
+                         compression        = compression  ,
+                         group_name         = 'DST'        ,
+                         table_name         = 'Events'     ,
+                         descriptive_string = 'KDST Events',
+                         columns_to_index   = ['event']    )
+    return write_kdst

--- a/invisible_cities/types/ic_types.py
+++ b/invisible_cities/types/ic_types.py
@@ -1,4 +1,5 @@
-from enum     import Enum
+from enum        import Enum
+from collections import OrderedDict
 
 import numpy as np
 
@@ -107,3 +108,29 @@ class AutoNameEnumBase(Enum):
     """
     def _generate_next_value_(name, start, count, last_values):
         return name
+
+
+
+types_dict_summary = OrderedDict({'event'     : np.int32  , 'evt_energy' : np.float64, 'evt_charge'    : np.float64,
+                                  'evt_ntrks' : np.int    , 'evt_nhits'  : np.int    , 'evt_x_avg'     : np.float64,
+                                  'evt_y_avg' : np.float64, 'evt_z_avg'  : np.float64, 'evt_r_avg'     : np.float64,
+                                  'evt_x_min' : np.float64, 'evt_y_min'  : np.float64, 'evt_z_min'     : np.float64,
+                                  'evt_r_min' : np.float64, 'evt_x_max'  : np.float64, 'evt_y_max'     : np.float64,
+                                  'evt_z_max' : np.float64, 'evt_r_max'  : np.float64, 'evt_out_of_map': bool      })
+
+
+
+
+types_dict_tracks = OrderedDict({'event'           : np.int32  , 'trackID'       : np.int    , 'energy'      : np.float64,
+                                 'length'          : np.float64, 'numb_of_voxels': np.int    , 'numb_of_hits': np.int    ,
+                                 'numb_of_tracks'  : np.int    , 'x_min'         : np.float64, 'y_min'       : np.float64,
+                                 'z_min'           : np.float64, 'r_min'         : np.float64, 'x_max'       : np.float64,
+                                 'y_max'           : np.float64, 'z_max'         : np.float64, 'r_max'       : np.float64,
+                                 'x_ave'           : np.float64, 'y_ave'         : np.float64, 'z_ave'       : np.float64,
+                                 'r_ave'           : np.float64, 'extreme1_x'    : np.float64, 'extreme1_y'  : np.float64,
+                                 'extreme1_z'      : np.float64, 'extreme2_x'    : np.float64, 'extreme2_y'  : np.float64,
+                                 'extreme2_z'      : np.float64, 'blob1_x'       : np.float64, 'blob1_y'     : np.float64,
+                                 'blob1_z'         : np.float64, 'blob2_x'       : np.float64, 'blob2_y'     : np.float64,
+                                 'blob2_z'         : np.float64, 'eblob1'        : np.float64, 'eblob2'      : np.float64,
+                                 'ovlp_blob_energy': np.float64,
+                                 'vox_size_x'      : np.float64, 'vox_size_y'    : np.float64, 'vox_size_z'  : np.float64})


### PR DESCRIPTION
According to issue #749, the aim of this PR is to add a city (to be run just after Beersheba, for the moment), that computes all the tracking information. Since the tracking-related functions will be shared between Esmeralda and this new city (so-called Isaura (credits to @jjgomezcadenas)), they will be moved to other places (`components.py`, in most of the cases).

There are two issues that I faced while doing the city. The first one was already pointed out in #749, and it is related to the kdst information. It would be interesting that the output of this tracking city contains kdst information (`nS2` variable is used for the posterior analysis), however current `Beersheba` version doesn't save this table. Therefore, for the time being, we can access to this information just opening the `cdst` files, although I believe that in the near futurue we should add this table in `Beersheba` and then in `Isaura`.
The second issue concerns the tracking algorithm. As you may know, it seems that `Paolina`, and particularly `reco/paolina_functions/find_extrema()` funcion is not deterministic. This is because in some events there are more than one possible extreme voxels for a given track, and it appear that in those cases they are chosen randomly. The solution that I propose (and add here, in order to check that the output was correct -event though maybe this is not the place to do it-) consists in save all the possibilities, and then choose the extreme where the sum of their energy takes the maximum value (in order to avoid, if possible, the usage of `paolina_functions/drop_end_point_voxels()` function). Nonetheless, there would be other solutions, but the choice of one or another will be a bit arbitrary at the end, in my opinion.