### PR TITLE
Generate MC timestamp

### DIFF
--- a/invisible_cities/cities/buffy.py
+++ b/invisible_cities/cities/buffy.py
@@ -45,7 +45,7 @@ from .  components import                  wf_binner
 @city
 def buffy(files_in     , file_out   , compression      , event_range,
           print_mod    , detector_db, run_number       , max_time   ,
-          buffer_length, pre_trigger, trigger_threshold):
+          buffer_length, pre_trigger, trigger_threshold, rate       ):
 
     npmt, nsipm       = get_n_sensors(detector_db, run_number)
     pmt_wid, sipm_wid = pmt_and_sipm_bin_width_safe_(files_in)
@@ -100,7 +100,8 @@ def buffy(files_in     , file_out   , compression      , event_range,
 
         result = fl.push(source = mcsensors_from_file(files_in   ,
                                                       detector_db,
-                                                      run_number )           ,
+                                                      run_number ,
+                                                      rate       )           ,
                          pipe   = fl.pipe(fl.slice(*event_range  ,
                                                    close_all=True)      ,
                                           event_count_in.spy            ,

--- a/invisible_cities/cities/buffy_test.py
+++ b/invisible_cities/cities/buffy_test.py
@@ -100,6 +100,8 @@ def test_buffy_filters_empty(config_tmpdir, ICDATADIR):
 
 
 def test_buffy_exact_result(config_tmpdir, ICDATADIR):
+    np.random.seed(27)
+
     file_in     = os.path.join(ICDATADIR                              ,
                                'nexus_new_kr83m_full.newformat.sim.h5')
     file_out    = os.path.join(config_tmpdir, 'exact_result.buffers.h5')

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -211,8 +211,9 @@ def test_copy_mc_info_split_nexus_events(ICDATADIR, config_tmpdir):
 
 
 def test_mcsensors_from_file_fast_returns_empty(ICDATADIR):
+    rate = 0.5
     file_in = os.path.join(ICDATADIR, "nexus_new_kr83m_fast.newformat.sim.h5")
-    sns_gen = mcsensors_from_file([file_in], 'new', -7951)
+    sns_gen = mcsensors_from_file([file_in], 'new', -7951, rate)
     with warns(UserWarning, match='No binning info available.'):
         first_evt = next(sns_gen)
     assert first_evt[ 'pmt_resp'].empty
@@ -221,7 +222,7 @@ def test_mcsensors_from_file_fast_returns_empty(ICDATADIR):
 
 def test_mcsensors_from_file_correct_yield(ICDATADIR):
     evt_no         =    0
-    timestamp      =    0
+    rate           =    0.5
     npmts_hit      =   12
     total_pmthits  = 4303
     nsipms_hit     =  313
@@ -229,13 +230,13 @@ def test_mcsensors_from_file_correct_yield(ICDATADIR):
     keys           = ['event_number', 'timestamp', 'pmt_resp' , 'sipm_resp']
 
     file_in   = os.path.join(ICDATADIR, "nexus_new_kr83m_full.newformat.sim.h5")
-    sns_gen   = mcsensors_from_file([file_in], 'new', -7951)
+    sns_gen   = mcsensors_from_file([file_in], 'new', -7951, rate)
     first_evt = next(sns_gen)
 
     assert set(keys) == set(first_evt.keys())
 
     assert      first_evt['event_number']                 == evt_no
-    assert      first_evt[   'timestamp']                 == timestamp
+    assert      first_evt[   'timestamp']                 >= evt_no / rate
     assert type(first_evt[    'pmt_resp'])                == pd.DataFrame
     assert type(first_evt[   'sipm_resp'])                == pd.DataFrame
     assert  len(first_evt[    'pmt_resp'].index.unique()) == npmts_hit

--- a/invisible_cities/config/buffy.conf
+++ b/invisible_cities/config/buffy.conf
@@ -15,3 +15,5 @@ max_time          =  10 * ms
 buffer_length     = 800 * mus
 pre_trigger       = 100 * mus
 trigger_threshold =   0
+
+rate              =   0.5 * hertz

--- a/invisible_cities/database/test_data/nexus_new_kr83m_full.newformat.buffers.h5
+++ b/invisible_cities/database/test_data/nexus_new_kr83m_full.newformat.buffers.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c069eb6999ee9ef3e70c13d8c9eb077561517ec8e63f033deb4b2f8c7fd71eb0
-size 140542
+oid sha256:69d38f2d206f51c8dca4a554a9cc6077123c28975e628e82916d16c65fa13b48
+size 140548

--- a/invisible_cities/detsim/sensor_utils.py
+++ b/invisible_cities/detsim/sensor_utils.py
@@ -5,10 +5,37 @@ import pandas as pd
 from typing import Callable
 from typing import     List
 from typing import    Tuple
+from typing import    Union
+
+from .. core import system_of_units as units
 
 from .. database.load_db   import            DataPMT
 from .. database.load_db   import           DataSiPM
 from .. io      .mcinfo_io import get_sensor_binning
+
+
+def create_timestamp(event_number: Union[int, float],
+                     rate        :            float ) -> float:
+    """
+    Calculates timestamp for a given Event Number and Rate.
+
+    Parameters
+    ----------
+    event_number : Union[int, float]
+                   ID value of the current event.
+    rate         : float
+                   Value of the rate.
+
+    Returns
+    -------
+    Calculated timestamp : float
+    """
+    try:
+        period = 1 / rate
+        timestamp = abs(event_number * period) + np.random.uniform(0, period)
+    except ZeroDivisionError:
+        timestamp = event_number * 1 * units.ms
+    return timestamp
 
 
 def trigger_times(trigger_indx: List[int] ,

--- a/invisible_cities/detsim/sensor_utils_test.py
+++ b/invisible_cities/detsim/sensor_utils_test.py
@@ -11,6 +11,7 @@ from . sensor_utils import          get_n_sensors
 from . sensor_utils import           sensor_order
 from . sensor_utils import pmt_and_sipm_bin_width
 from . sensor_utils import          trigger_times
+from . sensor_utils import       create_timestamp
 
 
 def test_trigger_times():
@@ -97,3 +98,20 @@ def test_pmt_and_sipm_bin_width(full_sim_file):
     pmt_binwid, sipm_binwid = pmt_and_sipm_bin_width(file_in)
     assert pmt_binwid  == expected_pmtwid
     assert sipm_binwid == expected_sipmwid
+
+
+def test_create_timestamp_greater_with_greater_eventnumber():
+    """
+    Value of timestamp must be always positive and 
+    greater with greater event numbers.
+    """
+    evt_no_1 = 10
+    rate_1   = 0.5
+    evt_no_2 = 100
+    rate_2   = 0.6
+
+    timestamp_1 = create_timestamp(evt_no_1, rate_1)
+    timestamp_2 = create_timestamp(evt_no_2, rate_2)
+    assert abs(timestamp_1) == timestamp_1
+    assert timestamp_1      <  timestamp_2
+    assert abs(timestamp_2) == timestamp_2


### PR DESCRIPTION
With the intention of adding a function that generates timestamps, this push is presented with the following changes:

- Updated `sensor_utils.py` with the create_timestamp function.
- Added `test_create_timestamp_greater_with_greater_arguments` to `sensor_utils_test.py` with the intention of testing whether with larger parameters said timestamp is greater.
- Updated `buffy.conf`, `buffy.py` and `components.py` to implement the function `create_timestamp`.

Fixes #752