### PR TITLE
Update DEMOPPDB

### DIFF
--- a/invisible_cities/database/localdb.DEMOPPDB.sqlite3
+++ b/invisible_cities/database/localdb.DEMOPPDB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:41a2ca4c5ebe2439705f4a1a70f757789ae482857e1aa3f0fac6558a95e6eead
-size 13742080
+oid sha256:46f0ad856fd700393f364e4dfc5e174894351a9355611d1534845faed0da9fef
+size 16560128


### PR DESCRIPTION
Demo++ database has been updated with the calibration constants from R10159 for the SiPMs and pdfs. In the database, however, The `Min_run` set is 9862 because the values from the previous calibrations were incorrect after the first rotation of the dice boards 1 and 3. 