### PR TITLE
Speed up the process of getting event numbers from mc files

### DIFF
--- a/invisible_cities/io/mcinfo_io.py
+++ b/invisible_cities/io/mcinfo_io.py
@@ -128,7 +128,7 @@ def safe_copy_nexus_eventmap(h5out  : tb.file.File,
 
     returns
     -------
-    Mapping : 
+    Mapping :
             'evt_number': the evt_number copied to the output;
             'nexus_evt' : the nexus event_ids copied to the output.
     """
@@ -325,12 +325,20 @@ def get_event_numbers_in_file(file_name: str) -> np.ndarray:
 
 
 def _get_list_of_events_new(h5in : tb.file.File) -> np.ndarray:
+    """
+    This function relies on the assumption that, if the particles table exists,
+    it includes all the events of the file. At the same time,
+    if that table doesn't exists, all the events are assumed to have
+    generated some sensor response, therefore to appear in the sns_response table.
+    Events that don't generate sensor response and don't have any saved particle
+    are assumed to be irrelevant for the analysis.
+    """
     def get_event_ids_table(tablename):
         try:
             evt_list = getattr(h5in.root.MC, tablename).cols.event_id
         except tb.exceptions.NoSuchNodeError:
             raise AttributeError('Trying to get event number from MC corrupted file.')
-        return np.unique(evt_list).astype(int)   
+        return np.unique(evt_list).astype(int)
     evt_list = get_event_ids_table('particles')
     if len(evt_list):
         return evt_list


### PR DESCRIPTION
This PR addresses issue #771 speeding up the process of getting the event numbers from nexus files stored with the new persistency.

To illustrate the gain, I have profiles the process of getting the event numbers from 10 different full simulation files containing 4 bb0nu events each one of the files.

Current function yields an average time of:  833356.9 microseconds
This PR function yields an average time of:       7693.2 microseconds

All tests pass succesfully.