### PR TITLE
Fix Xpeak & Ypeak in Penthesilea

### DIFF
--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -725,6 +725,7 @@ def build_pointlike_event(dbfile, run_number, drift_v,
 
 def hit_builder(dbfile, run_number, drift_v, reco,
                 rebin_slices, rebin_method,
+                global_reco_params,
                 charge_type = SiPMCharge.raw):
     datasipm = load_db.DataSiPM(dbfile, run_number)
     sipm_xs  = datasipm.X.values
@@ -733,13 +734,7 @@ def hit_builder(dbfile, run_number, drift_v, reco,
 
     sipm_noise = NoiseSampler(dbfile, run_number).signal_to_noise
 
-    barycenter = partial(corona,
-                         all_sipms      =  datasipm,
-                         Qthr           =  0 * units.pes,
-                         Qlm            =  0 * units.pes,
-                         lm_radius      = -1 * units.mm,
-                         new_lm_radius  = -1 * units.mm,
-                         msipm          =  1)
+    barycenter = partial(corona, all_sipms = datasipm, **global_reco_params)
 
     def empty_cluster():
         return Cluster(NN, xy(0,0), xy(0,0), 0)

--- a/invisible_cities/cities/penthesilea.py
+++ b/invisible_cities/cities/penthesilea.py
@@ -70,7 +70,11 @@ def penthesilea(files_in, file_out, compression, event_range, print_mod, detecto
     pmap_select           = df.count_filter(bool, args="pmap_passed")
 
     reco_algo_slice       = compute_xy_position(detector_db, run_number, **slice_reco_params)
-    build_hits            = df.map(hit_builder(detector_db, run_number, drift_v, reco_algo_slice, rebin, RebinMethod[rebin_method], SiPMCharge[sipm_charge_type]),
+    build_hits            = df.map(hit_builder(detector_db, run_number, drift_v,
+                                               reco_algo_slice, rebin,
+                                               RebinMethod[rebin_method],
+                                               global_reco_params,
+                                               SiPMCharge[sipm_charge_type]),
                                    args = ("pmap", "selector_output", "event_number", "timestamp"),
                                    out  = "hits"                                                 )
     reco_algo_global      = compute_xy_position(detector_db, run_number, **global_reco_params)

--- a/invisible_cities/cities/penthesilea_test.py
+++ b/invisible_cities/cities/penthesilea_test.py
@@ -373,11 +373,12 @@ def test_penthesilea_global_xyreco_bias(config_tmpdir, ICDATADIR):
     PATH_OUT = os.path.join(config_tmpdir, 'fake_hdst_nothreshold_barycenter_bias.h5')
 
     conf = configure('dummy invisible_cities/config/penthesilea.conf'.split())
-    conf.update(dict(files_in    = PATH_IN ,
-                     file_out    = PATH_OUT,
-                     rebin       =      100,
-                     run_number  =     7000,
-                     s2_nsipmmax =      200))
+    conf.update(dict( files_in    = PATH_IN
+                    , file_out    = PATH_OUT
+                    , rebin       =  100
+                    , run_number  = 7000
+                    , s2_nsipmmax =  200
+                    ))
 
     conf["global_reco_params"].update(dict(Qthr=5))
 

--- a/invisible_cities/database/test_data/fake_pmap_nothreshold_barycenter_bias.h5
+++ b/invisible_cities/database/test_data/fake_pmap_nothreshold_barycenter_bias.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7395082eb33896ad149ddb7489c9df73230e6c9b418e3438807b6a7044e9839
+size 40344


### PR DESCRIPTION
This PR addresses issue #730. The computation of the `Xpeak` and `Ypeak` columns used hardwired parameters which included `Qthr = 0`. This results in a biased computation of those columns. The solution includes the usage of the `global_reco_params` city argument (currently used for the kdst side of the pipeline) for the calculation of `Xpeak` and `Ypeak`.

A test together with a new test file has been added. The test file contains a single event with an artificial pmap made to illustrate the problem. The S2 of this pmap contains a single sipm with charge over threshold and a bunch of sipms with charge below threshold (threshold = 5 pes). With the previous configuration, no threshold is applied and therefore all the sipms are taken into account, resulting in a biased result. However, if the threshold is applied (this PR), only 1 sipm survives, and the reconstructed position matches that of the sipm.

Fixes  #730.