### PR TITLE
Update NEWDB

### DIFF
--- a/invisible_cities/database/localdb.NEWDB.sqlite3
+++ b/invisible_cities/database/localdb.NEWDB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:243eed0ca3d9f0978c82f6074b2e8a8faaf8d1bb8bebb850a23b9d38253feb44
-size 524673024
+oid sha256:875a30919780fd573d158c7b7b133ca9925122df71c1ca0522d6b771902a7ad8
+size 545050624


### PR DESCRIPTION
This PR includes the latest sensor calibrations starting from run 8692. The database has been uploaded with the PMT/SiPMs gains and the pdf values.

Here some plots comparing the calibration runs with previous calibrations:

![sipmRunDifferencePlots](https://user-images.githubusercontent.com/44235769/122060342-c8847800-cded-11eb-80f3-a1005ee4e9af.png)
![pmtRunDifferencePlots](https://user-images.githubusercontent.com/44235769/122060377-d0441c80-cded-11eb-8dad-7c13e86b21c3.png)

