### PR TITLE
Demo++ rotate DBs 2.0

### DIFF
--- a/invisible_cities/database/localdb.DEMOPPDB.sqlite3
+++ b/invisible_cities/database/localdb.DEMOPPDB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aa28e1f01f86215a1918cc9a60c60e952fe738fb67da0d0aaf989fc0712afe52
+oid sha256:26f8ffe9374284ad0967885e1d79f0258eff26bb055bc6b64c4e78a23438b426
 size 10973184


### PR DESCRIPTION
Due to the configuration with the new Hamamatsu dice boards connectors, the DB1 and DB3 have been rotated 180º. The ChannelMapping table of the database has been correctly updated according to this change.