### PR TITLE
Fix isaura processing for zero-energy events

### DIFF
--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -1094,6 +1094,7 @@ def make_event_summary(event_number  : int              ,
     DataFrame containing relevant per event information.
     """
     es = pd.DataFrame(columns=list(types_dict_summary.keys()))
+    if len(paolina_hits.hits) == 0: return es
 
     ntrks = len(topology_info.index)
     nhits = len(paolina_hits.hits)

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -1196,7 +1196,9 @@ def track_blob_info_creator_extractor(vox_size         : [float, float, float],
             hitc      = HitCollection(hitc.event, hitc.time)
             hitc.hits = hits_without_nan
 
-        if len(hitc.hits) > 0:
+        hit_energies = np.array([getattr(h, HitEnergy.Ep.value) for h in hitc.hits])
+
+        if len(hitc.hits) > 0 and (hit_energies>0).all():
             voxels           = plf.voxelize_hits(hitc.hits, vox_size, strict_vox_size, HitEnergy.Ep)
             (    mod_voxels,
              dropped_voxels) = plf.drop_end_point_voxels(voxels, energy_threshold, min_voxels)

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -1199,7 +1199,7 @@ def track_blob_info_creator_extractor(vox_size         : [float, float, float],
 
         hit_energies = np.array([getattr(h, HitEnergy.Ep.value) for h in hitc.hits])
 
-        if len(hitc.hits) > 0 and (hit_energies>0).all():
+        if len(hitc.hits) > 0 and (hit_energies>0).any():
             voxels           = plf.voxelize_hits(hitc.hits, vox_size, strict_vox_size, HitEnergy.Ep)
             (    mod_voxels,
              dropped_voxels) = plf.drop_end_point_voxels(voxels, energy_threshold, min_voxels)


### PR DESCRIPTION
Beersheba can return a deconvoluted track such all hit energies are zero. This can happen when esmeralda corrected energies are NaN values, when the event hits are outside the boundaries of the kr correction map.

When this kind of events are processed by isaura, the voxelization function returns an empty list, since no zero energy voxels are built. An empty list cannot be further processed (see `track_blob_info_creator_extractor` function).

This PR solves this issue by allowing isaura to process this events, such that paolina algorithm is not run for them.