### PR TITLE
Force colouring of pytest output on GitHub Action

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -32,5 +32,4 @@ jobs:
       run: |
         source $CONDA/etc/profile.d/conda.sh
         source manage.sh work_in_python_version_no_tests ${{ matrix.python-version }}
-        HYPOTHESIS_PROFILE=travis-ci bash manage.sh run_tests_par
-
+        PYTEST_ADDOPTS=--color=yes HYPOTHESIS_PROFILE=travis-ci bash manage.sh run_tests_par


### PR DESCRIPTION
The GHA environment conspires to disable colouring of pytest output. This makes it more difficult to understand test failures.

This PR enables colouring of pytest output in the GHA.