### PR TITLE
Paolina city

### DIFF
--- a/invisible_cities/cities/paolina.py
+++ b/invisible_cities/cities/paolina.py
@@ -1,0 +1,115 @@
+"""
+-----------------------------------------------------------------------
+                              Paolina
+-----------------------------------------------------------------------
+This city reads beersheba deconvoluted hits.
+This city outputs a similar results as esmeralda:
+    - Tracking/Tracks: track info of paolina algorithm applied on deconvoluted tracks
+    - PHITS/hits     : paolina hits used by the paolina algorithm
+"""
+
+import os
+import numpy  as np
+import tables as tb
+
+from . components import city
+from . components import print_every
+from . components import collect
+from . components import copy_mc_info
+from . components import get_event_info
+
+from .. dataflow import dataflow      as fl
+from .. reco     import tbl_functions as tbl
+from .. database import load_db       as db
+
+from .. io.run_and_event_io import run_and_event_writer
+from .. io.event_filter_io  import event_filter_writer
+from .. io.hits_io          import hits_writer
+
+# city source
+from .. io.dst_io import load_dst
+from . components import get_run_number
+def decohits_from_files(files_in):
+    """ Reads deconvoluted hits from beersheba files"""
+    for filename in files_in:
+        try:
+            deco = load_dst(filename, "DECO", "Events")
+        except tb.exceptions.NoSuchNodeError:
+            continue
+
+        with tb.open_file(filename, "r") as h5in:
+            try:
+                run_number = get_run_number(h5in)
+                event_info = get_event_info(h5in)
+            except (tb.exceptions.NoSuchNodeError, IndexError):
+                continue
+
+            for evtinfo in event_info:
+                event_number, timestamp = evtinfo.fetch_all_fields()
+                yield dict( deco         = deco.loc[deco.event == event_number].copy()
+                          , run_number   = run_number
+                          , event_number = event_number
+                          , timestamp    = timestamp)
+
+
+from .. io.hits_io import hits_from_df
+def create_deco_hitcollection(deco):
+    """ Auxiliar function to create the hit collection for DECO table hits.
+        DECO hits does not contain Ec and Ep, which are needed to be used with
+        hits_from_df function."""
+    deco.loc[:, "Ec"]   = deco["E"]
+    deco.loc[:, "Ep"]   = deco["E"]
+    hitc = hits_from_df(deco)[deco["event"].unique()[0]]
+    return hitc
+
+from . esmeralda   import track_blob_info_creator_extractor
+from . esmeralda   import track_writer
+
+@city
+def paolina(*, files_in, file_out, event_range, print_mod, compression,
+            run_number, detector_db, paolina_params):
+
+    # 1 peak filter (select 1S2 events)
+    has_1peak  = lambda deco: (deco.npeak.nunique() == 1)
+    has_1peak_ = fl.map(has_1peak, args="deco", out="passed_1peak")
+    events_passsed_1peak = fl.count_filter(bool, args="passed_1peak")
+
+    # create hit collection
+    create_hitcolection = fl.map(create_deco_hitcollection, args="deco", out="hitc")
+
+    # paolina algorithm
+    paolina_algorithm = fl.map(track_blob_info_creator_extractor(**paolina_params),
+                               args = "hitc", out  = ('topology_info', 'paolina_hits', 'out_of_map'))
+
+    event_count_in = fl.spy_count()
+    evtnum_collect = collect()
+
+    with tb.open_file(file_out, "w", filters = tbl.filters(compression)) as h5out:
+
+        write_event_info   = fl.sink(run_and_event_writer(h5out), args=("run_number", "event_number", "timestamp"))
+        write_1peak_filter = fl.sink(event_filter_writer(h5out, "one_peak"), args=("event_number", "passed_1peak"))
+        write_tracks       = fl.sink(       track_writer(h5out)            , args="topology_info")
+        # write_paolina_hits = fl.sink(        hits_writer(h5out, group_name='PHITS', table_name='hits')
+        #                                                                    , args="paolina_hits")
+
+        result = fl.push(source= decohits_from_files(files_in),
+                         pipe  = fl.pipe( fl.slice(*event_range, close_all=True)
+                                        , event_count_in.spy
+                                        , fl.branch(write_event_info)
+                                        , print_every(print_mod)
+                                        , has_1peak_
+                                        , fl.branch(write_1peak_filter)
+                                        , events_passsed_1peak.filter
+                                        , create_hitcolection
+                                        , paolina_algorithm
+                                        , fl.branch(write_tracks)
+                                        # , fl.branch(write_paolina_hits)
+                                        , "event_number"
+                                        , evtnum_collect.sink),
+                         result = dict(events_in     = event_count_in.future,
+                                       evtnum_list   = evtnum_collect.future))
+
+        if run_number <= 0:
+            copy_mc_info(files_in, h5out, result.evtnum_list, detector_db, run_number)
+
+        return result

--- a/invisible_cities/cities/paolina_test.py
+++ b/invisible_cities/cities/paolina_test.py
@@ -1,0 +1,94 @@
+import os
+import shutil
+import numpy  as np
+import pandas as pd
+import tables as tb
+
+from .. cities.paolina import paolina
+from .. core           import system_of_units as units
+from .. core.configure import configure
+from .. core.configure import all             as all_events
+from .. io.dst_io      import load_dst
+
+from .. core.testing_utils   import assert_tables_equality
+
+
+def test_paolina_contains_all_tables(ICDATADIR, output_tmpdir):
+
+    PATH_IN  = os.path.join(ICDATADIR    , "deconvoluted_0nubb_next100.h5")
+    PATH_OUT = os.path.join(output_tmpdir, "contain_all_tables.paolina.h5")
+    conf = configure('paolina $ICTDIR/invisible_cities/config/paolina.conf'.split())
+    conf.update(dict(files_in      = PATH_IN,
+                     file_out      = PATH_OUT,
+                     run_number    = 0,
+                     event_range   = (0, 2)))
+    result = paolina(**conf)
+
+    with tb.open_file(PATH_OUT, mode="r") as h5out:
+        assert hasattr(h5out.root,               'MC')
+        assert hasattr(h5out.root,  'Tracking/Tracks')
+        assert hasattr(h5out.root,              'Run')
+        assert hasattr(h5out.root, 'Filters/one_peak')
+
+
+def test_paolina_filter_multipeak(ICDATADIR, output_tmpdir):
+
+    PATH_IN  = os.path.join(ICDATADIR    , "deconvoluted_0nubb_next100.h5")
+    PATH_OUT = os.path.join(output_tmpdir, "filtered_multipeak_events.h5")
+    conf = configure('paolina $ICTDIR/invisible_cities/config/paolina.conf'.split())
+    conf.update(dict(files_in      = PATH_IN,
+                     file_out      = PATH_OUT,
+                     run_number    = 0,
+                     event_range   = all_events))
+    result = paolina(**conf)
+
+    assert result.events_in   == 10
+    assert result.evtnum_list == [2, 4, 6, 10, 12, 14, 16, 18]
+    passed = [False,  True,  True,  True, False,  True,  True,  True,  True, True]
+
+    with tb.open_file(PATH_OUT, mode="r") as h5out:
+        filters = h5out.root.Filters.one_peak.read()
+        np.testing.assert_array_equal(filters["passed"], passed)
+
+
+def test_paolina_empty_input_file(ICDATADIR, output_tmpdir):
+
+    PATH_IN  = os.path.join(ICDATADIR    , "empty_file.h5")
+    PATH_OUT = os.path.join(output_tmpdir, "empty_paolina.h5")
+    conf = configure('paolina $ICTDIR/invisible_cities/config/paolina.conf'.split())
+    conf.update(dict(files_in      = PATH_IN,
+                     file_out      = PATH_OUT,
+                     run_number    = 0,
+                     event_range   = all_events))
+    result = paolina(**conf)
+
+    assert result.events_in   == 0
+    assert result.evtnum_list == []
+
+
+def test_paolina_exact(ICDATADIR, output_tmpdir):
+
+    PATH_IN   = os.path.join(ICDATADIR    , "deconvoluted_0nubb_next100.h5")
+    PATH_OUT  = os.path.join(output_tmpdir, "exact_tables.paolina.h5")
+    PATH_TRUE = os.path.join(ICDATADIR    , "paolina_0nubb_next100_10evts.h5")
+    conf = configure('paolina $ICTDIR/invisible_cities/config/paolina.conf'.split())
+    conf.update(dict(files_in      = PATH_IN,
+                     file_out      = PATH_OUT,
+                     run_number    = 0,
+                     event_range   = all_events))
+    np.random.seed(1234)
+    result = paolina(**conf)
+
+    tables = ["Tracking/Tracks",
+              "Run/eventMap", "Run/events", "Run/runInfo",
+              "MC/configuration", "MC/event_mapping", "MC/hits",
+              "MC/particles", "MC/sns_positions", "MC/sns_response",
+              "Filters/one_peak"]
+
+    with tb.open_file(PATH_TRUE) as true_output_file:
+        with tb.open_file(PATH_OUT) as output_file:
+            for table in tables:
+                assert hasattr(output_file.root, table)
+                got      = getattr(     output_file.root, table)
+                expected = getattr(true_output_file.root, table)
+                assert_tables_equality(got, expected)

--- a/invisible_cities/config/paolina.conf
+++ b/invisible_cities/config/paolina.conf
@@ -1,0 +1,17 @@
+files_in = "$ICDIR/database/test_data/deconvoluted_0nubb_next100.h5"
+file_out = "/tmp/paolina_out.h5"
+
+compression = "ZLIB4"
+event_range = all
+run_number  = 0
+detector_db = "next100"
+
+# How frequently to print events
+print_mod = 1
+
+paolina_params = dict( vox_size         = [10 * mm, 10 * mm, 10 * mm]
+                     , strict_vox_size  = False
+                     , energy_threshold = 10 * keV
+                     , min_voxels       = 3
+                     , blob_radius      = 21 * mm
+                     , max_num_hits     = 50000)

--- a/invisible_cities/database/test_data/deconvoluted_0nubb_next100.h5
+++ b/invisible_cities/database/test_data/deconvoluted_0nubb_next100.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66a04f65e21df2a1ed7b8bffa7fcf3ba2b94d4b0ff1e36995fddc64f39c7bec5
+size 7369302

--- a/invisible_cities/database/test_data/paolina_0nubb_next100_10evts.h5
+++ b/invisible_cities/database/test_data/paolina_0nubb_next100_10evts.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74ae3ac1bc6a92738ef7390eb0d80a00077f8656c891a081bdfbea436d0dec3d
+size 129807

--- a/invisible_cities/io/hits_io.py
+++ b/invisible_cities/io/hits_io.py
@@ -30,16 +30,19 @@ def hits_from_df (dst : pd.DataFrame, skip_NN : bool = False) -> Dict[int, HitCo
     Dictionary {event_number : HitCollection}
     """
     all_events = {}
-    for (event, time) , hits_df in dst.groupby(['event', 'time']):
+    for (event, time) , hits_df in dst.groupby(['event', getattr(dst, 'time', [-1]*len(dst))]):
         #pandas is not consistent with numpy dtypes so we have to change it by hand
         event = np.int32(event)
         hits  = []
         for i, row in hits_df.iterrows():
-            if skip_NN and row.Q == NN:
+            if skip_NN and getattr(row, 'Q', -1) == NN:
                 continue
             hit = Hit(row.npeak,
-                      Cluster(row.Q, xy(row.X, row.Y), xy(row.Xrms**2, row.Yrms**2),
-                              row.nsipm, row.Z, row.E,
+                      Cluster(getattr(row, 'Q', row.E),
+                              xy(row.X, row.Y),
+                              xy(getattr(row, 'Xrms', 0)**2, getattr(row, 'Yrms', 0)**2),
+                              getattr(row, 'nsipm', -1),
+                              row.Z, row.E,
                               Qc = getattr(row, 'Qc', -1)),       # for backwards compatibility
                       row.Z, row.E,
                       xy(getattr(row, 'Xpeak', -1000),            # for backwards compatibility


### PR DESCRIPTION
This city runs Paolina track extreme search algorithm over deconvoluted track. This city reads the output of `beersheba` city and outputs the track information per event.

In order to make the PR easier to review, I have kept `esmeralda` functions in its module, but they will likely be moved to `components.py` once the PR is accepted. I have also kept the city source function in the city module itself, but will also be moved.

The city is simple and short, essentially it implements the following steps:
- Read DECO hits (deconvoluted tracks from `beersheba`)
- Filter multipeak events
- Convert the DECO hits dataframe to a `HitCollection`
- Run Paolina algorithm
- Save track information results

It also modifies the `hits_from_df` function to be compatible with the current DECO dataframe format.