### PR TITLE
Add fix to be able to create the current environment on MacOS 13.3.1

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -83,6 +83,9 @@ function make_environment {
 
     cat <<EOF > ${YML_FILENAME}
 name: ${CONDA_ENV_NAME}
+channels:
+- conda-forge
+- defaults
 dependencies:
 - python       = ${PYTHON_VERSION}
 # *REMEMBER TO CHANGE CONDA_ENV_TAG WHEN CHANGING VERSION NUMBERS*


### PR DESCRIPTION
I had problems creating the `3.8-2022-04-13` environment  and this fix by Corey Adams solves it.