### PR TITLE
Update PMT xpos in DEMOPPDB

### DIFF
--- a/invisible_cities/database/localdb.DEMOPPDB.sqlite3
+++ b/invisible_cities/database/localdb.DEMOPPDB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:245f25b7b874a6996041ee0cfd93e8b47abaef767e0728462f6f35c3987bbed0
+oid sha256:5d6cff5c4729e09cba32e037b9d76bf0ed5ff6f7ed619f7b9c90304a4b891e9b
 size 8167424


### PR DESCRIPTION
DEMO++ database has been updated with the x values of the PMTs. The three of them have been changed adding a `-`:

- `PMT2` --> `x_old = 41.14mm`, `x_new = -41.14mm`

- `PMT4` --> `x_old = -69.62mm`, `x_new = 69.62mm`

- `PMT3` --> `x_old = 28.47mm`, `x_new = -28.47mm`