### PR TITLE
Change `max_time` annotation in Buffy functions

### DIFF
--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -992,6 +992,9 @@ def check_max_time(max_time: float, buffer_length: float) -> Union[int, float]:
     :param buffer_length: Length of buffers.
     :return: `max_time` if `max_time` >= `buffer_length`, else `buffer_length`.
     """
+    if max_time % units.mus:
+        message = "Invalid value for max_time, it has to be a multiple of 1 mus"
+        raise ValueError(message)
 
     if max_time < buffer_length:
         warnings.warn("`max_time` shorter than `buffer_length`, "

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -981,7 +981,7 @@ def compute_and_write_pmaps(detector_db, run_number, pmt_samp_wid, sipm_samp_wid
     return compute_pmaps, empty_indices, empty_pmaps
 
 
-def check_max_time(max_time: Union[int, float], buffer_length: float) -> Union[int, float]:
+def check_max_time(max_time: float, buffer_length: float) -> Union[int, float]:
     """
     `max_time` must be greater than `buffer_length`. If not, raise warning
         and set `max_time` == `buffer_length`.
@@ -1003,7 +1003,7 @@ def check_max_time(max_time: Union[int, float], buffer_length: float) -> Union[i
 
 
 def calculate_and_save_buffers(buffer_length    : float        ,
-                               max_time         : int          ,
+                               max_time         : float        ,
                                pre_trigger      : float        ,
                                pmt_wid          : float        ,
                                sipm_wid         : float        ,

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -302,3 +302,15 @@ def test_check_max_time_eg_buffer_length():
 
     assert max_time_1 >  buffer_length_1
     assert max_time_2 == buffer_length_2
+
+def test_check_max_time_units():
+    """
+    Check if `check_max_time` rejects values of `max_time`
+        that are not multiples of 1 mus.
+    """
+    max_time      = 1000.5 * units.mus
+    buffer_length = 800 * units.mus
+
+    with raises(ValueError):
+        check_max_time(max_time, buffer_length)
+

--- a/invisible_cities/detsim/buffer_functions.py
+++ b/invisible_cities/detsim/buffer_functions.py
@@ -18,7 +18,7 @@ def bin_sensors(sensors   : pd.DataFrame,
                 bin_width : float       ,
                 t_min     : float       ,
                 t_max     : float       ,
-                max_buffer: int         ) -> Tuple[np.ndarray, pd.Series]:
+                max_buffer: float       ) -> Tuple[np.ndarray, pd.Series]:
     """
     Raw data binning function.
 


### PR DESCRIPTION
In Buffy, `max_time` is defined as the maximum duration of the event that will be taken into account starting from the first detected signal. Despite it's a time unit it was defined as an `int`.  This PR modifies its type annotations from `int` to `float` in all the functions used by Buffy. 