### PR TITLE
Update event ID

### DIFF
--- a/invisible_cities/cities/berenice_test.py
+++ b/invisible_cities/cities/berenice_test.py
@@ -28,7 +28,7 @@ def test_berenice_sipmdarkcurrent(config_tmpdir, ICDATADIR):
     with tb.open_file(PATH_IN , mode='r') as h5in, \
          tb.open_file(PATH_OUT, mode='r') as h5out:
 
-        evts_in  = h5in .root.Run.events[:nrequired].astype([('evt_number', '<i4'), ('timestamp', '<u8')])
+        evts_in  = h5in .root.Run.events[:nrequired]
         evts_out = h5out.root.Run.events[:nrequired]
         assert_array_equal(evts_in, evts_out)
 

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -99,7 +99,7 @@ def test_irene_electrons_40keV(config_tmpdir, ICDATADIR, s12params,
          tb.open_file(PATH_OUT, mode='r') as h5out:
 
             # check events numbers & timestamps
-            evts_in  = h5in .root.Run.events[:nactual].astype([('evt_number', '<i4'), ('timestamp', '<u8')])
+            evts_in  = h5in .root.Run.events[:nactual]
             evts_out = h5out.root.Run.events[:nactual]
             np.testing.assert_array_equal(evts_in, evts_out)
 

--- a/invisible_cities/cities/isidora_test.py
+++ b/invisible_cities/cities/isidora_test.py
@@ -34,7 +34,7 @@ def test_isidora_electrons_40keV(config_tmpdir, ICDATADIR):
     with tb.open_file(PATH_IN,  mode='r') as h5in, \
          tb.open_file(PATH_OUT, mode='r') as h5out:
             # check events numbers & timestamps
-            evts_in  = h5in .root.Run.events[:nactual].astype([('evt_number', '<i4'), ('timestamp', '<u8')])
+            evts_in  = h5in .root.Run.events[:nactual]
             evts_out = h5out.root.Run.events[:nactual]
             np.testing.assert_array_equal(evts_in, evts_out)
 

--- a/invisible_cities/cities/phyllis_test.py
+++ b/invisible_cities/cities/phyllis_test.py
@@ -32,7 +32,7 @@ def test_phyllis_pulsedata(config_tmpdir, ICDATADIR, proc_opt):
     with tb.open_file(PATH_IN,  mode='r') as h5in, \
          tb.open_file(PATH_OUT, mode='r') as h5out:
 
-        evts_in  = h5in .root.Run.events[:nrequired].astype([('evt_number', '<i4'), ('timestamp', '<u8')])
+        evts_in  = h5in .root.Run.events[:nrequired]
         evts_out = h5out.root.Run.events[:nrequired]
         assert_array_equal(evts_in, evts_out)
 

--- a/invisible_cities/cities/trude_test.py
+++ b/invisible_cities/cities/trude_test.py
@@ -33,7 +33,7 @@ def test_trude_pulsedata(config_tmpdir, ICDATADIR, proc_opt):
     with tb.open_file(PATH_IN , mode='r') as h5in, \
          tb.open_file(PATH_OUT, mode='r') as h5out:
 
-        evts_in  = h5in .root.Run.events[:nrequired].astype([('evt_number', '<i4'), ('timestamp', '<u8')])
+        evts_in  = h5in .root.Run.events[:nrequired]
         evts_out = h5out.root.Run.events[:nrequired]
         assert_array_equal(evts_in, evts_out)
 

--- a/invisible_cities/database/test_data/Kr_hits_for_psf_0.h5
+++ b/invisible_cities/database/test_data/Kr_hits_for_psf_0.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1cbdbf3da050d5fb800bf7850fa03a18b83ca8b54dc705ee5d3fef787c5b1fd0
+oid sha256:65a9b4cffd60c036b1444ef365ed3d2c3b25fca27308c87d8467aaf10d965653
 size 529668

--- a/invisible_cities/database/test_data/Kr_hits_for_psf_1.h5
+++ b/invisible_cities/database/test_data/Kr_hits_for_psf_1.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6a9564414bc220d649ec001ee4d62b637a61ce44c4f4d8fa6eee5f650fa8244d
-size 540054
+oid sha256:a675e21528130191e21e85fd6ddf1c60ad817f20b8788fa6f0921d50229a8ce6
+size 540440

--- a/invisible_cities/database/test_data/Kr_hits_for_psf_2.h5
+++ b/invisible_cities/database/test_data/Kr_hits_for_psf_2.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2e7f472d343de47f123c9acc344428e4bd64796f47b6645213050f0bfeb04c09
-size 564804
+oid sha256:e75f340e4350314fc5476752d17526293352774edfdbe31b0804f8b9ce0dceda
+size 565197

--- a/invisible_cities/database/test_data/electrons_40keV_ACTIVE_10evts_RWF.h5
+++ b/invisible_cities/database/test_data/electrons_40keV_ACTIVE_10evts_RWF.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ca43fc96b2393385371b54cdf8af38456b516c85f0097a8f257f757b9921372c
+oid sha256:ad3602df9eab742f00501d465343ada1660abf1525ff346835c0c8a0be7cb0f8
 size 1497328

--- a/invisible_cities/database/test_data/electrons_40keV_z25_RWF.h5
+++ b/invisible_cities/database/test_data/electrons_40keV_z25_RWF.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:78a68fe4549e8896e3055b34d915ca399cf17de322fe657df86334f70c7ad8ce
+oid sha256:a21300bf9b20b024eaec602eb80dbe7b74020670c4f469cbd28bae1ff4ecc157
 size 2898908

--- a/invisible_cities/database/test_data/pmtledpulsedata.h5
+++ b/invisible_cities/database/test_data/pmtledpulsedata.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e796d2949c2ae3a9267c7b7095b5da13d83984e8e3f231579b7f6c2612a2aa50
-size 4701497
+oid sha256:aeffa61ee48e5b364245518ef6009e00525dde4cbd0cb2969c0c2b87ed6122a1
+size 4703593

--- a/invisible_cities/database/test_data/sipmdarkcurrentdata.h5
+++ b/invisible_cities/database/test_data/sipmdarkcurrentdata.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ad98fa586009e85bf59f8e2377bd957195f09bab1139c70bb69602a1619eca64
-size 5131461
+oid sha256:b7012900a4a6e670d9ccc043eb44706e1105376bfeb31e8dc43bddb9e79cd44e
+size 5133557

--- a/invisible_cities/database/test_data/sipmledpulsedata.h5
+++ b/invisible_cities/database/test_data/sipmledpulsedata.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1d68634a03201c7895650a7713c21592406d6efcec9177292c1b8e3a79f1c90c
-size 2553389
+oid sha256:131ee9d77547967bab4c04fd1ad5ea3c0ae22c233dff0c16b27b47a0456cded3
+size 2555485

--- a/invisible_cities/evm/nh5.py
+++ b/invisible_cities/evm/nh5.py
@@ -11,7 +11,7 @@ class TriggerType(tb.IsDescription):
 
 
 class EventInfo(tb.IsDescription):
-    evt_number = tb.Int32Col(shape=(), pos=0)
+    evt_number = tb. Int64Col(shape=(), pos=0)
     timestamp  = tb.UInt64Col(shape=(), pos=1)
 
 
@@ -28,9 +28,9 @@ class MCGeneratorInfo(tb.IsDescription):
     """Store MC generator information as metadata using
     Pytables.
     """
-    evt_number    = tb.Int32Col(pos=0)
-    atomic_number = tb.Int32Col(pos=1)
-    mass_number   = tb.Int32Col(pos=2)
+    evt_number    = tb. Int64Col(pos=0)
+    atomic_number = tb. Int32Col(pos=1)
+    mass_number   = tb. Int32Col(pos=2)
     region        = tb.StringCol(20, pos=3)
 
 
@@ -38,15 +38,15 @@ class MCExtentInfo(tb.IsDescription):
     """Store the last row of each table as metadata using
     Pytables.
     """
-    evt_number    = tb.Int32Col(pos=0)
+    evt_number    = tb. Int64Col(pos=0)
     last_hit      = tb.UInt64Col(pos=1)
     last_particle = tb.UInt64Col(pos=2)
 
 
 class MCEventMap(tb.IsDescription):
     """Map between event index and original event."""
-    evt_number = tb.Int32Col(shape=(), pos=0)
-    nexus_evt  = tb.Int32Col(shape=(), pos=1)
+    evt_number = tb.Int64Col(shape=(), pos=0)
+    nexus_evt  = tb.Int64Col(shape=(), pos=1)
 
 
 class MCHitInfo(tb.IsDescription):
@@ -89,7 +89,7 @@ class S12(tb.IsDescription):
     running over the number of peaks found
     time and energy of the peak.
     """
-    event  = tb.  Int32Col(pos=0)
+    event  = tb.  Int64Col(pos=0)
     peak   = tb.  UInt8Col(pos=2) # peak number
     time   = tb.Float32Col(pos=3) # time in ns
     bwidth = tb.Float32Col(pos=4) # bin width in ns
@@ -103,7 +103,7 @@ class S12Pmt(tb.IsDescription):
     npmt gives the pmt sensor id
     time and energy of the peak.
     """
-    event  = tb.  Int32Col(pos=0)
+    event  = tb.  Int64Col(pos=0)
     peak   = tb.  UInt8Col(pos=2) # peak number
     npmt   = tb.  UInt8Col(pos=3) # pmt number (in order of IC db 26/8/2017: equal to SensorID)
     ene    = tb.Float32Col(pos=5) # energy in pes
@@ -116,14 +116,14 @@ class S2Si(tb.IsDescription):
     nsipm gives the SiPM number
     only energies are stored (times are defined in S2)
     """
-    event = tb.  Int32Col(pos=0)
+    event = tb.  Int64Col(pos=0)
     peak  = tb.  UInt8Col(pos=2) # peak number
     nsipm = tb.  Int16Col(pos=3) # sipm number
     ene   = tb.Float32Col(pos=5) # energy in pes
 
 
 class KrTable(tb.IsDescription):
-    event   = tb.  Int32Col(pos= 0)
+    event   = tb.  Int64Col(pos= 0)
     time    = tb.Float64Col(pos= 1)
     s1_peak = tb. UInt16Col(pos= 2)
     s2_peak = tb. UInt16Col(pos= 3)
@@ -155,7 +155,7 @@ class KrTable(tb.IsDescription):
 
 
 class HitsTable(tb.IsDescription):
-    event    = tb.  Int32Col(pos=0)
+    event    = tb.  Int64Col(pos=0)
     time     = tb.Float64Col(pos=1)
     npeak    = tb. UInt16Col(pos=2)
     Xpeak    = tb.Float64Col(pos=3)
@@ -175,7 +175,7 @@ class HitsTable(tb.IsDescription):
 
 
 class VoxelsTable(tb.IsDescription):
-    event    = tb.  Int32Col(pos=0)
+    event    = tb.  Int64Col(pos=0)
     X        = tb.Float64Col(pos=1)
     Y        = tb.Float64Col(pos=2)
     Z        = tb.Float64Col(pos=3)
@@ -184,5 +184,5 @@ class VoxelsTable(tb.IsDescription):
 
 
 class EventPassedFilter(tb.IsDescription):
-    event  = tb.Int32Col(pos=0)
+    event  = tb.Int64Col(pos=0)
     passed = tb. BoolCol(pos=1)


### PR DESCRIPTION
This PR changes the `event_ID` field of the IC table from `int32` to `int64` to avoid overflow in the case of large background productions.