### PR TITLE
Remove NoSuchNodeError catch in dst loading

### DIFF
--- a/invisible_cities/io/dst_io_test.py
+++ b/invisible_cities/io/dst_io_test.py
@@ -112,7 +112,7 @@ def test_load_dsts_warns_not_of_kdst_type(ICDATADIR):
     group = "DST"
     node  = "Events"
     with pytest.warns(UserWarning, match='not of kdst type'):
-        load_dsts([good_file, wrong_file], group, node)
+        load_dsts([good_file, wrong_file], group, node, ignore_errors=True)
 
 
 def test_load_dsts_warns_if_not_existing_file(ICDATADIR):
@@ -124,7 +124,7 @@ def test_load_dsts_warns_if_not_existing_file(ICDATADIR):
     group = "DST"
     node  = "Events"
     with pytest.warns(UserWarning, match='does not exist'):
-        load_dsts([good_file, wrong_file], group, node)
+        load_dsts([good_file, wrong_file], group, node, ignore_errors=True)
 
 
 def test_load_dst_converts_from_bytes(ICDATADIR, fixed_dataframe):

--- a/invisible_cities/io/mcinfo_io.py
+++ b/invisible_cities/io/mcinfo_io.py
@@ -132,16 +132,12 @@ def safe_copy_nexus_eventmap(h5out  : tb.file.File,
             'evt_number': the evt_number copied to the output;
             'nexus_evt' : the nexus event_ids copied to the output.
     """
-    # Suppress warning raised when table not
-    # present since case dealt with in try except.
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", category=UserWarning)
-        evt_map = load_eventnumbermap(file_in)
     try:
+        evt_map = load_eventnumbermap(file_in)
         evt_mask = evt_map.evt_number.isin(evt_arr)
         df_writer(h5out, evt_map[evt_mask], 'Run', 'eventMap')
         return evt_map[evt_mask].to_dict('list')
-    except AttributeError:
+    except (AttributeError, tb.exceptions.NoSuchNodeError):
         ## Invoked when the eventMap table not found
         ## which occurs for pre-2020 MC files and
         ## at the first processing stage from nexus


### PR DESCRIPTION
This PR solves issue #800. The proposed solution removes the `NoSuchNodeError` catch in `load_dst` function.