### PR TITLE
Fix incorrect calculation of peak width

### DIFF
--- a/invisible_cities/cities/dorothea_test.py
+++ b/invisible_cities/cities/dorothea_test.py
@@ -79,11 +79,11 @@ def test_dorothea_filter_events(config_tmpdir, Kr_pmaps_run4628_filename):
                      s2_nsipmmax =     30,
                      event_range = (0, nrequired)))
 
-    events_pass = [ 1,  4, 10, 19, 20, 21, 26,
+    events_pass = [ 1,  4, 10, 15, 19, 20, 21, 26,
                    26, 29, 33, 41, 43, 45, 46]
-    s1_peak_pass = [ 0,  0,  0,  0,  0,  0,  0,
+    s1_peak_pass = [ 0,  0,  0,  0,  0,  0,  0, 0,
                      0,  0,  0,  0,  0,  0,  0]
-    s2_peak_pass = [ 0,  0,  0,  0,  0,  0,  0,
+    s2_peak_pass = [ 0,  0,  0,  0,  0,  0,  0, 0,
                      1,  0,  0,  0,  0,  0,  0]
 
     cnt = dorothea(**conf)

--- a/invisible_cities/cities/penthesilea_test.py
+++ b/invisible_cities/cities/penthesilea_test.py
@@ -85,12 +85,12 @@ def test_penthesilea_filter_events(config_tmpdir, Kr_pmaps_run4628_filename):
                      s2_nsipmmax =     30,
                      event_range = (0, nrequired)))
 
-    events_pass_reco = ([ 1]*21 + [ 4]*15 + [10]*16 + [19]*17 +
-                        [20]*19 + [21]*15 + [26]*23 + [29]*22 +
-                        [33]*14 + [41]*18 + [43]*18 + [45]*13 +
-                        [46]*18)
-    peak_pass_reco   = [int(in_range(i, 119, 126))
-                        for i in range(229)]
+    events_pass_reco = ([ 1]*21 + [ 4]*15 + [10]*16 + [15]*19 +
+                        [19]*17 + [20]*19 + [21]*15 + [26]*23 +
+                        [29]*22 + [33]*14 + [41]*18 + [43]*18 +
+                        [45]*13 + [46]*18)
+    peak_pass_reco   = [int(in_range(i, 138, 145))
+                        for i in range(248)]
 
     cnt      = penthesilea(**conf)
     nevt_in  = cnt.events_in
@@ -104,11 +104,11 @@ def test_penthesilea_filter_events(config_tmpdir, Kr_pmaps_run4628_filename):
     assert  np.all(df_penthesilea_reco.npeak.values   ==   peak_pass_reco)
 
 
-    events_pass_dst = [ 1,  4, 10, 19, 20, 21, 26,
+    events_pass_dst = [ 1,  4, 10, 15, 19, 20, 21, 26,
                         26, 29, 33, 41, 43, 45, 46]
-    s1_peak_pass_dst = [ 0,  0,  0,  0,  0,  0,  0,
+    s1_peak_pass_dst = [ 0,  0,  0,  0,  0,  0,  0, 0,
                          0,  0,  0,  0,  0,  0,  0]
-    s2_peak_pass_dst = [ 0,  0,  0,  0,  0,  0,  0,
+    s2_peak_pass_dst = [ 0,  0,  0,  0,  0,  0,  0, 0,
                          1,  0,  0,  0,  0,  0,  0]
     assert nevt_out     == len(set(events_pass_dst))
     df_penthesilea_dst  = dio.load_dst(PATH_OUT , 'DST' , 'Events')

--- a/invisible_cities/evm/pmaps.py
+++ b/invisible_cities/evm/pmaps.py
@@ -61,8 +61,9 @@ class _Peak:
         i_above_thr = self.pmts.where_above_threshold(thr)
         if np.size(i_above_thr) < 1:
             return 0
-
-        return np.sum(self.bin_widths[i_above_thr])
+        imin = i_above_thr[0]
+        imax = i_above_thr[-1]
+        return np.sum(self.bin_widths[imin:imax+1])
 
     def    rms_above_threshold(self, thr):
         i_above_thr     = self.pmts.where_above_threshold(thr)

--- a/invisible_cities/evm/pmaps_test.py
+++ b/invisible_cities/evm/pmaps_test.py
@@ -177,12 +177,7 @@ def test_Peak_height(pks):
     assert peak.height == approx(peak.pmts.sum_over_sensors.max())
 
 
-#@given(peaks())
-#def test_Peak_width(pks):
-#    _, peak = pks
-#    assert peak.width == approx(peak.times[-1] - peak.times[0])
-
-def test_Peak_width_correct():
+def test_peak_width_signal_positive():
     nsamples = 3
     times  = np.arange(nsamples)
     widths = np.full(nsamples, 1)
@@ -190,6 +185,32 @@ def test_Peak_width_correct():
 
     peak = S1(times, widths, pmts, SiPMResponses.build_empty_instance())
     assert peak.width == nsamples
+
+
+def test_peak_width_signal_not_positive():
+    nsamples = 10
+    times  = np.arange(nsamples)
+    widths = np.full(nsamples, 1)
+    signal = np.full((1, nsamples), 1)
+    signal[0, 1:nsamples-1:2] = 0
+    signal[0, 2:nsamples-1:2] = -100
+
+    pmts = PMTResponses(np.arange(1), signal)
+    peak = S1(times, widths, pmts, SiPMResponses.build_empty_instance())
+    assert peak.width == nsamples
+
+
+def test_peak_width_signal_limits():
+    nsamples = 10
+    times  = np.arange(nsamples)
+    widths = np.full(nsamples, 1)
+    signal = np.full((1, nsamples), 1)
+    signal[0, 0] = 0
+    signal[0,-1] = -100
+
+    pmts = PMTResponses(np.arange(1), signal)
+    peak = S1(times, widths, pmts, SiPMResponses.build_empty_instance())
+    assert peak.width == (nsamples-2)
 
 
 def _get_indices_above_thr(sr, thr):

--- a/invisible_cities/evm/pmaps_test.py
+++ b/invisible_cities/evm/pmaps_test.py
@@ -177,7 +177,7 @@ def test_Peak_height(pks):
     assert peak.height == approx(peak.pmts.sum_over_sensors.max())
 
 
-def test_peak_width_signal_positive():
+def test_Peak_width_signal_positive():
     nsamples = 3
     times  = np.arange(nsamples)
     widths = np.full(nsamples, 1)
@@ -187,7 +187,7 @@ def test_peak_width_signal_positive():
     assert peak.width == nsamples
 
 
-def test_peak_width_signal_not_positive():
+def test_Peak_width_signal_not_positive():
     nsamples = 10
     times  = np.arange(nsamples)
     widths = np.full(nsamples, 1)
@@ -200,7 +200,7 @@ def test_peak_width_signal_not_positive():
     assert peak.width == nsamples
 
 
-def test_peak_width_signal_limits():
+def test_Peak_width_signal_limits():
     nsamples = 10
     times  = np.arange(nsamples)
     widths = np.full(nsamples, 1)
@@ -210,7 +210,7 @@ def test_peak_width_signal_limits():
 
     pmts = PMTResponses(np.arange(1), signal)
     peak = S1(times, widths, pmts, SiPMResponses.build_empty_instance())
-    assert peak.width == (nsamples-2)
+    assert peak.width == nsamples - 2
 
 
 def _get_indices_above_thr(sr, thr):
@@ -280,7 +280,7 @@ def test_Peak_width_above_threshold_max_zero(pks):
 def test_Peak_width_above_threshold(pks, thr):
     _, peak = pks
     i_above_thr     = _get_indices_above_thr(peak.pmts, thr)
-    if np.size(i_above_thr)>0:
+    if np.size(i_above_thr) > 0:
         imin = i_above_thr[0]
         imax = i_above_thr[-1]
         expected = np.sum(peak.bin_widths[imin:imax+1])

--- a/invisible_cities/evm/pmaps_test.py
+++ b/invisible_cities/evm/pmaps_test.py
@@ -280,9 +280,12 @@ def test_Peak_width_above_threshold_max_zero(pks):
 def test_Peak_width_above_threshold(pks, thr):
     _, peak = pks
     i_above_thr     = _get_indices_above_thr(peak.pmts, thr)
-    expected        = (np.sum(peak.bin_widths[i_above_thr])
-                       if np.size(i_above_thr) > 0
-                       else 0)
+    if np.size(i_above_thr)>0:
+        imin = i_above_thr[0]
+        imax = i_above_thr[-1]
+        expected = np.sum(peak.bin_widths[imin:imax+1])
+    else:
+        expected = 0
     assert peak.width_above_threshold(thr) == approx(expected)
 
 


### PR DESCRIPTION
This PR changes the computation of signal (peak) width for signals. The current default is to sum the width of the bins with charge larger than 0. This may bias the expected/desired calculation for S1 signals, which are much shorter than S2's and it is common for them to contain zero charge bins.