### PR TITLE
Update run numbers in demoppdb

### DIFF
--- a/invisible_cities/database/localdb.DEMOPPDB.sqlite3
+++ b/invisible_cities/database/localdb.DEMOPPDB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:46f0ad856fd700393f364e4dfc5e174894351a9355611d1534845faed0da9fef
+oid sha256:5d2f855fbad204b645ca79fb4002aa9bb45d06c4241d677707024a4fb5b8acc5
 size 16560128


### PR DESCRIPTION
There was a run number (R9859) from the Demo++ Run9 that was not included in the current gains in the DB. In order to fix that, the following changes have been added:

- Runs with `MinRun=9523` and `MaxRun=9859` --> change `MaxRun` to 9856
- Runs with `MinRun=9860` and `MaxRun=9861` --> change `MinRun` to 9857 and `MaxRun` to 9858
- Runs with `MinRun=9862` and `MaxRun=100000` --> change `MinRun` to 9859