### PR TITLE
Update NEWDB

### DIFF
--- a/invisible_cities/database/localdb.NEWDB.sqlite3
+++ b/invisible_cities/database/localdb.NEWDB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9eab29680aa3a0f44a8f47b24b6cdd327a30da46d7b447f7775dfac486b2091b
-size 422776832
+oid sha256:d3919b30167bcd925bf0aeb519859e5452ad0b7ae34def1c31620b23041dd93f
+size 443146240


### PR DESCRIPTION
NEWDB has been updated according to the last sensor calibration. PMT gains, SiPMs gains and pdfs have been added from run 8293.

Pedestal sigma for PMT9 seems to be decreased and it's under study, but it doesn't affect the calibration constants.

Comparison with previous runs are attached.

![pmt_comparison](https://user-images.githubusercontent.com/32193826/101776780-c4e7ff80-3af1-11eb-81e3-28d3c042e77e.png)

![sipmRunDifferencePlots_test](https://user-images.githubusercontent.com/32193826/101776816-d5987580-3af1-11eb-822f-be1fc4eac7e1.png)
