### PR TITLE
Add citation metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,7 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+  - name: "NEXT Collaboration"
+title: "Invisible Cities"
+url: "https://github.com/next-exp/IC"
+license-url: "https://github.com/next-exp/IC/blob/master/doc/ic_authors_and_legal.rst"


### PR DESCRIPTION
This PR adds a citation metadata file into IC, allowing simple citation for APA or Bibtex formats.

It uses the provided GitHub interface [about-citation-files](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files).

As you can check in the branch of this PR, a `Cite this repository` is now visible at the right column of the repository webpage [this-branch](https://github.com/gondiaz/IC/tree/citation) providing the citation styles.