### PR TITLE
Allow numpy to be used in config files

### DIFF
--- a/invisible_cities/core/configure.py
+++ b/invisible_cities/core/configure.py
@@ -2,6 +2,7 @@
 JJGC August 2016
 """
 import argparse
+import numpy
 import sys
 import os
 
@@ -89,6 +90,8 @@ def make_config_file_reader():
 
     builtins = __builtins__.copy()
     builtins.update(vars(units))
+    builtins["np"] = numpy
+
     # TODO: move setting of extra 'builtins' elsewhere
     builtins['all']  = EventRange.all
     builtins['last'] = EventRange.last

--- a/invisible_cities/core/configure_test.py
+++ b/invisible_cities/core/configure_test.py
@@ -387,3 +387,14 @@ def test_config_penthesilea_counters(config_tmpdir, KrMC_pmaps_filename, flags, 
     argv = f'penthesilea {config_filename} -i {input_filename} -o {output_filename} {flags}'.split()
     counters = penthesilea(**configure(argv))
     assert getattr(counters, counter) == value
+
+
+def test_configure_numpy(config_tmpdir):
+    config_filename = config_tmpdir.join("conf_with_numpy.conf")
+    config_contents = "a_numpy_array = np.linspace(0, 1, 3)\n"
+    write_config_file(config_filename, config_contents)
+
+    argv    = f"some_city {config_filename}".split()
+    conf_ns = configure(argv).as_namespace
+    assert hasattr(conf_ns, "a_numpy_array")
+    assert conf_ns.a_numpy_array.tolist() == [0, 0.5, 1]


### PR DESCRIPTION
Usually, cities don't take sequences of numbers as arguments, so there was no need to have NumPy in the namespace used to read config files. Probably #781 is the first case where it is interesting in practice. For tests and demo purposes we can live without it, but in realistic cases, we might want to do something like `np.linspace(0, 100, 17)`. The pure-python equivalent would be more difficult to read, so I propose we introduce NumPy as a valid package in config files.

This is a very simple and short PR. Maybe it would be good for someone that wants to get involved in IC to review it.

