### PR TITLE
Add DST group in high level files

### DIFF
--- a/invisible_cities/cities/beersheba_test.py
+++ b/invisible_cities/cities/beersheba_test.py
@@ -149,3 +149,20 @@ def test_beersheba_expandvar(deconvolution_config):
     conf['deconv_params']['psf_fname'] = '$ICDIR/database/test_data/PSF_dst_sum_collapsed.h5'
 
     beersheba(**conf)
+
+
+def test_beersheba_copy_kdst(deconvolution_config, ICDATADIR):
+    PATH_IN = os.path.join(ICDATADIR, "test_cdst_NEW_v1.2.0_bg.h5")
+    conf, PATH_OUT = deconvolution_config
+    conf["files_in"]   = PATH_IN
+    conf["run_number"] = 8515
+
+    expected_events = [3, 90, 152]
+
+    beersheba(**conf)
+
+    with tb.open_file(PATH_OUT) as output_file:
+        assert hasattr(output_file.root, "DST/Events")
+
+        got_events = output_file.root.DST.Events.read()["event"]
+        assert expected_events == got_events.tolist()

--- a/invisible_cities/cities/isaura_test.py
+++ b/invisible_cities/cities/isaura_test.py
@@ -96,3 +96,25 @@ def test_isaura_conserves_energy(ICDATADIR, output_tmpdir):
 
     np.testing.assert_allclose(dhits_energy, dtracks_energy)
     np.testing.assert_allclose(dhits_energy, devents_energy)
+
+
+def test_isaura_copy_kdst(ICDATADIR, output_tmpdir):
+
+    PATH_IN  = os.path.join(ICDATADIR    , "test_deconv_NEW_v1.2.0_bg.h5")
+    PATH_OUT = os.path.join(output_tmpdir, "test_isaura_dst.h5")
+    n_evts = 2
+    conf = configure('isaura $ICTDIR/invisible_cities/config/isaura.conf'.split())
+    conf.update(dict(files_in    = PATH_IN ,
+                     file_out    = PATH_OUT,
+                     run_number  = 8515    ,
+                     event_range = n_evts  ))
+
+    isaura(**conf)
+
+    expected_events = [3, 90]
+
+    with tb.open_file(PATH_OUT) as output_file:
+        assert hasattr(output_file.root, "/DST/Events")
+
+        got_events = output_file.root.DST.Events.read()["event"]
+        assert expected_events == got_events.tolist()

--- a/invisible_cities/database/test_data/test_cdst_NEW_v1.2.0_bg.h5
+++ b/invisible_cities/database/test_data/test_cdst_NEW_v1.2.0_bg.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f2ece2666c3dc86c66541c44e76229fdea72f959d17ba06ccc478ad9f374db7
+size 64123493

--- a/invisible_cities/database/test_data/test_deconv_NEW_v1.2.0_bg.h5
+++ b/invisible_cities/database/test_data/test_deconv_NEW_v1.2.0_bg.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d75fe6a8a29131843465f7db06dac483a5015ac2e5abfbe83f365d1c6b6c6465
+size 383622


### PR DESCRIPTION
This PR adds 'DST/Events' group in beersheba and subsequent isaura outputs. Until now high level analysis was performed using esmeralda files, but the two extra cities were added afterwards. These cities did not contain the DST group, which contain relevant information, for example the S1 data. Ideally, high level analysis will be performed with  isaura files, thus both cities must carry the DST group. The PR ensures backward compatibility, old files without DST group can be processed as well.