### PR TITLE
Skip database test which causes too many spurious failures

### DIFF
--- a/invisible_cities/database/db_connection.py
+++ b/invisible_cities/database/db_connection.py
@@ -1,3 +1,5 @@
+from pytest import mark
+
 import sqlite3
 import pymysql
 pymysql.install_as_MySQLdb()
@@ -9,9 +11,9 @@ def connect_sqlite(dbfile):
     return conn_sqlite, cursor_sqlite
 
 
+@mark.skip(reason='server timeouts cause too many spurious test failures')
 def connect_mysql(dbname):
     conn_mysql  = pymysql.connect(host="neutrinos1.ific.uv.es",
                                   user='nextreader',passwd='readonly', db=dbname)
     cursor_mysql  = conn_mysql .cursor()
     return connect_mysql, cursor_mysql
-

--- a/invisible_cities/database/download_test.py
+++ b/invisible_cities/database/download_test.py
@@ -8,6 +8,7 @@ from pytest import mark
 
 from . import download as db
 
+@mark.skip(reason='server timeouts cause too many spurious test failures')
 @mark.parametrize('dbname', 'DEMOPPDB NEWDB NEXT100DB Flex100DB'.split())
 def test_create_table_sqlite(dbname, output_tmpdir):
     dbfile = os.path.join(output_tmpdir, 'db.sqlite3')


### PR DESCRIPTION
This test has been responsible for far too many spurious failures of CI runs, thereby significantly increasing the workload of managing PRs.

Here we skip the test, but this should be reversed as soon as the problem is fixed at the server.