### PR TITLE
Allow null event range

### DIFF
--- a/invisible_cities/cities/cities_test.py
+++ b/invisible_cities/cities/cities_test.py
@@ -10,11 +10,11 @@ from pytest import raises
 
 from .. core.configure      import configure
 
-online_cities = "irene dorothea sophronia esmeralda beersheba".split()
-all_cities_with_event_range = online_cities + """
-  berenice buffy detsim diomira hypathia isaura isidora phyllis trude
-  """.split()
-all_cities  = sorted(all_cities_with_event_range + ["eutropia"])
+online_cities  = "irene dorothea sophronia esmeralda beersheba isaura".split()
+mc_cities      = "buffy detsim diomira hypathia".split()
+other_cities   = "berenice isidora phyllis trude eutropia".split()
+all_cities     = sorted(online_cities + mc_cities + other_cities)
+all_cities_with_event_range = sorted(set(all_cities).difference(set(["eutropia"])))
 
 
 @mark.filterwarnings("ignore::UserWarning")

--- a/invisible_cities/cities/cities_test.py
+++ b/invisible_cities/cities/cities_test.py
@@ -11,9 +11,11 @@ from pytest import raises
 from .. core.configure      import configure
 
 online_cities = "irene dorothea sophronia esmeralda beersheba".split()
-all_cities    = """beersheba berenice buffy detsim diomira dorothea esmeralda
-                   eutropia hypathia irene isaura isidora phyllis sophronia
-                   trude""".split()
+all_cities_with_event_range = online_cities + """
+  berenice buffy detsim diomira hypathia isaura isidora phyllis trude
+  """.split()
+all_cities  = sorted(all_cities_with_event_range + ["eutropia"])
+
 
 @mark.filterwarnings("ignore::UserWarning")
 @mark.parametrize("city", online_cities)
@@ -28,6 +30,23 @@ def test_city_empty_input_file(config_tmpdir, ICDATADIR, city):
     conf = configure(config_file.split())
     conf.update(dict(files_in      = PATH_IN,
                      file_out      = PATH_OUT))
+
+    module_name   = f'invisible_cities.cities.{city}'
+    city_function = getattr(import_module(module_name), city)
+
+    city_function(**conf)
+
+
+@mark.filterwarnings("ignore::UserWarning")
+@mark.parametrize("city", all_cities_with_event_range)
+def test_city_null_event_range(config_tmpdir, ICDATADIR, city):
+    # All cities must run with event_range = 0
+    PATH_OUT = os.path.join(config_tmpdir, 'empty_output.h5')
+
+    config_file = 'dummy invisible_cities/config/{}.conf'.format(city)
+    conf = configure(config_file.split())
+    conf.update(dict( file_out = PATH_OUT
+                     , event_range = 0))
 
     module_name   = f'invisible_cities.cities.{city}'
     city_function = getattr(import_module(module_name), city)

--- a/invisible_cities/cities/cities_test.py
+++ b/invisible_cities/cities/cities_test.py
@@ -62,21 +62,27 @@ def test_city_output_file_is_compressed(config_tmpdir, ICDATADIR, city):
     config_file = 'dummy invisible_cities/config/{}.conf'.format(city)
 
     conf = configure(config_file.split())
-    conf.update(dict(file_out = file_out))
+    conf.update(dict( file_out    = file_out
+                    , event_range = 0))
 
     module_name   = f'invisible_cities.cities.{city}'
     city_function = getattr(import_module(module_name), city)
 
     city_function(**conf)
 
+    checked_nodes = 0
     with tb.open_file(file_out) as file:
         for node in chain([file], file.walk_nodes()):
             try:
                 assert (node.filters.complib   is not None and
                         node.filters.complevel > 0)
+                checked_nodes += 1
 
             except tb.NoSuchNodeError:
                 continue
+
+    # ensure that we didn't pass the test because there were no nodes checked
+    assert checked_nodes > 2
 
 
 @mark.filterwarnings("ignore::UserWarning")

--- a/invisible_cities/dataflow/dataflow_test.py
+++ b/invisible_cities/dataflow/dataflow_test.py
@@ -478,7 +478,20 @@ def test_slice_downstream(spec):
     assert result == the_source[specslice.start : specslice.stop : specslice.step]
 
 
-#TODO: Write test slice_close_all
+def test_slice_null_close_all():
+    spec       = (0,)
+
+    the_source = list('abcdefghij')
+    result     = []
+    the_sink   = df.sink(result.append)
+
+    df.push(source = the_source,
+            pipe   = df.pipe(df.slice(*spec, close_all=True), the_sink))
+
+    specslice = slice(*spec)
+    assert result == the_source[specslice]
+    assert result == the_source[specslice.start : specslice.stop : specslice.step]
+
 
 @parametrize('args',
              ((      -1,),

--- a/invisible_cities/dataflow/dataflow_test.py
+++ b/invisible_cities/dataflow/dataflow_test.py
@@ -465,13 +465,13 @@ slice_arg_nonzero  = one_of(none(), small_ints_nonzero)
               tuples(small_ints, small_ints),
               tuples(slice_arg,  slice_arg, slice_arg_nonzero)))
 def test_slice_downstream(spec):
-
     the_source = list('abcdefghij')
     result = []
     the_sink = df.sink(result.append)
 
     df.push(source = the_source,
-            pipe   = df.pipe(df.slice(*spec), the_sink))
+            pipe   = df.pipe(df.slice(*spec, close_all=False), the_sink))
+
 
     specslice = slice(*spec)
     assert result == the_source[specslice]


### PR DESCRIPTION
This PR adds the option to run a city with `event_range = 0`, which can be useful for testing.

Closes #573