### PR TITLE
Simplify file compression

### DIFF
--- a/invisible_cities/cities/beersheba.py
+++ b/invisible_cities/cities/beersheba.py
@@ -297,14 +297,13 @@ def check_nonempty_dataframe(df) -> bool:
     return len(df) > 0
 
 
-def deconv_writer(h5out, compression='ZLIB4'):
+def deconv_writer(h5out):
     """
     For a given open table returns a writer for deconvolution hits dataframe
     """
     def write_deconv(df):
         return df_writer(h5out              = h5out             ,
                          df                 = df                ,
-                         compression        = compression       ,
                          group_name         = 'DECO'            ,
                          table_name         = 'Events'          ,
                          descriptive_string = 'Deconvolved hits',

--- a/invisible_cities/cities/cities_test.py
+++ b/invisible_cities/cities/cities_test.py
@@ -1,13 +1,21 @@
 import os
 
 from importlib import import_module
+from itertools import chain
+
+import tables as tb
+
 from pytest import mark
+
 from .. core.configure      import configure
 
-cities = "irene dorothea penthesilea esmeralda beersheba".split()
+some_cities = "irene dorothea penthesilea esmeralda beersheba".split()
+all_cities  = """beersheba berenice buffy detsim diomira dorothea esmeralda
+                 eutropia hypathia irene isaura isidora penthesilea phyllis
+                 trude""".split()
 
 @mark.filterwarnings("ignore::UserWarning")
-@mark.parametrize("city", cities)
+@mark.parametrize("city", some_cities)
 def test_city_empty_input_file(config_tmpdir, ICDATADIR, city):
     # All cities run in Canfranc must run on an empty file
     # without raising any exception
@@ -24,3 +32,28 @@ def test_city_empty_input_file(config_tmpdir, ICDATADIR, city):
     city_function = getattr(import_module(module_name), city)
 
     city_function(**conf)
+
+
+
+@mark.filterwarnings("ignore::UserWarning")
+@mark.parametrize("city", all_cities)
+def test_city_output_file_is_compressed(config_tmpdir, ICDATADIR, city):
+    file_out    = os.path.join(config_tmpdir, f"{city}_compression.h5")
+    config_file = 'dummy invisible_cities/config/{}.conf'.format(city)
+
+    conf = configure(config_file.split())
+    conf.update(dict(file_out = file_out))
+
+    module_name   = f'invisible_cities.cities.{city}'
+    city_function = getattr(import_module(module_name), city)
+
+    city_function(**conf)
+
+    with tb.open_file(file_out) as file:
+        for node in chain([file], file.walk_nodes()):
+            try:
+                assert (node.filters.complib   is not None and
+                        node.filters.complevel > 0)
+
+            except tb.NoSuchNodeError:
+                continue

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -922,7 +922,7 @@ def waveform_integrator(limits):
 def compute_and_write_pmaps(detector_db, run_number, pmt_samp_wid, sipm_samp_wid,
                   s1_lmax, s1_lmin, s1_rebin_stride, s1_stride, s1_tmax, s1_tmin,
                   s2_lmax, s2_lmin, s2_rebin_stride, s2_stride, s2_tmax, s2_tmin, thr_sipm_s2,
-                  h5out, compression, sipm_rwf_to_cal=None):
+                  h5out, sipm_rwf_to_cal=None):
 
     # Filter events without signal over threshold
     indices_pass    = fl.map(check_nonempty_indices,
@@ -942,9 +942,9 @@ def compute_and_write_pmaps(detector_db, run_number, pmt_samp_wid, sipm_samp_wid
     empty_pmaps     = fl.count_filter(bool, args = "pmaps_pass")
 
     # Define writers...
-    write_pmap_         = pmap_writer        (h5out,                compression=compression)
-    write_indx_filter_  = event_filter_writer(h5out, "s12_indices", compression=compression)
-    write_pmap_filter_  = event_filter_writer(h5out, "empty_pmap" , compression=compression)
+    write_pmap_         = pmap_writer        (h5out,              )
+    write_indx_filter_  = event_filter_writer(h5out, "s12_indices")
+    write_pmap_filter_  = event_filter_writer(h5out, "empty_pmap" )
 
     # ... and make them sinks
     write_pmap         = sink(write_pmap_        , args=(        "pmap", "event_number"))
@@ -1123,14 +1123,13 @@ def make_event_summary(event_number  : int              ,
 
 
 
-def track_writer(h5out, compression='ZLIB4'):
+def track_writer(h5out):
     """
     For a given open table returns a writer for topology info dataframe
     """
     def write_tracks(df):
         return df_writer(h5out              = h5out              ,
                          df                 = df                 ,
-                         compression        = compression        ,
                          group_name         = 'Tracking'         ,
                          table_name         = 'Tracks'           ,
                          descriptive_string = 'Track information',
@@ -1138,14 +1137,13 @@ def track_writer(h5out, compression='ZLIB4'):
     return write_tracks
 
 
-def summary_writer(h5out, compression='ZLIB4'):
+def summary_writer(h5out):
     """
     For a given open table returns a writer for summary info dataframe
     """
     def write_summary(df):
         return df_writer(h5out              = h5out                      ,
                          df                 = df                         ,
-                         compression        = compression                ,
                          group_name         = 'Summary'                  ,
                          table_name         = 'Events'                   ,
                          descriptive_string = 'Event summary information',

--- a/invisible_cities/cities/diomira.py
+++ b/invisible_cities/cities/diomira.py
@@ -107,9 +107,7 @@ def diomira(files_in    , file_out      , compression   ,
                                  args="sipm_sim")
 
         write_event_info_ = run_and_event_writer(h5out)
-        write_evt_filter_ = event_filter_writer (h5out                    ,
-                                                 "trigger"                ,
-                                                 compression = compression)
+        write_evt_filter_ = event_filter_writer (h5out, "trigger")
 
         write_event_info = fl.sink(write_event_info_,
                                    args=("run_number", "event_number",

--- a/invisible_cities/cities/eutropia.py
+++ b/invisible_cities/cities/eutropia.py
@@ -128,7 +128,6 @@ def eutropia( files_in, file_out, compression, event_range
 
         df_writer(h5out, result
                  , "PSF", "PSFs"
-                 , compression = compression
                  , descriptive_string = f"PSF with {bin_size_xy} mm bin size"
                  )
 

--- a/invisible_cities/cities/eutropia.py
+++ b/invisible_cities/cities/eutropia.py
@@ -45,6 +45,7 @@ from .. core    .core_functions   import in_range
 from .. database.load_db          import DataSiPM
 from .. io      .dst_io           import df_writer
 from .. io      .run_and_event_io import run_and_event_writer
+from .. reco                      import tbl_functions as tbl
 from .. reco    .psf_functions    import create_psf
 from .. reco    .psf_functions    import hdst_psf_processing
 
@@ -104,7 +105,7 @@ def eutropia( files_in, file_out, compression, event_range
 
     accumulate_psf = fl.reduce(combine_psfs, None)()
 
-    with tb.open_file(file_out, "w") as h5out:
+    with tb.open_file(file_out, "w", filters=tbl.filters(compression)) as h5out:
         write_event_info = fl.sink( run_and_event_writer(h5out)
                                   , args = ("run_number", "event_number", "timestamp")
                                   )

--- a/invisible_cities/cities/hypathia.py
+++ b/invisible_cities/cities/hypathia.py
@@ -121,7 +121,7 @@ def hypathia(files_in, file_out, compression, event_range, print_mod, detector_d
                                              detector_db, run_number, pmt_samp_wid, sipm_samp_wid,
                                              s1_lmax, s1_lmin, s1_rebin_stride, s1_stride, s1_tmax, s1_tmin,
                                              s2_lmax, s2_lmin, s2_rebin_stride, s2_stride, s2_tmax, s2_tmin, thr_sipm_s2,
-                                             h5out, compression, sipm_rwf_to_cal)
+                                             h5out, sipm_rwf_to_cal)
 
         result = push(source = wf_from_files(files_in, WfType.mcrd),
                       pipe   = pipe(fl.slice(*event_range, close_all=True),
@@ -164,4 +164,3 @@ def rebin_pmts(rebin_stride):
 
 def pmts_sum(rwfs):
     return rwfs.sum(axis=0)
-

--- a/invisible_cities/cities/irene.py
+++ b/invisible_cities/cities/irene.py
@@ -105,7 +105,7 @@ def irene(files_in, file_out, compression, event_range, print_mod, detector_db, 
                                          s1_lmax, s1_lmin, s1_rebin_stride, s1_stride, s1_tmax, s1_tmin,
                                          s2_lmax, s2_lmin, s2_rebin_stride, s2_stride, s2_tmax, s2_tmin,
                                          thr_sipm_s2,
-                                         h5out, compression, sipm_rwf_to_cal)
+                                         h5out, sipm_rwf_to_cal)
 
         result = push(source = wf_from_files(files_in, WfType.rwf),
                       pipe   = pipe(fl.slice(*event_range, close_all=True),

--- a/invisible_cities/io/dst_io.py
+++ b/invisible_cities/io/dst_io.py
@@ -11,6 +11,11 @@ from .  table_io        import make_table
 
 from    typing          import Optional
 from    typing          import Sequence
+from    typing          import Union
+
+
+# Temporary. Will be fixed in the future
+NoneType = type(None)
 
 
 def _decode_str_columns(df):
@@ -78,10 +83,11 @@ def df_writer(h5out              : tb.file.File ,
               df                 : pd.DataFrame ,
               group_name         : str          ,
               table_name         : str          ,
-              compression        : str = 'ZLIB4',
               descriptive_string : str = ""     ,
               str_col_length     : int = 32     ,
-              columns_to_index   : Optional[Sequence[str]] = None
+              columns_to_index   : Optional[Sequence[str]] = None,
+              *,
+              compression        : Optional[Union[str, NoneType]] = None,
               ) -> None:
     """ The function writes a dataframe to open pytables file.
     Parameters:

--- a/invisible_cities/io/event_filter_io.py
+++ b/invisible_cities/io/event_filter_io.py
@@ -5,10 +5,10 @@ from .. evm      import nh5        as table_formats
 from .  table_io import make_table
 
 
-def event_filter_writer(file, filter_name, *, compression='ZLIB4'):
+def event_filter_writer(file, filter_name, *, compression=None):
     table = make_table(file,
                        group       = "Filters",
-                        name        = filter_name,
+                        name       = filter_name,
                        fformat     = table_formats.EventPassedFilter,
                        description = "Event has passed filter flag",
                        compression = compression)

--- a/invisible_cities/io/histogram_io.py
+++ b/invisible_cities/io/histogram_io.py
@@ -22,7 +22,12 @@ def hist_writer(file,
                                     filters = tbl.filters(compression))
 
     ## The bins can be written just once at definition of the writer
-    file.create_array(hist_group, table_name+'_bins', bin_centres)
+    file.create_carray( hist_group
+                      , table_name + '_bins'
+                      , tb.Float64Atom()
+                      , filters = tbl.filters(compression)
+                      , obj     = bin_centres)
+
 
     def write_hist(histo : 'np.array of histograms, one for each sensor'):
         hist_table.append(histo.reshape(1, n_sensors, n_bins))

--- a/invisible_cities/io/histogram_io.py
+++ b/invisible_cities/io/histogram_io.py
@@ -7,9 +7,9 @@ def hist_writer(file,
                 *,
                 group_name  : 'options: HIST, HIST2D',
                 table_name  : 'options: pmt, pmtMAU, sipm, sipmMAU',
-                compression = 'ZLIB4',
                 n_sensors   : 'number of pmts or sipms',
-                bin_centres : 'np.array of bin centres'):
+                bin_centres : 'np.array of bin centres',
+                compression = None):
     try:                       hist_group = getattr          (file.root, group_name)
     except tb.NoSuchNodeError: hist_group = file.create_group(file.root, group_name)
 

--- a/invisible_cities/io/hits_io.py
+++ b/invisible_cities/io/hits_io.py
@@ -130,7 +130,7 @@ def load_hits_skipping_NN(DST_file_name : str, group_name : str = 'RECO', table_
 
 
 # writers
-def hits_writer(hdf5_file, group_name='RECO', table_name='Events', *, compression='ZLIB4'):
+def hits_writer(hdf5_file, group_name='RECO', table_name='Events', *, compression=None):
     hits_table  = make_table(hdf5_file,
                              group       = group_name,
                              name        = table_name,

--- a/invisible_cities/io/kdst_io.py
+++ b/invisible_cities/io/kdst_io.py
@@ -4,7 +4,7 @@ from .. evm.nh5  import KrTable
 from .. io.dst_io import df_writer
 
 
-def kr_writer(hdf5_file, *, compression='ZLIB4'):
+def kr_writer(hdf5_file, *, compression=None):
     kr_table = make_table(hdf5_file,
                           group       = 'DST',
                           name        = 'Events',
@@ -19,7 +19,7 @@ def kr_writer(hdf5_file, *, compression='ZLIB4'):
     return write_kr
 
 
-def kdst_from_df_writer(h5out, compression='ZLIB4'):
+def kdst_from_df_writer(h5out, compression=None):
     """
     For a given open table returns a writer for KDST dataframe info
     """

--- a/invisible_cities/io/mcinfo_io.py
+++ b/invisible_cities/io/mcinfo_io.py
@@ -40,7 +40,7 @@ class MCTableType(AutoNameEnumBase):
     waveforms        = auto()
 
 
-def mc_writer(h5out : tb.file.File) -> Callable:
+def mc_writer(h5out : tb.file.File, *, compression=None) -> Callable:
     """
     Writes the MC tables to the output file.
 
@@ -54,9 +54,10 @@ def mc_writer(h5out : tb.file.File) -> Callable:
     write_mctables : Callable
         Function which writes to the file.
     """
-    mcwriter_ = partial(df_writer         ,
-                        h5out      = h5out,
-                        group_name =  'MC')
+    mcwriter_ = partial(df_writer                ,
+                        h5out       =       h5out,
+                        group_name  =        'MC',
+                        compression = compression)
     def write_mctables(table_dict : Dict):
         """
         Writer function

--- a/invisible_cities/io/pmaps_io.py
+++ b/invisible_cities/io/pmaps_io.py
@@ -54,12 +54,12 @@ def store_pmap(tables, pmap, event_number):
         store_peak(s2_table, s2i_table, si_table, s2, peak_number, event_number)
 
 
-def pmap_writer(file, *, compression="ZLIB4"):
-    tables = _make_tables(file, compression=compression)
+def pmap_writer(file, *, compression=None):
+    tables = _make_tables(file, compression)
     return partial(store_pmap, tables)
 
 
-def _make_tables(hdf5_file, *, compression="ZLIB4"):
+def _make_tables(hdf5_file, compression):
     compr       = tbl_filters(compression)
     pmaps_group = hdf5_file.create_group(hdf5_file.root, 'PMAPS')
     make_table  = partial(hdf5_file.create_table, pmaps_group, filters=compr)

--- a/invisible_cities/io/pmaps_io_test.py
+++ b/invisible_cities/io/pmaps_io_test.py
@@ -56,7 +56,7 @@ def test_make_tables(output_tmpdir):
     output_filename = os.path.join(output_tmpdir, "make_tables.h5")
 
     with tb.open_file(output_filename, "w") as h5f:
-        pmpio._make_tables(h5f)
+        pmpio._make_tables(h5f, None)
 
         assert "PMAPS" in h5f.root
         for tablename in ("S1", "S2", "S2Si", "S1Pmt", "S2Pmt"):
@@ -75,7 +75,7 @@ def test_store_peak_s1(output_tmpdir, KrMC_pmaps_dict):
         if not pmap.s1s: continue
 
         with tb.open_file(output_filename, "w") as h5f:
-            s1_table, _, _, s1i_table, _ = pmpio._make_tables(h5f)
+            s1_table, _, _, s1i_table, _ = pmpio._make_tables(h5f, None)
 
             peak = pmap.s1s[peak_number]
             pmpio.store_peak(s1_table, s1i_table, None,
@@ -105,7 +105,7 @@ def test_store_peak_s2(output_tmpdir, KrMC_pmaps_dict):
         if not pmap.s2s: continue
 
         with tb.open_file(output_filename, "w") as h5f:
-            _, s2_table, si_table, _, s2i_table = pmpio._make_tables(h5f)
+            _, s2_table, si_table, _, s2i_table = pmpio._make_tables(h5f, None)
 
             peak = pmap.s2s[peak_number]
             pmpio.store_peak(s2_table, s2i_table, si_table,
@@ -140,7 +140,7 @@ def test_store_pmap(output_tmpdir, KrMC_pmaps_dict):
     pmaps, _        = KrMC_pmaps_dict
     evt_numbers_set = np.random.randint(100, 200, size=len(pmaps))
     with tb.open_file(output_filename, "w") as h5f:
-        tables = pmpio._make_tables(h5f)
+        tables = pmpio._make_tables(h5f, None)
         for evt_number, pmap in zip(evt_numbers_set, pmaps.values()):
             pmpio.store_pmap(tables, pmap, evt_number)
         h5f.flush()

--- a/invisible_cities/io/run_and_event_io.py
+++ b/invisible_cities/io/run_and_event_io.py
@@ -20,7 +20,7 @@ def _make_run_event_tables(hdf5_file, compression):
     return run_tables
 
 
-def run_and_event_writer(file, *, compression='ZLIB4'):
+def run_and_event_writer(file, *, compression=None):
     run_tables = _make_run_event_tables(file, compression)
     def write_run_and_event(run_number, event_number, timestamp):
         run_table_dumper  (run_tables[0],   run_number)

--- a/invisible_cities/io/rwf_io.py
+++ b/invisible_cities/io/rwf_io.py
@@ -5,6 +5,7 @@ from functools import  partial
 from typing    import Callable
 from typing    import     List
 from typing    import Optional
+from typing    import    Union
 from typing    import    Tuple
 
 from .. evm .nh5         import           MCEventMap
@@ -13,13 +14,18 @@ from .  run_and_event_io import run_and_event_writer
 from .  table_io         import           make_table
 
 
-def rwf_writer(h5out           : tb.file.File          ,
+# Temporary. Will be fixed in the future
+NoneType = type(None)
+
+
+def rwf_writer(h5out           : tb.file.File,
                *,
-               group_name      :          str          ,
-               table_name      :          str          ,
-               compression     :          str = 'ZLIB4',
-               n_sensors       :          int          ,
-               waveform_length :          int          ) -> Callable:
+               group_name      : str         ,
+               table_name      : str         ,
+               n_sensors       : int         ,
+               waveform_length : int         ,
+               compression     : Optional[Union[str, NoneType]] = None,
+              ) -> Callable:
     """
     Defines group and table where raw waveforms
     will be written.
@@ -138,7 +144,7 @@ def buffer_writer(h5out, *,
                       events    : List[Tuple]) -> None:
         """
         Write run info and event waveforms to file.
-        
+
         parameters
         ----------
         nexus_evt  :  int

--- a/invisible_cities/io/table_io.py
+++ b/invisible_cities/io/table_io.py
@@ -2,9 +2,10 @@
 from .. reco import tbl_functions as tbl
 
 def make_table(hdf5_file,
-               group, name, fformat, description, compression):
+               group, name, fformat, description, compression = None):
     if group not in hdf5_file.root:
         hdf5_file.create_group(hdf5_file.root, group)
+
     table = hdf5_file.create_table(getattr(hdf5_file.root, group),
                                    name,
                                    fformat,

--- a/invisible_cities/io/trigger_io.py
+++ b/invisible_cities/io/trigger_io.py
@@ -19,12 +19,12 @@ def store_trigger(tables, trg_type, trg_channels):
         trg_channels_array.append(trg_channels.reshape(new_shape))
 
 
-def trigger_writer(file, n_sensors, compression="ZLIB4"):
-    tables = _make_tables(file, n_sensors, compression=compression)
+def trigger_writer(file, n_sensors, compression=None):
+    tables = _make_tables(file, n_sensors, compression)
     return partial(store_trigger, tables)
 
 
-def _make_tables(hdf5_file, n_sensors, compression="ZLIB4"):
+def _make_tables(hdf5_file, n_sensors, compression):
     compr         = tbl_filters(compression)
     trigger_group = hdf5_file.create_group(hdf5_file.root, 'Trigger')
     make_table    = partial(hdf5_file.create_table, trigger_group, filters=compr)

--- a/invisible_cities/io/voxels_io.py
+++ b/invisible_cities/io/voxels_io.py
@@ -6,7 +6,7 @@ from .. evm.event_model    import Voxel
 from .. evm.event_model    import VoxelCollection
 from .. evm.nh5            import VoxelsTable
 
-def true_voxels_writer(hdf5_file, *, compression='ZLIB4'):
+def true_voxels_writer(hdf5_file, *, compression=None):
 
     voxels_table  = make_table(hdf5_file,
                              group       = 'TrueVoxels',

--- a/invisible_cities/reco/tbl_functions.py
+++ b/invisible_cities/reco/tbl_functions.py
@@ -32,6 +32,8 @@ def filters(name):
     filt : tb.filters.Filter
         Filter mode instance.
     """
+    if name is None: return None
+
     try:
         level, lib = {"NOCOMPR": (0,  None)        ,
                       "ZLIB1"  : (1, 'zlib')       ,


### PR DESCRIPTION
In this PR, I revisit the file compression in IC. The main point was that this feature relied on the same default value being used everywhere (namely `"ZLIB4"`). While addressing this, I noticed that we didn't have any check for compression and that we were doing it inconsistently. Furthermore, the compression options were redundant, as the compression library and level can be set at file opening, and the data stored inherits this configuration.

There are two significant changes implemented here:
- Writers will no longer compress something with a default value that magically happened to be the same everywhere. As a consequence, cities are now fully responsible for file compression.
- By default, the compression configuration will be set only at file opening. This, however, can be overridden for each individual writer explicitly.

These changes won't have a major impact on users or developers. Nonetheless, developers writing new cities will have to be aware of this.