### PR TITLE
DEMO SiPMs calibration

### DIFF
--- a/invisible_cities/database/localdb.DEMOPPDB.sqlite3
+++ b/invisible_cities/database/localdb.DEMOPPDB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:53c58499fa5d03f7c28ef8f4ef5fc13ff8daef8afb5fcc02ec0db7d8f7716ae5
-size 19607552
+oid sha256:c15ffa11f8436fadeddd26873b45d1c5a2acc7f9056411af0149decad294dac3
+size 22208512

--- a/invisible_cities/database/localdb.DEMOPPDB.sqlite3
+++ b/invisible_cities/database/localdb.DEMOPPDB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:98fe82c7033e93c67e1f3de85cd6f78f4d5a793af85c9db5100fb4b354ac1064
-size 19374080
+oid sha256:f6edca01fbaeb8e27fa749657f7ae28da015b799b421cc8034ce761fab631002
+size 19595264

--- a/invisible_cities/database/localdb.DEMOPPDB.sqlite3
+++ b/invisible_cities/database/localdb.DEMOPPDB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f6edca01fbaeb8e27fa749657f7ae28da015b799b421cc8034ce761fab631002
-size 19595264
+oid sha256:53c58499fa5d03f7c28ef8f4ef5fc13ff8daef8afb5fcc02ec0db7d8f7716ae5
+size 19607552

--- a/invisible_cities/database/localdb.DEMOPPDB.sqlite3
+++ b/invisible_cities/database/localdb.DEMOPPDB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:df71cf141c2414c98d630e6f65ac88f2196b3ced98c31ea37f53e16fa07e5691
+oid sha256:087296b66b49843312db3c9e7703bc1c6f70946e479fc6454a5ddccc5464292c
 size 22208512

--- a/invisible_cities/database/localdb.DEMOPPDB.sqlite3
+++ b/invisible_cities/database/localdb.DEMOPPDB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c15ffa11f8436fadeddd26873b45d1c5a2acc7f9056411af0149decad294dac3
+oid sha256:df71cf141c2414c98d630e6f65ac88f2196b3ced98c31ea37f53e16fa07e5691
 size 22208512


### PR DESCRIPTION
Demo++ database has been updated with the calibration constants from R11179 for the SiPMs and pdfs. SiPM 14033 seems to be dead, therefore it has been masked. Also, the sensor ids have been fixed according to the frontends change and the positioning of the dices. Two sensors are unable to calibrate but they are hidden by the light tube (plotted in pink, top left, the red one is dead):

![Screenshot 2022-06-15 at 12 15 48](https://user-images.githubusercontent.com/32193826/173803904-8a08f2d4-079b-4c9b-9ba4-0acfdc4bf961.png)

![Screenshot 2022-06-15 at 12 12 10](https://user-images.githubusercontent.com/32193826/173803262-ef64f3d4-3657-4463-8180-c6ff1cea391f.png)

![Screenshot 2022-06-15 at 12 11 11](https://user-images.githubusercontent.com/32193826/173803081-8f0d6e43-7eb3-499c-8bec-f51fde1e6050.png)
 