### PR TITLE
Update NEXT100 PMT mapping according to latest changes at LSC

### DIFF
--- a/invisible_cities/database/localdb.NEXT100DB.sqlite3
+++ b/invisible_cities/database/localdb.NEXT100DB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:82aea5484084fac89090f8696653b446a8a17cd5e5cd72d521cb3a0b2e37bbbc
-size 34680832
+oid sha256:87f9e2c01c78df523622d25814f77d79d8e8f8cfbaea4a2325bb236bea371687
+size 34684928


### PR DESCRIPTION
This PR updates NEXT100's database to fix the PMT channel mapping according to the latest data from the installation at LSC.