### PR TITLE
Detsim city flow

### DIFF
--- a/invisible_cities/cities/detsim.py
+++ b/invisible_cities/cities/detsim.py
@@ -1,0 +1,225 @@
+"""
+-----------------------------------------------------------------------
+                              Detsim
+-----------------------------------------------------------------------
+From Detector Simulation. This city reads energy deposits (hits) and simulates
+S1 and S2 signals. This is accomplished using light tables to compute the signal
+generated in the sensors. The input of this city is nexus output containing hits.
+This city outputs:
+    - pmtrd : PMT  waveforms
+    - sipmrd: SIPM waveforms
+    - MC  info
+    - Run info
+    - Filters
+"""
+
+import os
+import numpy  as np
+import tables as tb
+
+from . components import city
+from . components import print_every
+from . components import copy_mc_info
+from . components import collect
+from . components import calculate_and_save_buffers
+from . components import MC_hits_from_files
+
+from .. reco     import tbl_functions as tbl
+from .. database import load_db       as db
+from .. dataflow import dataflow      as fl
+
+from .. io.event_filter_io  import event_filter_writer
+
+from .. detsim.simulate_electrons import generate_ionization_electrons
+from .. detsim.simulate_electrons import drift_electrons
+from .. detsim.simulate_electrons import diffuse_electrons
+from .. detsim.light_tables_c     import LT_SiPM
+from .. detsim.light_tables_c     import LT_PMT
+from .. detsim.s2_waveforms_c     import create_wfs
+from .. detsim.detsim_waveforms   import s1_waveforms_creator
+
+
+def hits_selector(active_only: bool=True):
+    """
+    Filtering function that selects hits. (see :active_only: description)
+
+    Parameters:
+        :active_only: bool
+            if True, returns hits in ACTIVE
+            if False, returns hits in ACTIVE and BUFFER
+    Returns:
+        :select_hits: Callable
+            function that select the hits depending on :active_only: parameter
+    """
+    def select_hits(x, y, z, energy, time, label):
+        sel = (label == "ACTIVE")
+        if not active_only:
+            sel =  sel | (label == "BUFFER")
+        return x[sel], y[sel], z[sel], energy[sel], time[sel], label[sel]
+    return select_hits
+
+
+def ielectron_simulator(*, wi: float, fano_factor: float, lifetime: float,
+                        transverse_diffusion: float, longitudinal_diffusion: float, drift_velocity:float,
+                        el_gain: float, conde_policarpo_factor: float):
+    """
+    Function that simulates electron creation, drift, diffusion and photon generation at the EL
+
+    Parameters: floats
+        parameter names are self-descriptive.
+    Returns:
+        :simulate_ielectrons:
+            function that returns the positions emission times and number of photons at the EL
+    """
+    def simulate_ielectrons(x, y, z, time, energy):
+        nelectrons = generate_ionization_electrons(energy, wi, fano_factor)
+        nelectrons = drift_electrons(z, nelectrons, lifetime, drift_velocity)
+        dx, dy, dz = diffuse_electrons(x, y, z, nelectrons, transverse_diffusion, longitudinal_diffusion)
+        dtimes = dz/drift_velocity + np.repeat(time, nelectrons)
+        nphotons = np.random.normal(el_gain, np.sqrt(el_gain * conde_policarpo_factor), size=nelectrons.sum())
+        nphotons = np.round(nphotons).astype(np.int32)
+        return dx, dy, dz, dtimes, nphotons
+    return simulate_ielectrons
+
+
+def buffer_times_and_length_getter(pmt_width, sipm_width, el_gap, el_dv, max_length):
+    """
+    Auxiliar function that computes the signal absolute starting-time and an estimated buffer_length
+    """
+    max_sensor_bin = max(pmt_width, sipm_width)
+    def get_buffer_times_and_length(time, times_ph):
+        start_time = np.floor(min(time) / max_sensor_bin) * max_sensor_bin
+        el_traverse_time = el_gap / el_dv
+        end_time   = np.ceil((max(times_ph) + el_traverse_time)/max_sensor_bin) * max_sensor_bin
+        buffer_length = min(max_length, end_time-start_time)
+        return start_time, buffer_length
+    return get_buffer_times_and_length
+
+
+def s2_waveform_creator(sns_bin_width, LT, el_drift_velocity):
+    """
+    Same function as create_wfs in module detsim.s2_waveforms_c with poissonization.
+    See description of the refered function for more details.
+    """
+    def create_s2_waveform(xs, ys, ts, phs, tmin, buffer_length):
+        waveforms = create_wfs(xs, ys, ts, phs, LT, el_drift_velocity, sns_bin_width, buffer_length, tmin)
+        return np.random.poisson(waveforms)
+    return create_s2_waveform
+
+
+def bin_edges_getter(pmt_width, sipm_width):
+    """
+    Auxiliar function that returns the waveform bin edges
+    """
+    def get_bin_edges(pmt_wfs, sipm_wfs):
+        pmt_bins  = np.arange(0, pmt_wfs .shape[1]) * pmt_width
+        sipm_bins = np.arange(0, sipm_wfs.shape[1]) * sipm_width
+        return pmt_bins, sipm_bins
+    return get_bin_edges
+
+
+@city
+def detsim(*, files_in, file_out, event_range, print_mod, compression,
+           detector_db, run_number, s1_lighttable, s2_lighttable, sipm_psf,
+           buffer_params, physics_params):
+
+    physics_params_ = physics_params.copy()
+
+    ws    = physics_params_.pop("ws")
+    el_dv = physics_params_.pop("el_drift_velocity")
+
+    # derived parameters
+    datapmt  = db.DataPMT (detector_db, run_number)
+    datasipm = db.DataSiPM(detector_db, run_number)
+    lt_pmt   = LT_PMT (fname=os.path.expandvars(s2_lighttable))
+    lt_sipm  = LT_SiPM(fname=os.path.expandvars(sipm_psf), sipm_database=datasipm)
+    el_gap   = lt_sipm.el_gap_width
+
+    select_s1_candidate_hits = fl.map(hits_selector(False),
+                                item = ('x', 'y', 'z', 'energy', 'time', 'label'))
+
+    select_active_hits = fl.map(hits_selector(True),
+                                args = ('x', 'y', 'z', 'energy', 'time', 'label'),
+                                out = ('x_a', 'y_a', 'z_a', 'energy_a', 'time_a', 'labels_a'))
+
+    filter_events_no_active_hits = fl.map(lambda x:np.any(x),
+                                          args= 'energy_a',
+                                          out = 'passed')
+    events_passed_active_hits = fl.count_filter(bool, args='passed')
+
+    simulate_electrons = fl.map(ielectron_simulator(**physics_params_),
+                                args = ('x_a', 'y_a', 'z_a', 'time_a', 'energy_a'),
+                                out  = ('x_ph', 'y_ph', 'z_ph', 'times_ph', 'nphotons'))
+
+    get_buffer_info = buffer_times_and_length_getter(buffer_params["pmt_width"],
+                                                     buffer_params["sipm_width"],
+                                                     el_gap, el_dv,
+                                                     buffer_params["max_time"])
+    get_buffer_times_and_length = fl.map(get_buffer_info,
+                                         args = ('time', 'times_ph'),
+                                         out = ('tmin', 'buffer_length'))
+
+    create_pmt_s1_waveforms = fl.map(s1_waveforms_creator(s1_lighttable, ws, buffer_params["pmt_width"]),
+                                     args = ('x_a', 'y_a', 'z_a', 'time_a', 'energy_a', 'tmin', 'buffer_length'),
+                                     out = 's1_pmt_waveforms')
+
+    create_pmt_s2_waveforms = fl.map(s2_waveform_creator(buffer_params["pmt_width"], lt_pmt, el_dv),
+                                     args = ('x_ph', 'y_ph', 'times_ph', 'nphotons', 'tmin', 'buffer_length'),
+                                     out = 's2_pmt_waveforms')
+
+    sum_pmt_waveforms = fl.map(lambda x, y : x+y,
+                               args = ('s1_pmt_waveforms', 's2_pmt_waveforms'),
+                               out = 'pmt_bin_wfs')
+
+    create_pmt_waveforms = fl.pipe(create_pmt_s1_waveforms, create_pmt_s2_waveforms, sum_pmt_waveforms)
+
+    create_sipm_waveforms = fl.map(s2_waveform_creator(buffer_params["sipm_width"], lt_sipm, el_dv),
+                                   args = ('x_ph', 'y_ph', 'times_ph', 'nphotons', 'tmin', 'buffer_length'),
+                                   out = 'sipm_bin_wfs')
+
+    get_bin_edges  = fl.map(bin_edges_getter(buffer_params["pmt_width"], buffer_params["sipm_width"]),
+                            args = ('pmt_bin_wfs', 'sipm_bin_wfs'),
+                            out = ('pmt_bins', 'sipm_bins'))
+
+    event_count_in = fl.spy_count()
+    evtnum_collect = collect()
+
+    with tb.open_file(file_out, "w", filters = tbl.filters(compression)) as h5out:
+        buffer_calculation = calculate_and_save_buffers(buffer_params["length"]     ,
+                                                        buffer_params["max_time"]   ,
+                                                        buffer_params["pre_trigger"],
+                                                        buffer_params["pmt_width"]  ,
+                                                        buffer_params["sipm_width"] ,
+                                                        buffer_params["trigger_thr"],
+                                                        h5out        ,
+                                                        run_number   ,
+                                                        len(datapmt) ,
+                                                        len(datasipm),
+                                                        int(buffer_params["length"] / buffer_params["pmt_width"]),
+                                                        int(buffer_params["length"] / buffer_params["sipm_width"]))
+
+        write_nohits_filter = fl.sink(event_filter_writer(h5out, "active_hits")   , args=("event_number", "passed"))
+        result = fl.push(source= MC_hits_from_files(files_in),
+                         pipe  = fl.pipe(fl.slice(*event_range, close_all=True),
+                                         event_count_in.spy    ,
+                                         print_every(print_mod),
+                                         select_s1_candidate_hits,
+                                         select_active_hits,
+                                         filter_events_no_active_hits,
+                                         fl.branch(write_nohits_filter),
+                                         events_passed_active_hits.filter,
+                                         simulate_electrons,
+                                         get_buffer_times_and_length,
+                                         create_pmt_waveforms,
+                                         create_sipm_waveforms,
+                                         get_bin_edges,
+                                         fl.branch("event_number"     ,
+                                                   evtnum_collect.sink),
+                                         buffer_calculation),
+                         result = dict(events_in     = event_count_in.future,
+                                       evtnum_list   = evtnum_collect.future))
+
+        copy_mc_info(files_in, h5out, result.evtnum_list,
+                     detector_db, run_number)
+
+        return result

--- a/invisible_cities/cities/detsim_test.py
+++ b/invisible_cities/cities/detsim_test.py
@@ -1,0 +1,221 @@
+import os
+import shutil
+import numpy  as np
+import pandas as pd
+import tables as tb
+
+from .. cities.detsim  import detsim
+from .. core           import system_of_units as units
+from .. core.configure import configure
+from .. core.configure import all             as all_events
+from .. io.dst_io      import load_dst
+
+from .. core.testing_utils   import assert_tables_equality
+
+
+def test_detsim_contains_all_tables(ICDATADIR, output_tmpdir):
+
+    PATH_IN  = os.path.join(ICDATADIR    , "nexus_new_kr83m_fast.newformat.sim.h5")
+    PATH_OUT = os.path.join(output_tmpdir, "detsim_test.h5")
+    conf = configure('detsim $ICTDIR/invisible_cities/config/detsim.conf'.split())
+    conf.update(dict(files_in      = PATH_IN,
+                     file_out      = PATH_OUT,
+                     run_number    = 0,
+                     event_range   = (0, 1)))
+    result = detsim(**conf)
+    buffer_params = conf["buffer_params"]
+
+    with tb.open_file(PATH_OUT, mode="r") as h5out:
+        assert hasattr(h5out.root,                  'MC')
+        assert hasattr(h5out.root,                 'Run')
+        assert hasattr(h5out.root,               'pmtrd')
+        assert hasattr(h5out.root,              'sipmrd')
+        assert hasattr(h5out.root, 'Filters/active_hits')
+
+        pmtrd  = h5out.root.pmtrd
+        sipmrd = h5out.root.sipmrd
+
+        n_pmt  = int(buffer_params["length"] / buffer_params["pmt_width"] )
+        n_sipm = int(buffer_params["length"] / buffer_params["sipm_width"])
+        assert pmtrd .shape == (1,   12, n_pmt)
+        assert sipmrd.shape == (1, 1792, n_sipm)
+
+
+def test_detsim_filter_active_hits(ICDATADIR, output_tmpdir):
+    # the first event in test file labels are set to NO_ACTIVE
+    PATH_IN  = os.path.join(ICDATADIR    , "nexus_new_kr83m_fast.newformat.sim.noactive.h5")
+    PATH_OUT = os.path.join(output_tmpdir, "detsim_test.h5")
+    conf = configure('detsim $ICTDIR/invisible_cities/config/detsim.conf'.split())
+    conf.update(dict(files_in    = PATH_IN,
+                     file_out    = PATH_OUT,
+                     run_number  = 0))
+    result = detsim(**conf)
+
+    assert result.events_in   == 2
+    assert result.evtnum_list == [1]
+
+    with tb.open_file(PATH_OUT, mode="r") as h5out:
+        filters = h5out.root.Filters.active_hits.read()
+        np.testing.assert_array_equal(filters["passed"], [False, True])
+
+
+def test_detsim_empty_input_file(ICDATADIR, output_tmpdir):
+
+    PATH_IN  = os.path.join(ICDATADIR    , "empty_mcfile.h5")
+    PATH_OUT = os.path.join(output_tmpdir, "detsim_test.h5")
+    conf = configure('detsim $ICTDIR/invisible_cities/config/detsim.conf'.split())
+    conf.update(dict(files_in    = PATH_IN,
+                     file_out    = PATH_OUT,
+                     run_number  = 0))
+    result = detsim(**conf)
+
+    assert result.events_in   == 0
+    assert result.evtnum_list == []
+
+
+def test_detsim_exact(ICDATADIR, output_tmpdir):
+
+    PATH_IN   = os.path.join(ICDATADIR    , "nexus_new_kr83m_fast.newformat.sim.h5")
+    PATH_OUT  = os.path.join(output_tmpdir, "detsim_test.h5")
+    PATH_TRUE = os.path.join(ICDATADIR    , "detsim_new_kr83m_fast.newformat.sim.h5")
+    conf = configure('detsim $ICTDIR/invisible_cities/config/detsim.conf'.split())
+    conf.update(dict(files_in      = PATH_IN,
+                     file_out      = PATH_OUT,
+                     run_number    = 0,
+                     event_range   = all_events,
+                     buffer_params = dict(length      = 800 * units.mus,
+                                          pmt_width   = 100 * units.ns ,
+                                          sipm_width  =   1 * units.mus,
+                                          max_time    =  10 * units.ms ,
+                                          pre_trigger = 100 * units.mus,
+                                          trigger_thr = 0)))
+    np.random.seed(1234)
+    result = detsim(**conf)
+
+    tables = ["pmtrd", "sipmrd",
+              "Run/eventMap", "Run/events", "Run/runInfo",
+              "MC/configuration", "MC/event_mapping", "MC/hits",
+              "MC/particles", "MC/sns_positions", "MC/sns_response",
+              "Filters/active_hits"]
+
+    with tb.open_file(PATH_TRUE) as true_output_file:
+        with tb.open_file(PATH_OUT) as output_file:
+            for table in tables:
+                assert hasattr(output_file.root, table)
+                got      = getattr(     output_file.root, table)
+                expected = getattr(true_output_file.root, table)
+                assert_tables_equality(got, expected)
+
+
+def test_detsim_exact_time_translation(ICDATADIR, output_tmpdir):
+
+    PATH_IN   = os.path.join(ICDATADIR    , "nexus_new_kr83m_fast.newformat.sim.h5")
+    PATH_OUT  = os.path.join(output_tmpdir, "detsim_test.h5")
+    # modified input file: time --> time + 10 micro-seconds
+    modified_testfile = os.path.join(ICDATADIR, "nexus_new_kr83m_fast.newformat.sim.time10mus.h5")
+
+    # run over test file
+    conf = configure('detsim $ICTDIR/invisible_cities/config/detsim.conf'.split())
+    conf.update(dict(files_in      = PATH_IN,
+                     file_out      = PATH_OUT,
+                     run_number    = 0,
+                     event_range   = all_events))
+    np.random.seed(1234)
+    result = detsim(**conf)
+
+    # run over modified file
+    modified_file_out = os.path.join(output_tmpdir, "detsim_test_modified.h5")
+    conf = configure('detsim $ICTDIR/invisible_cities/config/detsim.conf'.split())
+    conf.update(dict(files_in      = modified_testfile,
+                     file_out      = modified_file_out,
+                     run_number    = 0,
+                     event_range   = all_events))
+    np.random.seed(1234)
+    result = detsim(**conf)
+
+    tables = ["pmtrd", "sipmrd",
+              "Run/eventMap", "Run/events", "Run/runInfo",
+              "MC/configuration", "MC/event_mapping", #"MC/hits", note that MC/hits are different
+              "MC/particles", "MC/sns_positions", "MC/sns_response",
+              "Filters/active_hits"]
+
+    with tb.open_file(PATH_OUT) as output_file:
+        with tb.open_file(modified_file_out) as modified_output_file:
+            for table in tables:
+                assert hasattr(output_file.root, table)
+                got      = getattr( modified_output_file.root, table)
+                expected = getattr(          output_file.root, table)
+                assert_tables_equality(got, expected)
+
+
+def test_detsim_buffer_times(ICDATADIR, output_tmpdir):
+    """This test checks that the signal is properly placed in the buffer.
+    In particular:
+      - the S1 start time is positioned at pretrigger
+      - the S2 start time is positioned at pretrigger + min(time + Z/dv)
+      - the S2   end time is positioned at pretrigger + max(time + Z/dv)
+    This can only be tested with nulls longinutinal diffusion and el_drift_velocity.
+    To simplify the S2 search, we assume that it is beyond 2 micro-seconds from S1,
+    then we must use an event at Z drift larger than that.
+    """
+
+    PATH_IN   = os.path.join(ICDATADIR    , "nexus_new_kr83m_fast.newformat.sim.h5")
+    PATH_OUT  = os.path.join(output_tmpdir, "detsim_test.h5")
+
+    # run over test file
+    conf = configure('detsim $ICTDIR/invisible_cities/config/detsim.conf'.split())
+    physics_params = conf["physics_params"]
+    physics_params["longitudinal_diffusion"] = 0       * units.mm / units.cm**0.5
+    physics_params["el_drift_velocity"]      = 1000000 * units.mm / units.mus
+    # take second event because it has a relatively large Z
+    conf.update(dict(files_in      = PATH_IN,
+                     file_out      = PATH_OUT,
+                     run_number    = 0,
+                     event_range   = (1, 2),
+                     physics_params= physics_params))
+    result = detsim(**conf)
+
+    buffer_params = conf["buffer_params"]
+    # compute max signal time
+    hits = load_dst(PATH_IN, "MC", "hits")
+    hits = hits[hits["event_id"]==1]
+    z, time  = hits.z.values, hits.time.values
+    s2_times = z/physics_params["drift_velocity"] + time
+
+    s2_tmin = min(s2_times) + buffer_params["pre_trigger"]
+    s2_tmax = max(s2_times) + buffer_params["pre_trigger"]
+
+    with tb.open_file(PATH_OUT) as h5out:
+        pmtwf  = h5out.root.pmtrd .read()[0].sum(axis=0)
+        sipmwf = h5out.root.sipmrd.read()[0].sum(axis=0)
+
+    pmt_signal_bins  = np.argwhere(pmtwf >0).flatten()
+    sipm_signal_bins = np.argwhere(sipmwf>0).flatten()
+
+    # PMTs
+    # start s1 time
+    tstart = pmt_signal_bins[0]*buffer_params["pmt_width"]
+    assert tstart == buffer_params["pre_trigger"]
+
+    # search S2, assume that it is above pretrigger + 2 micro-s
+    pre_idx = np.floor(buffer_params["pre_trigger"]/buffer_params["pmt_width"])
+    s2_init = pre_idx + np.floor(2*units.mus/buffer_params["pmt_width"])
+    s2_bins = pmt_signal_bins[pmt_signal_bins>s2_init]
+
+    tstart = s2_bins[0]  * buffer_params["pmt_width"]
+    tend   = s2_bins[-1] * buffer_params["pmt_width"]
+
+    assert tstart == np.floor(s2_tmin / buffer_params["pmt_width"]) * buffer_params["pmt_width"]
+    assert tend   == np.floor(s2_tmax / buffer_params["pmt_width"]) * buffer_params["pmt_width"]
+
+    # SIPMs
+    # search S2, assume that it is above pretrigger + 2 micro-s
+    pre_idx = np.floor(buffer_params["pre_trigger"]/buffer_params["sipm_width"])
+    s2_init = pre_idx + np.floor(2*units.mus/buffer_params["sipm_width"])
+    s2_bins = sipm_signal_bins[sipm_signal_bins>s2_init]
+
+    tstart = s2_bins[0]  * buffer_params["sipm_width"]
+    tend   = s2_bins[-1] * buffer_params["sipm_width"]
+
+    assert tstart == np.floor(s2_tmin / buffer_params["sipm_width"]) * buffer_params["sipm_width"]
+    assert tend   == np.floor(s2_tmax / buffer_params["sipm_width"]) * buffer_params["sipm_width"]

--- a/invisible_cities/config/detsim.conf
+++ b/invisible_cities/config/detsim.conf
@@ -1,0 +1,36 @@
+files_in = "$ICDIR/database/test_data/nexus_new_kr83m_fast.newformat.sim.h5"
+file_out = "/tmp/detsim_out.h5"
+
+event_range = all
+
+detector_db = "new"
+run_number = 0
+
+s1_lighttable = "$ICDIR/database/test_data/NEXT_NEW.energy.S1.PmtR11410.LightTable.h5"
+s2_lighttable = "$ICDIR/database/test_data/NEXT_NEW.energy.S2.PmtR11410.LightTable.h5"
+sipm_psf      = "$ICDIR/database/test_data/NEXT_NEW.tracking.S2.SiPM.LightTable.h5"
+
+physics_params = dict(ws = 39.2 * eV,
+                      wi = 22.4 * eV,
+                      fano_factor = 0.15,
+                      conde_policarpo_factor = 1.00,
+                      drift_velocity         = 1.00 * mm / mus,
+                      lifetime               = 12 * ms,
+                      transverse_diffusion   = 1.20 * mm / cm**0.5,
+                      longitudinal_diffusion = 0.30 * mm / cm**0.5,
+                      el_gain                = 365,
+                      el_drift_velocity      = 2.5 * mm / mus)
+
+
+buffer_params = dict(pmt_width   = 100 * ns,
+                     sipm_width  =   1 * mus,
+                     max_time    =  10 * ms,
+                     length      = 800 * mus,
+                     pre_trigger = 100 * mus,
+                     trigger_thr =   0)
+
+# compression library
+compression = "ZLIB4"
+
+# How frequently to print events
+print_mod = 1

--- a/invisible_cities/database/test_data/detsim_new_kr83m_fast.newformat.sim.h5
+++ b/invisible_cities/database/test_data/detsim_new_kr83m_fast.newformat.sim.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5a32705bb22ba9811d1ff625e182a2cc54e1fa13ee4c13d9220c10f73aacf3c
+size 54677

--- a/invisible_cities/database/test_data/empty_mcfile.h5
+++ b/invisible_cities/database/test_data/empty_mcfile.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4bbbeeb604d5cf3a57c655070ccea3f1f973924ed27cbf50389dc2ac6c9e26e1
+size 63458

--- a/invisible_cities/database/test_data/nexus_new_kr83m_fast.newformat.sim.noactive.h5
+++ b/invisible_cities/database/test_data/nexus_new_kr83m_fast.newformat.sim.noactive.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c8e0d0050102e5277eec28469151436735c33e38ffbbc56851c8623e7448183
+size 68411

--- a/invisible_cities/database/test_data/nexus_new_kr83m_fast.newformat.sim.time10mus.h5
+++ b/invisible_cities/database/test_data/nexus_new_kr83m_fast.newformat.sim.time10mus.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e6901ed2f94f76947c23c268883b5c6e522823a7dbf08ca0eaa6df20047b82c
+size 63458


### PR DESCRIPTION
This is the last of the series of PRs #757 #756 #695  #694.

It contains detsim city flow module that performs a fast detector simulation.

From MC hits, it simulates inonization electron creation, drift and diffusion. Then it simulates the photon propagation based on previously computed light-tables, which depend on detector geometry. The final output are the signal waveforms at sensors (without electronic simulation).