### PR TITLE
Require `detector_db` in all cities

### DIFF
--- a/invisible_cities/cities/cities_test.py
+++ b/invisible_cities/cities/cities_test.py
@@ -6,6 +6,7 @@ from itertools import chain
 import tables as tb
 
 from pytest import mark
+from pytest import raises
 
 from .. core.configure      import configure
 
@@ -57,3 +58,23 @@ def test_city_output_file_is_compressed(config_tmpdir, ICDATADIR, city):
 
             except tb.NoSuchNodeError:
                 continue
+
+
+@mark.filterwarnings("ignore::UserWarning")
+@mark.parametrize("city", all_cities)
+def test_city_missing_detector_db(city):
+    # use default config file
+    config_file = 'dummy invisible_cities/config/{}.conf'.format(city)
+    conf = configure(config_file.split())
+
+    # delete the detector_db key from the config
+    del conf['detector_db']
+
+    # collect relevant city information for running
+    module_name   = f'invisible_cities.cities.{city}'
+    city_function = getattr(import_module(module_name), city)
+
+    # check that the test provides the
+    # required value error for missing detector_db
+    with raises(ValueError, match=r"The function `(\w+)` is missing an argument `detector_db`"):
+    	city_function(**conf)

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -112,11 +112,6 @@ def city(city_function):
         if 'files_in' not in kwds: raise NoInputFiles
         if 'file_out' not in kwds: raise NoOutputFile
 
-        # For backward-compatibility we set NEW as the default DB in
-        # case it is not defined in the config file
-        if 'detector_db' in inspect.getfullargspec(city_function).args and \
-           'detector_db' not in kwds:
-            conf.detector_db = 'new'
 
         conf.files_in  = sorted(glob(expandvars(conf.files_in)))
         conf.file_out  =             expandvars(conf.file_out)

--- a/invisible_cities/config/beersheba.conf
+++ b/invisible_cities/config/beersheba.conf
@@ -5,6 +5,9 @@ event_range=10
 # run number 0 is for MC
 run_number = 0
 
+# Detector database used
+detector_db = 'new'
+
 # How frequently to print events
 print_mod = 1
 

--- a/invisible_cities/config/esmeralda.conf
+++ b/invisible_cities/config/esmeralda.conf
@@ -5,6 +5,9 @@ event_range=10
 # run number 0 is for MC
 run_number = 0
 
+# Detector database used
+detector_db = 'new'
+
 # How frequently to print events
 print_mod = 1
 

--- a/invisible_cities/config/isaura.conf
+++ b/invisible_cities/config/isaura.conf
@@ -5,6 +5,9 @@ event_range=1000
 # run number 0 is for MC
 run_number = 0
 
+# Detector database used
+detector_db = 'new'
+
 # How frequently to print events
 print_mod = 100
 

--- a/invisible_cities/io/indexation_test.py
+++ b/invisible_cities/io/indexation_test.py
@@ -44,7 +44,7 @@ def _df_writer(h5out):
 def test_table_is_indexed(tmpdir_factory, writer, group, node, column, thing):
     tmpdir = tmpdir_factory.mktemp('indexation')
     file_out = os.path.join(tmpdir, f"empty_table_containing_{thing}.h5")
-    writer_test_city(writer=writer, file_out=file_out, files_in='dummy')
+    writer_test_city(writer=writer, file_out=file_out, files_in='dummy', detector_db = 'new')
     with tb.open_file(file_out, 'r') as h5out:
         table = getattr(getattr(h5out.root, group), node)
         assert getattr(table.cols, column).is_indexed


### PR DESCRIPTION
As discussed in issue #850, the default city decorator provides `detector_db = 'new'` to each city if none is provided. This causes some issues (particularly with Beersheba) and so has been removed.

In doing so, multiple cities now **require** `detector_db` to be within their config files to pass tests, and [indexation_test.py](https://github.com/jwaiton/IC/blob/force-detector_db/invisible_cities/io/indexation_test.py#L47) has been modified to account for this change in city signature.

Closes #850