### PR TITLE
Add city completion script

### DIFF
--- a/bin/city-completion
+++ b/bin/city-completion
@@ -1,15 +1,19 @@
 #/usr/bin/env bash
 
 _city_completions () {
-  for fullpath in `ls $ICTDIR/invisible_cities/cities/*.py`; do
-    cityname=$(basename $fullpath)
-    if [[ $cityname == *"test"* ]]; then continue; fi
-    if [[ $cityname == *"components"* ]]; then continue; fi
-    if [[ $cityname == "__"* ]]; then continue; fi
-    if [[ $cityname == *"~" ]]; then continue; fi
-    cityname=${cityname/.py/}
-    COMPREPLY+=("$cityname")
-  done
+  PREV_WORD=${COMP_WORDS[COMP_CWORD-1]}
+
+  if [[ ${PREV_WORD} == "city" ]]; then
+    for fullpath in `ls $ICTDIR/invisible_cities/cities/*.py`; do
+      cityname=$(basename $fullpath)
+      if [[ $cityname == *"test"* ]]; then continue; fi
+      if [[ $cityname == *"components"* ]]; then continue; fi
+      if [[ $cityname == "__"* ]]; then continue; fi
+      if [[ $cityname == *"~" ]]; then continue; fi
+      cityname=${cityname/.py/}
+      COMPREPLY+=("$cityname")
+    done
+  fi
 }
 
-complete -F _city_completions city
+complete -o default -F _city_completions city

--- a/bin/city-completion
+++ b/bin/city-completion
@@ -1,0 +1,15 @@
+#/usr/bin/env bash
+
+_city_completions () {
+  for fullpath in `ls $ICTDIR/invisible_cities/cities/*.py`; do
+    cityname=$(basename $fullpath)
+    if [[ $cityname == *"test"* ]]; then continue; fi
+    if [[ $cityname == *"components"* ]]; then continue; fi
+    if [[ $cityname == "__"* ]]; then continue; fi
+    if [[ $cityname == *"~" ]]; then continue; fi
+    cityname=${cityname/.py/}
+    COMPREPLY+=("$cityname")
+  done
+}
+
+complete -F _city_completions city

--- a/bin/city-completion
+++ b/bin/city-completion
@@ -2,6 +2,7 @@
 
 _city_completions () {
   PREV_WORD=${COMP_WORDS[COMP_CWORD-1]}
+  CURR_WORD=${COMP_WORDS[COMP_CWORD]}
 
   if [[ ${PREV_WORD} == "city" ]]; then
     for fullpath in `ls $ICTDIR/invisible_cities/cities/*.py`; do
@@ -10,6 +11,8 @@ _city_completions () {
       if [[ $cityname == *"components"* ]]; then continue; fi
       if [[ $cityname == "__"* ]]; then continue; fi
       if [[ $cityname == *"~" ]]; then continue; fi
+      if [[ $cityname != "${CURR_WORD}"* ]]; then continue; fi
+
       cityname=${cityname/.py/}
       COMPREPLY+=("$cityname")
     done

--- a/manage.sh
+++ b/manage.sh
@@ -138,6 +138,10 @@ function work_in_python_version {
     run_tests_par
 }
 
+function export_city_command_completion {
+    source $ICTDIR/bin/city-completion
+}
+
 function work_in_python_version_no_tests {
     if ! which conda >> /dev/null
     then
@@ -151,6 +155,7 @@ function work_in_python_version_no_tests {
 
     python_version_env
     compile_cython_components
+    export_city_command_completion
 }
 
 function ensure_environment_matches_checked_out_version {


### PR DESCRIPTION
This PR adds CLI completion to the city command. Examples:

```
city <tab>
# will display
# beersheba    buffy        diomira      esmeralda    hypathia     isaura       penthesilea  trude      
# berenice     detsim       dorothea     eutropia     irene        isidora      phyllis 
```
```
city e<tab>
# will display
# esmeralda eutropia
```
etc.

Closes #251