### PR TITLE
Update demopp database

### DIFF
--- a/invisible_cities/database/localdb.DEMOPPDB.sqlite3
+++ b/invisible_cities/database/localdb.DEMOPPDB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:245f25b7b874a6996041ee0cfd93e8b47abaef767e0728462f6f35c3987bbed0
+oid sha256:05abc6065f5c24a0064cddd31059515d17ac1fbf396b4a6f8f7de58122ede7ee
 size 8167424

--- a/invisible_cities/database/localdb.DEMOPPDB.sqlite3
+++ b/invisible_cities/database/localdb.DEMOPPDB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:05abc6065f5c24a0064cddd31059515d17ac1fbf396b4a6f8f7de58122ede7ee
-size 8167424
+oid sha256:cef851f580a503ad4391980ceb4536def3aed0c17abb2f0bb6b3bca303b2d3a9
+size 8179712

--- a/invisible_cities/database/localdb.DEMOPPDB.sqlite3
+++ b/invisible_cities/database/localdb.DEMOPPDB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cef851f580a503ad4391980ceb4536def3aed0c17abb2f0bb6b3bca303b2d3a9
-size 8179712
+oid sha256:cc4edfd13dcb520f3695b9a6c34ab67240900d55ddb12aeb936d6f08ca67a15a
+size 10973184


### PR DESCRIPTION
Demo++ database has been updated with the new constants for the SiPMs from run 9523. Channel `16028` may be dead so it has been masked and checked in the next calibrations. 

Some plots are attached comparing the current runs with the last calibration, taken in September. The gains apparently have been increased slightly and the 1pe sigma decreased...

![sipmRunDifferencePlots](https://user-images.githubusercontent.com/32193826/106792543-8a649400-6656-11eb-8657-653d35701321.png)


 