### PR TITLE
Add data preparation functions for the Kr map computation

### DIFF
--- a/invisible_cities/core/core_functions.py
+++ b/invisible_cities/core/core_functions.py
@@ -9,7 +9,11 @@ import numpy as np
 from typing import Sequence
 from typing import Tuple
 
+from . exceptions import ValueOutOfRange
+
 from ..types.symbols import NormMode
+from ..types.symbols import Strictness
+
 
 def timefunc(f):
     """
@@ -76,6 +80,43 @@ def in_range(data, minval=-np.inf, maxval=np.inf, left_closed=True, right_closed
     upper_bound = data <= maxval if right_closed else data < maxval
     return lower_bound & upper_bound
 
+
+def check_if_values_in_interval(data         : np.array,
+                                minval       : float   ,
+                                maxval       : float   ,
+                                display_name : str = '',
+                                strictness   : Strictness = Strictness.stop_proccess,
+                                **kwargs)->bool:
+    """
+    Checks whether input values are all inside the interval (minval, maxval).
+
+    Parameters
+    ----------
+    data : np.array
+        Input array to check.
+    minval: float
+        Lower limit of the interval.
+    maxval: float
+        Upper limit of the interval.
+    display_name: string
+        Name for the message to print if exception raises.
+    strictness: Strictness
+        If 'warning', function returns a False if the criteria
+        is not match. If 'stop_proccess' it raises an exception.
+    Returns
+    ----------
+        True if values are in the interval. False if not and strictness
+        is set to 'warning'. Otherwise, it raises an exception.
+    """
+    if in_range(data, minval, maxval, **kwargs).all():
+        return True;
+
+    elif strictness is Strictness.warning:
+        return False
+    else:
+        raise ValueOutOfRange(f' Variable {display_name} is out of bounds ({minval}, {maxval})')
+
+    return
 
 def weighted_mean_and_var(data       : Sequence,
                           weights    : Sequence,

--- a/invisible_cities/core/core_functions.py
+++ b/invisible_cities/core/core_functions.py
@@ -83,11 +83,11 @@ def in_range(data, minval=-np.inf, maxval=np.inf, left_closed=True, right_closed
     return lower_bound & upper_bound
 
 
-def all_in_range(data         : np.ndarray                                  ,
-                 minval       : float                                       ,
-                 maxval       : float                                       ,
-                 display_name : Optional[str] = ''                          ,
-                 strictness   :Optional[Strictness] = Strictness.raise_error,
+def all_in_range(data         : np.ndarray                                   ,
+                 minval       : float                                        ,
+                 maxval       : float                                        ,
+                 display_name : Optional[str] = ''                           ,
+                 strictness   : Optional[Strictness] = Strictness.raise_error,
                  **kwargs)->bool:
     """
     Checks whether input values are all inside the interval (minval, maxval).
@@ -103,17 +103,20 @@ def all_in_range(data         : np.ndarray                                  ,
     display_name: string
         Label to be displayed in case of warning or exception.
     strictness: Strictness
-        It `silent`, it returns a False if the criteria
-        is not match.
-        If `warning`, it returns a False and raises a warning.
-        If `raise_error`, it raises an exception.
+        Describes the behaviour when the output is `False`. If `strictness` is:
+        - `Strictness.raise_error`: an exception is raised.
+        - `Strictness.warning`: a warning is raised before returning.
+        - `Strictness.silent`: the function returns quietly.
 
     **kwargs:
         Optional arguments being passed to `in_range`.
     Returns
     -------
-        True if values are in the interval. False if not and strictness
-        is set to `warning` or `silent`. Otherwise, it raises an exception.
+    True if values are in the interval. False otherwise.
+
+    Raises
+    ------
+    ValueOutOfRange: if the output is `False` and `strictness` is `Strictness.raise_error`
     """
 
     values_in_interval = in_range(data, minval, maxval, **kwargs)

--- a/invisible_cities/core/core_functions.py
+++ b/invisible_cities/core/core_functions.py
@@ -9,6 +9,8 @@ import numpy as np
 
 from typing import Sequence
 from typing import Tuple
+from typing import Optional
+
 
 from . exceptions import ValueOutOfRange
 from . configure  import check_annotations
@@ -82,18 +84,18 @@ def in_range(data, minval=-np.inf, maxval=np.inf, left_closed=True, right_closed
     return lower_bound & upper_bound
 
 
-def all_in_range(data         : np.ndarray                           ,
-                 minval       : float                                ,
-                 maxval       : float                                ,
-                 display_name : str = ''                             ,
-                 strictness   : Strictness = Strictness.stop_proccess,
+def all_in_range(data         : np.ndarray                                    ,
+                 minval       : float                                         ,
+                 maxval       : float                                         ,
+                 display_name : Optional[str] = ''                            ,
+                 strictness   :Optional[Strictness] = Strictness.stop_proccess,
                  **kwargs)->bool:
     """
     Checks whether input values are all inside the interval (minval, maxval).
 
     Parameters
     ----------
-    data : np.array
+    data : np.ndarray
         Input array to check.
     minval: float
         Lower limit of the interval.

--- a/invisible_cities/core/core_functions.py
+++ b/invisible_cities/core/core_functions.py
@@ -84,11 +84,11 @@ def in_range(data, minval=-np.inf, maxval=np.inf, left_closed=True, right_closed
     return lower_bound & upper_bound
 
 
-def all_in_range(data         : np.ndarray                                    ,
-                 minval       : float                                         ,
-                 maxval       : float                                         ,
-                 display_name : Optional[str] = ''                            ,
-                 strictness   :Optional[Strictness] = Strictness.stop_proccess,
+def all_in_range(data         : np.ndarray                                  ,
+                 minval       : float                                       ,
+                 maxval       : float                                       ,
+                 display_name : Optional[str] = ''                          ,
+                 strictness   :Optional[Strictness] = Strictness.raise_error,
                  **kwargs)->bool:
     """
     Checks whether input values are all inside the interval (minval, maxval).

--- a/invisible_cities/core/core_functions.py
+++ b/invisible_cities/core/core_functions.py
@@ -13,7 +13,6 @@ from typing import Optional
 
 
 from . exceptions import ValueOutOfRange
-from . configure  import check_annotations
 from ..types.symbols import NormMode
 from ..types.symbols import Strictness
 

--- a/invisible_cities/core/core_functions.py
+++ b/invisible_cities/core/core_functions.py
@@ -82,12 +82,12 @@ def in_range(data, minval=-np.inf, maxval=np.inf, left_closed=True, right_closed
     return lower_bound & upper_bound
 
 
-def all_in_range(data         : np.ndarray,
-                 minval       : float   ,
-                 maxval       : float   ,
-                 display_name : str = '',
+def all_in_range(data         : np.ndarray                           ,
+                 minval       : float                                ,
+                 maxval       : float                                ,
+                 display_name : str = ''                             ,
                  strictness   : Strictness = Strictness.stop_proccess,
-                **kwargs)->bool:
+                 **kwargs)->bool:
     """
     Checks whether input values are all inside the interval (minval, maxval).
 
@@ -120,7 +120,7 @@ def all_in_range(data         : np.ndarray,
         return False
 
     text  = f'Variable {display_name} has {n_outliers} values out of bounds ({minval}, {maxval}\n'
-    text += f'Outsiders: {outliers}'
+    text += f'Outliers: {outliers}'
 
     if strictness is Strictness.warning:
         warnings.warn(text, UserWarning)

--- a/invisible_cities/core/core_functions.py
+++ b/invisible_cities/core/core_functions.py
@@ -111,17 +111,16 @@ def all_in_range(data         : np.ndarray,
     """
 
     values_in_interval = in_range(data, minval, maxval, **kwargs)
-    outsiders_mask     = np.logical_not(values_in_interval)
-    outsiders_list     = data[outsiders_mask]
-    n_outsiders        = np.sum(outsiders_mask)
+    outliers   = data[~values_in_interval]
+    n_outliers = len(outliers)
 
     if values_in_interval.all():
         return True
     elif strictness is Strictness.silent:
         return False
 
-    text  = f'Variable {display_name} has {n_outsiders} values out of bounds ({minval}, {maxval}\n'
-    text += f'Outsiders: {outsiders_list}'
+    text  = f'Variable {display_name} has {n_outliers} values out of bounds ({minval}, {maxval}\n'
+    text += f'Outsiders: {outliers}'
 
     if strictness is Strictness.warning:
         warnings.warn(text, UserWarning)

--- a/invisible_cities/core/core_functions.py
+++ b/invisible_cities/core/core_functions.py
@@ -102,14 +102,19 @@ def all_in_range(data         : np.ndarray                                  ,
     maxval: float
         Upper limit of the interval.
     display_name: string
-        Name for the message to print if exception raises.
+        Label to be displayed in case of warning or exception.
     strictness: Strictness
-        If 'warning', function returns a False if the criteria
-        is not match. If 'stop_proccess' it raises an exception.
+        It `silent`, it returns a False if the criteria
+        is not match.
+        If `warning`, it returns a False and raises a warning.
+        If `raise_error`, it raises an exception.
+
+    **kwargs:
+        Optional arguments being passed to `in_range`.
     Returns
-    ----------
+    -------
         True if values are in the interval. False if not and strictness
-        is set to 'warning'. Otherwise, it raises an exception.
+        is set to `warning` or `silent`. Otherwise, it raises an exception.
     """
 
     values_in_interval = in_range(data, minval, maxval, **kwargs)

--- a/invisible_cities/core/core_functions.py
+++ b/invisible_cities/core/core_functions.py
@@ -82,12 +82,12 @@ def in_range(data, minval=-np.inf, maxval=np.inf, left_closed=True, right_closed
     return lower_bound & upper_bound
 
 
-def check_if_values_in_interval(data         : np.ndarray,
-                                minval       : float   ,
-                                maxval       : float   ,
-                                display_name : str = '',
-                                strictness   : Strictness = Strictness.stop_proccess,
-                                **kwargs)->bool:
+def all_in_range(data         : np.ndarray,
+                 minval       : float   ,
+                 maxval       : float   ,
+                 display_name : str = '',
+                 strictness   : Strictness = Strictness.stop_proccess,
+                **kwargs)->bool:
     """
     Checks whether input values are all inside the interval (minval, maxval).
 

--- a/invisible_cities/core/core_functions_test.py
+++ b/invisible_cities/core/core_functions_test.py
@@ -117,7 +117,8 @@ def test_in_range_right_close_interval(data):
                                   min_value  = 0,
                                   max_value  = 100))
 def test_all_in_range_when_all_fall_inside(data):
-    assert core.all_in_range(data, 0, 100, left_closed=True, right_closed=True)
+    assert core.all_in_range(data, 0, 100, left_closed=True,right_closed=True,
+                             strictness=core.Strictness.raise_error)
 
 
 @given(random_length_float_arrays(min_length = 1,

--- a/invisible_cities/core/core_functions_test.py
+++ b/invisible_cities/core/core_functions_test.py
@@ -133,7 +133,7 @@ def test_all_in_range_when_some_fall_outside_silent(data):
                                   max_value  = 100))
 def test_all_in_range_when_some_fall_outside_warns(data):
     minvalue = np.min(data)
-    with warns(UserWarning):
+    with warns(UserWarning, match="values out of bounds"):
         core.all_in_range(data, minvalue+1, 100, strictness=core.Strictness.warning)
 
 @given(random_length_float_arrays(min_length = 1,

--- a/invisible_cities/core/core_functions_test.py
+++ b/invisible_cities/core/core_functions_test.py
@@ -141,7 +141,7 @@ def test_all_in_range_when_some_fall_outside_warns(data):
 def test_all_in_range_when_some_fall_outside_exception(data):
     minvalue =np.min(data)
     with raises(core.ValueOutOfRange, match="values out of bounds"):
-        core.all_in_range(data, minvalue+1, 100, strictness=core.Strictness.stop_proccess)
+        core.all_in_range(data, minvalue+1, 100, strictness=core.Strictness.raise_error)
 
 
 @mark.parametrize(" first  second       norm_mode        expected".split(),

--- a/invisible_cities/core/core_functions_test.py
+++ b/invisible_cities/core/core_functions_test.py
@@ -6,8 +6,6 @@ import pandas as pd
 import numpy  as np
 import numpy.testing as npt
 
-import warnings
-
 from pytest import approx
 from pytest import mark
 from pytest import raises

--- a/invisible_cities/core/core_functions_test.py
+++ b/invisible_cities/core/core_functions_test.py
@@ -125,14 +125,14 @@ def test_all_in_range_when_all_fall_inside(data):
                                   min_value  = 0,
                                   max_value  = 100))
 def test_all_in_range_when_some_fall_outside_silent(data):
-    minvalue =np.min(data)
+    minvalue = np.min(data)
     assert not core.all_in_range(data, minvalue+1, 100, strictness=core.Strictness.silent)
 
 @given(random_length_float_arrays(min_length = 1,
                                   min_value  = 0,
                                   max_value  = 100))
 def test_all_in_range_when_some_fall_outside_warns(data):
-    minvalue =np.min(data)
+    minvalue = np.min(data)
     with warns(UserWarning):
         core.all_in_range(data, minvalue+1, 100, strictness=core.Strictness.warning)
 
@@ -140,7 +140,7 @@ def test_all_in_range_when_some_fall_outside_warns(data):
                                   min_value  = 0,
                                   max_value  = 100))
 def test_all_in_range_when_some_fall_outside_exception(data):
-    minvalue =np.min(data)
+    minvalue = np.min(data)
     with raises(core.ValueOutOfRange, match="values out of bounds"):
         core.all_in_range(data, minvalue+1, 100, strictness=core.Strictness.raise_error)
 

--- a/invisible_cities/core/core_functions_test.py
+++ b/invisible_cities/core/core_functions_test.py
@@ -6,9 +6,13 @@ import pandas as pd
 import numpy  as np
 import numpy.testing as npt
 
+import warnings
+
 from pytest import approx
 from pytest import mark
 from pytest import raises
+from pytest import warns
+
 
 from flaky                  import flaky
 from hypothesis             import given
@@ -121,10 +125,17 @@ def test_check_if_values_in_interval_when_all_fall_inside(data):
 @given(random_length_float_arrays(min_length = 1,
                                   min_value  = 0,
                                   max_value  = 100))
-def test_check_if_values_in_interval_when_some_fall_outside_warning(data):
+def test_check_if_values_in_interval_when_some_fall_outside_silent(data):
     minvalue =np.min(data)
-    assert not core.check_if_values_in_interval(data, minvalue+1, 100, strictness=core.Strictness.warning)
+    assert not core.check_if_values_in_interval(data, minvalue+1, 100, strictness=core.Strictness.silent)
 
+@given(random_length_float_arrays(min_length = 1,
+                                  min_value  = 0,
+                                  max_value  = 100))
+def test_check_if_values_in_interval_when_some_fall_outside_warns(data):
+    minvalue =np.min(data)
+    with warns(UserWarning):
+        core.check_if_values_in_interval(data, minvalue+1, 100, strictness=core.Strictness.warning)
 
 @given(random_length_float_arrays(min_length = 1,
                                   min_value  = 0,

--- a/invisible_cities/core/core_functions_test.py
+++ b/invisible_cities/core/core_functions_test.py
@@ -131,9 +131,9 @@ def test_check_if_values_in_interval_when_some_fall_outside_warning(data):
                                   max_value  = 100))
 def test_check_if_values_in_interval_when_some_fall_outside_exception(data):
     minvalue =np.min(data)
-    npt.assert_raises(core.ValueOutOfRange,
-                      core.check_if_values_in_interval,
-                      data, minvalue+1, 100, strictness=core.Strictness.stop_proccess)
+    raises(core.ValueOutOfRange,
+           core.check_if_values_in_interval,
+           data, minvalue+1, 100, strictness=core.Strictness.stop_proccess)
 
 
 @mark.parametrize(" first  second       norm_mode        expected".split(),

--- a/invisible_cities/core/core_functions_test.py
+++ b/invisible_cities/core/core_functions_test.py
@@ -140,9 +140,8 @@ def test_all_in_range_when_some_fall_outside_warns(data):
                                   max_value  = 100))
 def test_all_in_range_when_some_fall_outside_exception(data):
     minvalue =np.min(data)
-    raises(core.ValueOutOfRange,
-           core.all_in_range,
-           data, minvalue+1, 100, strictness=core.Strictness.stop_proccess)
+    with raises(core.ValueOutOfRange, match="values out of bounds"):
+        core.all_in_range(data, minvalue+1, 100, strictness=core.Strictness.stop_proccess)
 
 
 @mark.parametrize(" first  second       norm_mode        expected".split(),

--- a/invisible_cities/core/core_functions_test.py
+++ b/invisible_cities/core/core_functions_test.py
@@ -111,6 +111,31 @@ def test_in_range_right_close_interval(data):
     assert all(output)
 
 
+@given(random_length_float_arrays(min_length = 1,
+                                  min_value  = 0,
+                                  max_value  = 100))
+def test_check_if_values_in_interval_when_all_fall_inside(data):
+    assert core.check_if_values_in_interval(data, 0, 100, left_closed=True, right_closed=True)
+
+
+@given(random_length_float_arrays(min_length = 1,
+                                  min_value  = 0,
+                                  max_value  = 100))
+def test_check_if_values_in_interval_when_some_fall_outside_warning(data):
+    minvalue =np.min(data)
+    assert not core.check_if_values_in_interval(data, minvalue+1, 100, strictness=core.Strictness.warning)
+
+
+@given(random_length_float_arrays(min_length = 1,
+                                  min_value  = 0,
+                                  max_value  = 100))
+def test_check_if_values_in_interval_when_some_fall_outside_exception(data):
+    minvalue =np.min(data)
+    npt.assert_raises(core.ValueOutOfRange,
+                      core.check_if_values_in_interval,
+                      data, minvalue+1, 100, strictness=core.Strictness.stop_proccess)
+
+
 @mark.parametrize(" first  second       norm_mode        expected".split(),
                   ((  1  ,    2  , core.NormMode.first ,   -1    ),
                    (  4  ,    2  , core.NormMode.second,    1    ),

--- a/invisible_cities/core/core_functions_test.py
+++ b/invisible_cities/core/core_functions_test.py
@@ -118,32 +118,32 @@ def test_in_range_right_close_interval(data):
 @given(random_length_float_arrays(min_length = 1,
                                   min_value  = 0,
                                   max_value  = 100))
-def test_check_if_values_in_interval_when_all_fall_inside(data):
-    assert core.check_if_values_in_interval(data, 0, 100, left_closed=True, right_closed=True)
+def test_all_in_range_when_all_fall_inside(data):
+    assert core.all_in_range(data, 0, 100, left_closed=True, right_closed=True)
 
 
 @given(random_length_float_arrays(min_length = 1,
                                   min_value  = 0,
                                   max_value  = 100))
-def test_check_if_values_in_interval_when_some_fall_outside_silent(data):
+def test_all_in_range_when_some_fall_outside_silent(data):
     minvalue =np.min(data)
-    assert not core.check_if_values_in_interval(data, minvalue+1, 100, strictness=core.Strictness.silent)
+    assert not core.all_in_range(data, minvalue+1, 100, strictness=core.Strictness.silent)
 
 @given(random_length_float_arrays(min_length = 1,
                                   min_value  = 0,
                                   max_value  = 100))
-def test_check_if_values_in_interval_when_some_fall_outside_warns(data):
+def test_all_in_range_when_some_fall_outside_warns(data):
     minvalue =np.min(data)
     with warns(UserWarning):
-        core.check_if_values_in_interval(data, minvalue+1, 100, strictness=core.Strictness.warning)
+        core.all_in_range(data, minvalue+1, 100, strictness=core.Strictness.warning)
 
 @given(random_length_float_arrays(min_length = 1,
                                   min_value  = 0,
                                   max_value  = 100))
-def test_check_if_values_in_interval_when_some_fall_outside_exception(data):
+def test_all_in_range_when_some_fall_outside_exception(data):
     minvalue =np.min(data)
     raises(core.ValueOutOfRange,
-           core.check_if_values_in_interval,
+           core.all_in_range,
            data, minvalue+1, 100, strictness=core.Strictness.stop_proccess)
 
 

--- a/invisible_cities/core/exceptions.py
+++ b/invisible_cities/core/exceptions.py
@@ -55,3 +55,6 @@ class MCEventNotFound(ICException):
 
 class SensorIDMismatch(ICException):
     pass
+
+class ValueOutOfRange(ICException):
+    pass

--- a/invisible_cities/reco/corrections.py
+++ b/invisible_cities/reco/corrections.py
@@ -243,9 +243,9 @@ def get_normalization_factor(map_e0    : ASectorMap,
 
     return norm_value
 
-def apply_geo_correction(map_e0         : ASectorMap,
-                         norm_strat     : NormStrategy         = NormStrategy.max,
-                         norm_value     : Optional[float]      = None
+def apply_geo_correction(map_e0     : ASectorMap,
+                         norm_strat : NormStrategy    = NormStrategy.max,
+                         norm_value : Optional[float] = None
                         ) -> Callable:
     """
     For a map for each correction, it returns a function
@@ -265,12 +265,11 @@ def apply_geo_correction(map_e0         : ASectorMap,
     -------
         A function that returns geometric correction factor without passing a map.
     """
-
     normalization   = get_normalization_factor(map_e0, norm_strat, norm_value)
     get_xy_corr_fun = maps_coefficient_getter(map_e0.mapinfo, map_e0.e0)
 
-    def geo_correction_factor(x : np.array,
-                                y : np.array)-> np.array:
+    def geo_correction_factor(x : np.ndarray,
+                              y : np.ndarray)-> np.ndarray:
         geo_factor = correct_geometry_(get_xy_corr_fun(x,y))
         factor     = geo_factor * normalization
         return factor

--- a/invisible_cities/reco/corrections.py
+++ b/invisible_cities/reco/corrections.py
@@ -248,14 +248,14 @@ def apply_geo_correction(map_e0     : ASectorMap,
                          norm_value : Optional[float] = None
                         ) -> Callable:
     """
-    For a map for each correction, it returns a function
-    that provides a geometric only correction factor for a
-    given hit collection when (x,y,z,time) is provided.
+    Given a map and a correction strategy, it returns a
+    function that provides a geometric only correction factor
+    for a given hit collection when (x,y) is provided.
 
     Parameters
     ----------
     map_e0 : AsectorMap
-        Correction map for geometric corrections.
+        Correction map for geometric effects.
     norm_strat : NormStrategy
         Provides the desired normalization to be used.
     norm_value : Float(optional)

--- a/invisible_cities/reco/corrections.py
+++ b/invisible_cities/reco/corrections.py
@@ -243,6 +243,41 @@ def get_normalization_factor(map_e0    : ASectorMap,
 
     return norm_value
 
+def apply_geo_correction(map_e0         : ASectorMap,
+                         norm_strat     : NormStrategy         = NormStrategy.max,
+                         norm_value     : Optional[float]      = None
+                        ) -> Callable:
+    """
+    For a map for each correction, it returns a function
+    that provides a geometric only correction factor for a
+    given hit collection when (x,y,z,time) is provided.
+
+    Parameters
+    ----------
+    map_e0 : AsectorMap
+        Correction map for geometric corrections.
+    norm_strat : NormStrategy
+        Provides the desired normalization to be used.
+    norm_value : Float(optional)
+        If norm_strat is selected to be custom, user must provide the
+        desired scale.
+    Returns
+    -------
+        A function that returns geometric correction factor without passing a map.
+    """
+
+    normalization   = get_normalization_factor(map_e0, norm_strat, norm_value)
+    get_xy_corr_fun = maps_coefficient_getter(map_e0.mapinfo, map_e0.e0)
+
+    def geo_correction_factor(x : np.array,
+                                y : np.array)-> np.array:
+        geo_factor = correct_geometry_(get_xy_corr_fun(x,y))
+        factor     = geo_factor * normalization
+        return factor
+
+    return geo_correction_factor
+
+
 
 def apply_all_correction_single_maps(map_e0         : ASectorMap,
                                      map_lt         : ASectorMap,

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -269,34 +269,34 @@ def test_apply_all_correction_single_maps_raises_exception_when_invalid_map(map_
 
 @few_examples
 @given(float_arrays(size      = 1,
-                   min_value = -198,
-                   max_value = +198),
+                    min_value = -198,
+                    max_value = +198),
        float_arrays(size      = 1,
-                   min_value = -198,
-                   max_value = +198))
+                    min_value = -198,
+                    max_value = +198))
 def test_apply_geo_correction_properly(map_filename, x, y):
     """
     Due the map taken as input, the geometric correction
     factor must be 1.
     """
     maps      = read_maps(map_filename)
-    load_corr = apply_geo_correction(map_e0     = maps, norm_strat = NormStrategy.max)
-    corr   = load_corr(x, y)
+    load_corr = apply_geo_correction(map_e0 = maps, norm_strat = NormStrategy.max)
+    corr      = load_corr(x, y)
     assert_allclose (corr, np.ones_like(corr))
 
 @few_examples
 @given(float_arrays(size      = 1,
-                   min_value = -198,
-                   max_value = +198),
+                    min_value = -198,
+                    max_value = +198),
        float_arrays(size      = 1,
-                   min_value = -198,
-                   max_value = +198),
+                    min_value = -198,
+                    max_value = +198),
        float_arrays(size      = 1,
-                   min_value = 0,
-                   max_value = 5e2),
+                    min_value = 0,
+                    max_value = 5e2),
        float_arrays(size      = 1,
-                   min_value = 0,
-                   max_value = 1e5))
+                    min_value = 0,
+                    max_value = 1e5))
 def test_apply_all_correction_single_maps_properly(map_filename, x, y, z, t):
     """
     Due the map taken as input, the geometric correction

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -280,7 +280,7 @@ def test_apply_geo_correction_properly(map_filename, x, y):
     factor must be 1.
     """
     maps      = read_maps(map_filename)
-    load_corr = apply_geo_correction(map_e0 = maps, norm_strat = NormStrategy.max)
+    load_corr = apply_geo_correction(map_e0=maps, norm_strat=NormStrategy.max)
     corr      = load_corr(x, y)
     assert_allclose (corr, np.ones_like(corr))
 

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -276,8 +276,8 @@ def test_apply_all_correction_single_maps_raises_exception_when_invalid_map(map_
                     max_value = +198))
 def test_apply_geo_correction_properly(map_filename, x, y):
     """
-    Due the map taken as input, the geometric correction
-    factor must be 1.
+    The input map is homogeneous, therefore the geometric
+    correction factor must be 1.
     """
     maps      = read_maps(map_filename)
     load_corr = apply_geo_correction(map_e0=maps, norm_strat=NormStrategy.max)
@@ -299,8 +299,8 @@ def test_apply_geo_correction_properly(map_filename, x, y):
                     max_value = 1e5))
 def test_apply_all_correction_single_maps_properly(map_filename, x, y, z, t):
     """
-    Due the map taken as input, the geometric correction
-    factor must be 1, the temporal correction 1 and the
+The input map is homogeneous, therefore the geometric
+    correction factor must be 1, the temporal correction 1 and the
     lifetime one: exp(Z/5000).
     """
     maps      = read_maps(map_filename)

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -11,6 +11,7 @@ from . corrections import get_df_to_z_converter
 from . corrections import get_normalization_factor
 from . corrections import apply_all_correction_single_maps
 from . corrections import apply_all_correction
+from . corrections import apply_geo_correction
 
 from pytest                import fixture
 from numpy.testing         import assert_allclose
@@ -265,6 +266,23 @@ def test_apply_all_correction_single_maps_raises_exception_when_invalid_map(map_
                   apply_all_correction_single_maps,
                   map_e, map_e, map_e,
                   apply_temp = True)
+
+@few_examples
+@given(float_arrays(size      = 1,
+                   min_value = -198,
+                   max_value = +198),
+       float_arrays(size      = 1,
+                   min_value = -198,
+                   max_value = +198))
+def test_apply_geo_correction_properly(map_filename, x, y):
+    """
+    Due the map taken as input, the geometric correction
+    factor must be 1.
+    """
+    maps      = read_maps(map_filename)
+    load_corr = apply_geo_correction(map_e0     = maps, norm_strat = NormStrategy.max)
+    corr   = load_corr(x, y)
+    assert_allclose (corr, np.ones_like(corr))
 
 @few_examples
 @given(float_arrays(size      = 1,

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -285,21 +285,13 @@ def test_apply_geo_correction_properly(map_filename, x, y):
     assert_allclose (corr, np.ones_like(corr))
 
 @few_examples
-@given(float_arrays(size      = 1,
-                    min_value = -198,
-                    max_value = +198),
-       float_arrays(size      = 1,
-                    min_value = -198,
-                    max_value = +198),
-       float_arrays(size      = 1,
-                    min_value = 0,
-                    max_value = 5e2),
-       float_arrays(size      = 1,
-                    min_value = 0,
-                    max_value = 1e5))
+@given(float_arrays(size      = 1, min_value = -198, max_value =      198),
+       float_arrays(size      = 1, min_value = -198, max_value =      198),
+       float_arrays(size      = 1, min_value =    0, max_value =      500),
+       float_arrays(size      = 1, min_value =    0, max_value = 100*1000))
 def test_apply_all_correction_single_maps_properly(map_filename, x, y, z, t):
     """
-The input map is homogeneous, therefore the geometric
+    The input map is homogeneous, therefore the geometric
     correction factor must be 1, the temporal correction 1 and the
     lifetime one: exp(Z/5000).
     """

--- a/invisible_cities/reco/icaro_components.py
+++ b/invisible_cities/reco/icaro_components.py
@@ -63,15 +63,15 @@ def selection_nS_mask_and_checking(dst        : pd.DataFrame                    
     return mask
 
 
-def band_selector_and_check(dst         : pd.DataFrame,
-                            boot_map    : ASectorMap,
-                            norm_strat  : NormStrategy              = NormStrategy.max,
-                            input_mask  : np.array                  = None            ,
-                            range_DT     : Tuple[np.array, np.array] = (10, 1300)      ,
-                            range_E     : Tuple[np.array, np.array] = (10.0e+3,14e+3) ,
-                            nsigma_sel  : float                     = 3.5             ,
-                            eff_interval: Tuple[float, float]       = [0,1]           ,
-                            strictness : Strictness = Strictness.stop_proccess
+def band_selector_and_check(dst         : pd.DataFrame                                 ,
+                            boot_map    : ASectorMap                                   ,
+                            norm_strat  : NormStrategy               = NormStrategy.max,
+                            input_mask  : np.ndarray                 = None            ,
+                            range_DT    : Tuple[np.array, np.array]  = (10, 1300)      ,
+                            range_E     : Tuple[np.array, np.array]  = (10.0e+3,14e+3) ,
+                            nsigma_sel  : float                      = 3.5             ,
+                            eff_interval: Tuple[float, float]        = [0,1]           ,
+                            strictness  : Strictness = Strictness.stop_proccess
                             )->np.array:
     """
     This function returns a selection of the events that
@@ -111,26 +111,25 @@ def band_selector_and_check(dst         : pd.DataFrame,
                                        dst_sel.Y.values)
 
     sel_krband = np.zeros_like(input_mask)
-    sel_krband[input_mask] = selection_in_band(dst_sel.DT,
-                                               E0,
+    sel_krband[input_mask] = selection_in_band(dst_sel.DT, E0     ,
                                                range_dt = range_DT,
-                                               range_e = range_E,
-                                               nsigma  = nsigma_sel)
+                                               range_e  = range_E ,
+                                               nsigma   = nsigma_sel)
 
     effsel   = dst[sel_krband].event.nunique()/dst[input_mask].event.nunique()
 
-    all_in_range(data         = np.array(effsel)  ,
-                 minval       = eff_interval[0]   ,
-                 maxval       = eff_interval[1]   ,
+    all_in_range(data         = np.array(effsel)   ,
+                 minval       = eff_interval[0]    ,
+                 maxval       = eff_interval[1]    ,
                  display_name = "DT-band selection",
-                 strictness   = strictness        ,
+                 strictness   = strictness         ,
                  right_closed = True)
 
     return sel_krband
 
 
-def selection_in_band(dt        : np.array,
-                      e         : np.array,
+def selection_in_band(dt        : np.ndarray         ,
+                      e         : np.ndarray         ,
                       range_dt  : Tuple[float, float],
                       range_e   : Tuple[float, float],
                       nsigma    : float   = 3.5) ->np.array:
@@ -156,7 +155,7 @@ def selection_in_band(dt        : np.array,
     # Reshapes and flattens are needed for RANSAC function
 
     dt_sel = dt[in_range(dt, *range_dt)]
-    e_sel = e[in_range(e, *range_e)]
+    e_sel  = e [in_range( e, *range_e )]
 
     res_fit      = RANSACRegressor().fit(dt_sel.reshape(-1,1),
                                          np.log(e_sel).reshape(-1, 1))
@@ -165,13 +164,12 @@ def selection_in_band(dt        : np.array,
     prefict_fun  = lambda dt: res_fit.predict(dt.reshape(-1, 1)).flatten()
     upper_band   = lambda dt: prefict_fun(dt) + nsigma * sigma
     lower_band   = lambda dt: prefict_fun(dt) - nsigma * sigma
-
     sel_inband   = in_range(np.log(e), lower_band(dt), upper_band(dt))
 
     return  sel_inband
 
-def sigma_estimation(dt     : np.array       ,
-                     e      : np.array       ,
+def sigma_estimation(dt     : np.ndarray     ,
+                     e      : np.ndarray     ,
                      res_fit: RANSACRegressor
                     ) -> float:
     """

--- a/invisible_cities/reco/icaro_components.py
+++ b/invisible_cities/reco/icaro_components.py
@@ -141,9 +141,9 @@ def select_band(dt        : np.ndarray         ,
         axial (dt/z) values
     e: np.array
         energy values
-    range_dt: Tuple[np.array, np.array]
+    range_dt: Tuple[float, float]
         Range in DT-axis
-    range_e: Tuple[np.array, np.array]
+    range_e: Tuple[float, float]
         Range in Energy-axis
     nsigma: float
         Number of sigmas to set the band width

--- a/invisible_cities/reco/icaro_components.py
+++ b/invisible_cities/reco/icaro_components.py
@@ -25,8 +25,7 @@ def select_nS_mask_and_check(dst          : pd.DataFrame                       ,
     """
     Selects nS1(or nS2) == 1 for a given kr dst and
     returns the mask. It also computes selection efficiency,
-    checking if the value is within a given interval, and
-    saves histogram parameters.
+    checking if the value is within a given interval.
     Parameters
     ----------
     dst: pd.Dataframe
@@ -133,7 +132,8 @@ def select_band(dt        : np.ndarray         ,
                 range_e   : Tuple[float, float],
                 nsigma    : float   = 3.5) ->np.ndarray:
     """
-    This function returns a mask for the selection of the events that are inside the Kr E vz Z
+    This function returns a mask for the selection of the events
+    that are inside the Kr E vz Z
 
     Parameters
     ----------
@@ -165,7 +165,7 @@ def select_band(dt        : np.ndarray         ,
     lower_band   = lambda dt: prefict_fun(dt) - nsigma * sigma
     sel_inband   = in_range(np.log(e), lower_band(dt), upper_band(dt))
 
-    return  sel_inband
+    return sel_inband
 
 def estimate_sigma(dt     : np.ndarray     ,
                    e      : np.ndarray     ,

--- a/invisible_cities/reco/icaro_components.py
+++ b/invisible_cities/reco/icaro_components.py
@@ -1,0 +1,55 @@
+import numpy  as np
+import pandas as pd
+
+from   typing       import Tuple, Optional
+
+from .. types.symbols       import type_of_signal
+from .. types.symbols       import Strictness
+from .. core.core_functions import check_if_values_in_interval
+
+
+def selection_nS_mask_and_checking(dst        : pd.DataFrame                         ,
+                                   column     : type_of_signal                       ,
+                                   input_mask : Optional[np.array]  = None           ,
+                                   interval   : Tuple[float, float] = [0,1]          ,
+                                   strictness : Strictness = Strictness.stop_proccess
+                                   )->np.array:
+    """
+    Selects nS1(or nS2) == 1 for a given kr dst and
+    returns the mask. It also computes selection efficiency,
+    checking if the value is within a given interval, and
+    saves histogram parameters.
+    Parameters
+    ----------
+    dst: pd.Dataframe
+        Krypton dst dataframe.
+    column: type_of_signal
+        The function can be appplied over nS1 or nS2.
+    input_mask: np.array (Optional)
+        Selection mask of the previous cut. If this is the first selection
+        /no previous maks is input, input_mask is set to be an all True array.
+    interval: length-2 tuple
+        If the selection efficiency is out of this interval
+        the map production will abort/just warn, depending on "strictness".
+    sstrictness: Strictness
+        If 'warning', function returns a False if the criteria
+        is not matched. If 'stop_proccess' it raises an exception.
+    Returns
+    ----------
+        A mask corresponding to the selected events.
+    """
+    input_mask = input_mask if input_mask is not None else [True] * len(dst)
+    mask             = np.zeros_like(input_mask)
+    mask[input_mask] = getattr(dst[input_mask], column.value) == 1
+
+    nevts_after      = dst[mask]      .event.nunique()
+    nevts_before     = dst[input_mask].event.nunique()
+    eff              = nevts_after / nevts_before
+    check_if_values_in_interval(data         = np.array(eff),
+                                minval       = interval[0]  ,
+                                maxval       = interval[1]  ,
+                                display_name = column.value ,
+                                strictness   = strictness   ,
+                                right_closed = True)
+
+    return mask

--- a/invisible_cities/reco/icaro_components.py
+++ b/invisible_cities/reco/icaro_components.py
@@ -16,11 +16,11 @@ from .. core.core_functions import shift_to_bin_centers
 from .. core.fit_functions  import fit
 from .. core.fit_functions  import gauss
 
-def select_nS_mask_and_check(dst          : pd.DataFrame                       ,
-                             column       : type_of_signal                     ,
-                             input_mask   : Optional[np.ndarray]  = None       ,
-                             eff_interval : Tuple[float, float] = [0,1]        ,
-                             strictness   : Strictness = Strictness.raise_error
+def select_nS_mask_and_check(dst          : pd.DataFrame                                 ,
+                             column       : type_of_signal                               ,
+                             input_mask   : Optional[np.ndarray]  = None                 ,
+                             eff_interval : Optional[Tuple[float, float]] = [0,1]        ,
+                             strictness   : Optional[Strictness] = Strictness.raise_error
                              )->np.ndarray:
     """
     Selects nS1(or nS2) == 1 for a given kr dst and
@@ -35,12 +35,15 @@ def select_nS_mask_and_check(dst          : pd.DataFrame                       ,
     input_mask: np.array (Optional)
         Selection mask of the previous cut. If this is the first selection
         /no previous maks is input, input_mask is set to be an all True array.
-    interval: length-2 tuple
+        Defaults to None.
+    interval: length-2 tuple (Optional)
         If the selection efficiency is out of this interval
         the map production will abort/just warn, depending on "strictness".
-    sstrictness: Strictness
+        Defaults to [0, 1].
+    strictness: Strictness (Optional)
         If 'warning', function returns a False if the criteria
         is not matched. If 'stop_proccess' it raises an exception.
+        Defaults to `raise_error`.
     Returns
     ----------
         A mask corresponding to the selected events.
@@ -62,15 +65,15 @@ def select_nS_mask_and_check(dst          : pd.DataFrame                       ,
     return mask
 
 
-def select_band_and_check(dst         : pd.DataFrame                                     ,
-                          boot_map    : ASectorMap                                       ,
-                          norm_strat  : NormStrategy                   = NormStrategy.max,
-                          input_mask  : np.ndarray                     = None            ,
-                          range_DT    : Tuple[np.ndarray, np.ndarray]  = (10, 1300)      ,
-                          range_E     : Tuple[np.ndarray, np.ndarray]  = (10.0e+3,14e+3) ,
-                          nsigma_sel  : float                          = 3.5             ,
-                          eff_interval: Tuple[float, float]            = [0,1]           ,
-                          strictness  : Strictness = Strictness.raise_error
+def select_band_and_check(dst         : pd.DataFrame                                              ,
+                          boot_map    : ASectorMap                                                ,
+                          norm_strat  : Optional[NormStrategy]                  = NormStrategy.max,
+                          input_mask  : Optional[np.ndarray]                    = None            ,
+                          range_DT    : Optional[Tuple[np.ndarray, np.ndarray]] = (10, 1300)      ,
+                          range_E     : Optional[Tuple[np.ndarray, np.ndarray]] = (10.0e+3,14e+3) ,
+                          nsigma_sel  : Optional[float]                         = 3.5             ,
+                          eff_interval: Optional[Tuple[float, float]]           = [0,1]           ,
+                          strictness  : Optional[Strictness]                    = Strictness.raise_error
                           )->np.array:
     """
     This function returns a selection of the events that
@@ -85,17 +88,27 @@ def select_band_and_check(dst         : pd.DataFrame                            
         Name of bootstrap map file.
     norm_strat: norm_strategy
         Provides the desired normalization to be used.
-    mask_input: np.array
+        Defaults to `max`.
+    mask_input: np.array (Optional)
         Mask of the previous selection cut.
-    range_DT: Tuple[np.array, np.array]
-        Range in Z-axis
-    range_E: Tuple[np.array, np.array]
-        Range in Energy-axis
-    nsigma_sel: float
-        Number of sigmas to set the band width
-    eff_interval
-        Limits of the range where selection efficiency
-        is considered correct.
+        Defaults to None.
+    range_DT: Tuple[np.array, np.array] (Optional)
+        Range in DT-axis
+        Defaults to (10, 300).
+    range_E: Tuple[np.array, np.array] (Optional)
+        Range in Energy-axis.
+        Defaults to (10e3, 14e3).
+    nsigma_sel: float (Optional)
+        Number of sigmas to set the band width.
+        Defaults to 3.5.
+    eff_interval (Optional)
+        If the selection efficiency is out of this interval
+        the map production will abort/just warn, depending on "strictness".
+        Defaults to [0, 1].
+    strictness: Strictness (Optional)
+        If 'warning', function returns a False if the criteria
+        is not matched. If 'stop_proccess' it raises an exception.
+        Defaults to `raise_error`.
     Returns
     -------
         A  mask corresponding to the selection made.
@@ -130,7 +143,7 @@ def select_band(dt        : np.ndarray         ,
                 e         : np.ndarray         ,
                 range_dt  : Tuple[float, float],
                 range_e   : Tuple[float, float],
-                nsigma    : float   = 3.5) ->np.ndarray:
+                nsigma    : Optional[float] = 3.5) ->np.ndarray:
     """
     This function returns a mask for the selection of the events
     that are inside the Kr E vz Z
@@ -145,8 +158,9 @@ def select_band(dt        : np.ndarray         ,
         Range in DT-axis
     range_e: Tuple[float, float]
         Range in Energy-axis
-    nsigma: float
+    nsigma: float (Optional)
         Number of sigmas to set the band width
+        Defaults to 3.5
     Returns
     -------
         A  mask corresponding to the selection made.

--- a/invisible_cities/reco/icaro_components.py
+++ b/invisible_cities/reco/icaro_components.py
@@ -84,7 +84,7 @@ def band_selector_and_check(dst         : pd.DataFrame                          
         Krypton dataframe.
     boot_map: str
         Name of bootstrap map file.
-    norm_strt: norm_strategy
+    norm_strat: norm_strategy
         Provides the desired normalization to be used.
     mask_input: np.array
         Mask of the previous selection cut.
@@ -98,7 +98,7 @@ def band_selector_and_check(dst         : pd.DataFrame                          
         Limits of the range where selection efficiency
         is considered correct.
     Returns
-    ----------
+    -------
         A  mask corresponding to the selection made.
     """
     if input_mask is None:
@@ -106,17 +106,16 @@ def band_selector_and_check(dst         : pd.DataFrame                          
 
     dst_sel = dst[input_mask]
 
-    emaps = apply_geo_correction(boot_map, norm_strat  = norm_strat)
-    E0    = dst_sel.S2e.values * emaps(dst_sel.X.values,
-                                       dst_sel.Y.values)
+    emaps = apply_geo_correction(boot_map, norm_strat=norm_strat)
+    E0    = dst_sel.S2e.values * emaps(dst_sel.X.values, dst_sel.Y.values)
 
-    sel_krband = np.zeros_like(input_mask)
+    sel_krband             = np.zeros_like(input_mask)
     sel_krband[input_mask] = selection_in_band(dst_sel.DT, E0     ,
                                                range_dt = range_DT,
                                                range_e  = range_E ,
                                                nsigma   = nsigma_sel)
 
-    effsel   = dst[sel_krband].event.nunique()/dst[input_mask].event.nunique()
+    effsel = dst[sel_krband].event.nunique()/dst[input_mask].event.nunique()
 
     all_in_range(data         = np.array(effsel)   ,
                  minval       = eff_interval[0]    ,
@@ -149,7 +148,7 @@ def selection_in_band(dt        : np.ndarray         ,
     nsigma: float
         Number of sigmas to set the band width
     Returns
-    ----------
+    -------
         A  mask corresponding to the selection made.
     """
     # Reshapes and flattens are needed for RANSAC function
@@ -185,7 +184,7 @@ def sigma_estimation(dt     : np.ndarray     ,
         RANSAC object fitted to the data
 
     Returns
-    ----------
+    -------
         The sigma of the residuals as a float.
     """
     # Reshapes and flattens are needed for RANSAC function

--- a/invisible_cities/reco/icaro_components.py
+++ b/invisible_cities/reco/icaro_components.py
@@ -102,7 +102,6 @@ def band_selector_and_check(dst         : pd.DataFrame,
     """
     if input_mask is None:
         input_mask = [True] * len(dst)
-    else: pass;
 
     dst_sel = dst[input_mask]
 

--- a/invisible_cities/reco/icaro_components.py
+++ b/invisible_cities/reco/icaro_components.py
@@ -10,7 +10,7 @@ from .  corrections         import apply_geo_correction
 from .. types.symbols       import type_of_signal
 from .. types.symbols       import Strictness
 from .. types.symbols       import NormStrategy
-from .. core.core_functions import check_if_values_in_interval
+from .. core.core_functions import all_in_range
 from .. core.core_functions import in_range
 from .. core.core_functions import shift_to_bin_centers
 from .. core.fit_functions  import fit
@@ -53,12 +53,12 @@ def selection_nS_mask_and_checking(dst        : pd.DataFrame                    
     nevts_after      = dst[mask]      .event.nunique()
     nevts_before     = dst[input_mask].event.nunique()
     eff              = nevts_after / nevts_before
-    check_if_values_in_interval(data         = np.array(eff),
-                                minval       = interval[0]  ,
-                                maxval       = interval[1]  ,
-                                display_name = column.value ,
-                                strictness   = strictness   ,
-                                right_closed = True)
+    all_in_range(data         = np.array(eff),
+                 minval       = interval[0]  ,
+                 maxval       = interval[1]  ,
+                 display_name = column.value ,
+                 strictness   = strictness   ,
+                 right_closed = True)
 
     return mask
 
@@ -119,12 +119,12 @@ def band_selector_and_check(dst         : pd.DataFrame,
 
     effsel   = dst[sel_krband].event.nunique()/dst[input_mask].event.nunique()
 
-    check_if_values_in_interval(data         = np.array(effsel)  ,
-                                minval       = eff_interval[0]   ,
-                                maxval       = eff_interval[1]   ,
-                                display_name = "DT-band selection",
-                                strictness   = strictness        ,
-                                right_closed = True)
+    all_in_range(data         = np.array(effsel)  ,
+                 minval       = eff_interval[0]   ,
+                 maxval       = eff_interval[1]   ,
+                 display_name = "DT-band selection",
+                 strictness   = strictness        ,
+                 right_closed = True)
 
     return sel_krband
 

--- a/invisible_cities/reco/icaro_components.py
+++ b/invisible_cities/reco/icaro_components.py
@@ -50,7 +50,7 @@ def selection_nS_mask_and_checking(dst        : pd.DataFrame                    
     """
     input_mask = input_mask if input_mask is not None else [True] * len(dst)
     mask             = np.zeros_like(input_mask)
-    mask[input_mask] = getattr(dst[input_mask], column.value) == 1
+    mask[input_mask] = dst.loc[input_mask, column.value] == 1
 
     nevts_after      = dst[mask]      .event.nunique()
     nevts_before     = dst[input_mask].event.nunique()

--- a/invisible_cities/reco/icaro_components.py
+++ b/invisible_cities/reco/icaro_components.py
@@ -10,12 +10,9 @@ from .  corrections         import apply_geo_correction
 from .. types.symbols       import type_of_signal
 from .. types.symbols       import Strictness
 from .. types.symbols       import NormStrategy
-from .. types.symbols       import KrFitFunction
 from .. core.core_functions import check_if_values_in_interval
 from .. core.core_functions import in_range
-from .. core.fit_functions  import profileX
 from .. core.fit_functions  import fit
-from .  krmap_functions     import get_function_and_seed_lt
 
 
 def selection_nS_mask_and_checking(dst        : pd.DataFrame                         ,
@@ -71,8 +68,6 @@ def band_selector_and_check(dst         : pd.DataFrame,
                             input_mask  : np.array                  = None            ,
                             range_Z     : Tuple[np.array, np.array] = (10, 1300)      ,
                             range_E     : Tuple[np.array, np.array] = (10.0e+3,14e+3) ,
-                            nbins_z     : int                       = 50              ,
-                            nbins_e     : int                       = 50              ,
                             nsigma_sel  : float                     = 3.5             ,
                             eff_interval: Tuple[float, float]       = [0,1]           ,
                             strictness : Strictness = Strictness.stop_proccess
@@ -96,10 +91,6 @@ def band_selector_and_check(dst         : pd.DataFrame,
         Range in Z-axis
     range_E: Tuple[np.array, np.array]
         Range in Energy-axis
-    nbins_z: int
-        Number of bins in Z-axis
-    nbins_e: int
-        Number of bins in energy-axis
     nsigma_sel: float
         Number of sigmas to set the band width
     eff_interval
@@ -122,8 +113,6 @@ def band_selector_and_check(dst         : pd.DataFrame,
                                                E0,
                                                range_z = range_Z,
                                                range_e = range_E,
-                                               nbins_z = nbins_z,
-                                               nbins_e = nbins_e,
                                                nsigma  = nsigma_sel)
 
     effsel   = dst[sel_krband].event.nunique()/dst[input_mask].event.nunique()

--- a/invisible_cities/reco/icaro_components.py
+++ b/invisible_cities/reco/icaro_components.py
@@ -104,12 +104,14 @@ def band_selector_and_check(dst         : pd.DataFrame,
         input_mask = [True] * len(dst)
     else: pass;
 
+    dst_sel = dst[input_mask]
+
     emaps = apply_geo_correction(boot_map, norm_strat  = norm_strat)
-    E0    = dst[input_mask].S2e.values * emaps(dst[input_mask].X.values,
-                                               dst[input_mask].Y.values)
+    E0    = dst_sel.S2e.values * emaps(dst_sel.X.values,
+                                       dst_sel.Y.values)
 
     sel_krband = np.zeros_like(input_mask)
-    sel_krband[input_mask] = selection_in_band(dst[input_mask].DT,
+    sel_krband[input_mask] = selection_in_band(dst_sel.DT,
                                                E0,
                                                range_dt = range_DT,
                                                range_e = range_E,

--- a/invisible_cities/reco/icaro_components.py
+++ b/invisible_cities/reco/icaro_components.py
@@ -20,7 +20,7 @@ def selection_nS_mask_and_checking(dst        : pd.DataFrame                    
                                    column     : type_of_signal                       ,
                                    input_mask : Optional[np.ndarray]  = None         ,
                                    interval   : Tuple[float, float] = [0,1]          ,
-                                   strictness : Strictness = Strictness.stop_proccess
+                                   strictness : Strictness = Strictness.raise_error
                                    )->np.ndarray:
     """
     Selects nS1(or nS2) == 1 for a given kr dst and
@@ -63,15 +63,15 @@ def selection_nS_mask_and_checking(dst        : pd.DataFrame                    
     return mask
 
 
-def band_selector_and_check(dst         : pd.DataFrame                                 ,
-                            boot_map    : ASectorMap                                   ,
-                            norm_strat  : NormStrategy               = NormStrategy.max,
-                            input_mask  : np.ndarray                 = None            ,
-                            range_DT    : Tuple[np.array, np.array]  = (10, 1300)      ,
-                            range_E     : Tuple[np.array, np.array]  = (10.0e+3,14e+3) ,
-                            nsigma_sel  : float                      = 3.5             ,
-                            eff_interval: Tuple[float, float]        = [0,1]           ,
-                            strictness  : Strictness = Strictness.stop_proccess
+def band_selector_and_check(dst         : pd.DataFrame                                     ,
+                            boot_map    : ASectorMap                                       ,
+                            norm_strat  : NormStrategy                   = NormStrategy.max,
+                            input_mask  : np.ndarray                     = None            ,
+                            range_DT    : Tuple[np.ndarray, np.ndarray]  = (10, 1300)      ,
+                            range_E     : Tuple[np.ndarray, np.ndarray]  = (10.0e+3,14e+3) ,
+                            nsigma_sel  : float                          = 3.5             ,
+                            eff_interval: Tuple[float, float]            = [0,1]           ,
+                            strictness  : Strictness = Strictness.raise_error
                             )->np.array:
     """
     This function returns a selection of the events that

--- a/invisible_cities/reco/icaro_components.py
+++ b/invisible_cities/reco/icaro_components.py
@@ -194,7 +194,12 @@ def estimate_sigma(dt     : np.ndarray     ,
     residuals_ln = e[in_mask] - e_predict
     resy, resx   = np.histogram(residuals_ln, 100)
     resx         = shift_to_bin_centers(resx)
-    fitres       = fit(gauss, resx, resy, seed=[4e3,0,10])
+    seed         = [np.max(resy) * (2 * np.pi) **.5 * np.std(residuals_ln),
+                    0., np.std(residuals_ln)]
+    # Ideally, a np.mean for the mean should be better that a plain 0 but the
+    # fit does not cope well with that input value, so 0 (fair guess anyway) is
+    # used instead
+    fitres       = fit(gauss, resx, resy, seed=seed)
     fitsigma     = fitres.values[2]
 
     return fitsigma

--- a/invisible_cities/reco/icaro_components.py
+++ b/invisible_cities/reco/icaro_components.py
@@ -16,11 +16,11 @@ from .. core.core_functions import shift_to_bin_centers
 from .. core.fit_functions  import fit
 from .. core.fit_functions  import gauss
 
-def select_nS_mask_and_check(dst        : pd.DataFrame                         ,
-                             column     : type_of_signal                       ,
-                             input_mask : Optional[np.ndarray]  = None         ,
-                             interval   : Tuple[float, float] = [0,1]          ,
-                             strictness : Strictness = Strictness.raise_error
+def select_nS_mask_and_check(dst          : pd.DataFrame                       ,
+                             column       : type_of_signal                     ,
+                             input_mask   : Optional[np.ndarray]  = None       ,
+                             eff_interval : Tuple[float, float] = [0,1]        ,
+                             strictness   : Strictness = Strictness.raise_error
                              )->np.ndarray:
     """
     Selects nS1(or nS2) == 1 for a given kr dst and
@@ -53,11 +53,11 @@ def select_nS_mask_and_check(dst        : pd.DataFrame                         ,
     nevts_after      = dst[mask]      .event.nunique()
     nevts_before     = dst[input_mask].event.nunique()
     eff              = nevts_after / nevts_before
-    all_in_range(data         = np.array(eff),
-                 minval       = interval[0]  ,
-                 maxval       = interval[1]  ,
-                 display_name = column.value ,
-                 strictness   = strictness   ,
+    all_in_range(data         = np.array(eff)  ,
+                 minval       = eff_interval[0],
+                 maxval       = eff_interval[1],
+                 display_name = column.value   ,
+                 strictness   = strictness     ,
                  right_closed = True)
 
     return mask

--- a/invisible_cities/reco/icaro_components.py
+++ b/invisible_cities/reco/icaro_components.py
@@ -18,10 +18,10 @@ from .. core.fit_functions  import gauss
 
 def selection_nS_mask_and_checking(dst        : pd.DataFrame                         ,
                                    column     : type_of_signal                       ,
-                                   input_mask : Optional[np.array]  = None           ,
+                                   input_mask : Optional[np.ndarray]  = None         ,
                                    interval   : Tuple[float, float] = [0,1]          ,
                                    strictness : Strictness = Strictness.stop_proccess
-                                   )->np.array:
+                                   )->np.ndarray:
     """
     Selects nS1(or nS2) == 1 for a given kr dst and
     returns the mask. It also computes selection efficiency,
@@ -132,7 +132,7 @@ def selection_in_band(dt        : np.ndarray         ,
                       e         : np.ndarray         ,
                       range_dt  : Tuple[float, float],
                       range_e   : Tuple[float, float],
-                      nsigma    : float   = 3.5) ->np.array:
+                      nsigma    : float   = 3.5) ->np.ndarray:
     """
     This function returns a mask for the selection of the events that are inside the Kr E vz Z
 

--- a/invisible_cities/reco/icaro_components_test.py
+++ b/invisible_cities/reco/icaro_components_test.py
@@ -21,11 +21,9 @@ from .                      import icaro_components as icarcomp
                           max_value = 1e4))
 def test_selection_nS_mask_and_checking_right_output(nsignals, signal):
     nevt = int(1e4)
-    data = np.concatenate([np.zeros(nevt- nsignals),
-                          np.ones  (nsignals)])
+    data = np.concatenate([np.zeros(nevt- nsignals), np.ones(nsignals)])
     np.random.shuffle(data)
-
-    data = pd.DataFrame({'nS1': data, 'nS2': data,'event': range(nevt)})
+    data = pd.DataFrame({'nS1': data, 'nS2': data, 'event': range(nevt)})
 
     mask = icarcomp.selection_nS_mask_and_checking(data, signal)
 
@@ -64,8 +62,8 @@ def test_selection_nS_mask_and_checking_concatenating(ns1, ns2):
     maskS1 = icarcomp.selection_nS_mask_and_checking(data, icarcomp.type_of_signal.nS1)
     maskS2 = icarcomp.selection_nS_mask_and_checking(data, icarcomp.type_of_signal.nS2, maskS1)
 
-    assert( np.sum(maskS1) >=  np.sum(maskS2))
-    assert( np.logical_not(maskS2[np.logical_not(maskS1)].all()))
+    assert np.sum(maskS1) >=  np.sum(maskS2)
+    assert np.logical_not(maskS2[np.logical_not(maskS1)].all())
 
 
 def test_selection_nS_mask_and_checking_range_assertion():

--- a/invisible_cities/reco/icaro_components_test.py
+++ b/invisible_cities/reco/icaro_components_test.py
@@ -19,25 +19,25 @@ from .                      import icaro_components as icarcomp
 @mark.parametrize("signal", (icarcomp.type_of_signal.nS1, icarcomp.type_of_signal.nS2))
 @given(nsignals= integers(min_value = 1,
                           max_value = 1e4))
-def test_selection_nS_mask_and_checking_right_output(nsignals, signal):
+def test_select_nS_mask_and_check_right_output(nsignals, signal):
     nevt = int(1e4)
     data = np.concatenate([np.zeros(nevt- nsignals), np.ones(nsignals)])
     np.random.shuffle(data)
     data = pd.DataFrame({'nS1': data, 'nS2': data, 'event': range(nevt)})
-    mask = icarcomp.selection_nS_mask_and_checking(data, signal)
+    mask = icarcomp.select_nS_mask_and_check(data, signal)
 
     assert np.sum(mask) == nsignals
 
 
 @given(integers(min_value = 1,
                 max_value = 1e4))
-def test_selection_nS_mask_and_checking_consistency(nsignals):
+def test_select_nS_mask_and_check_consistency(nsignals):
     nevt = int(1e4)
     data = np.concatenate([np.zeros(nevt - nsignals), np.ones(nsignals)])
     np.random.shuffle(data)
     data    = pd.DataFrame({'nS1': data, 'event': range(nevt)})
-    mask    = icarcomp.selection_nS_mask_and_checking(data, icarcomp.type_of_signal.nS1)
-    mask_re = icarcomp.selection_nS_mask_and_checking(data, icarcomp.type_of_signal.nS1, input_mask=mask)
+    mask    = icarcomp.select_nS_mask_and_check(data, icarcomp.type_of_signal.nS1)
+    mask_re = icarcomp.select_nS_mask_and_check(data, icarcomp.type_of_signal.nS1, input_mask=mask)
     npt.assert_equal(mask, mask_re)
 
 
@@ -45,7 +45,7 @@ def test_selection_nS_mask_and_checking_consistency(nsignals):
                 max_value = 1e4),
        integers(min_value = 1,
                 max_value = 1e4))
-def test_selection_nS_mask_and_checking_concatenating(ns1, ns2):
+def test_select_nS_mask_and_check_concatenating(ns1, ns2):
     nevt = int(1e4)
     dataS1 = np.concatenate([np.zeros(nevt- ns1),
                              np.ones (ns1)])
@@ -54,14 +54,14 @@ def test_selection_nS_mask_and_checking_concatenating(ns1, ns2):
     np.random.shuffle(dataS1)
     np.random.shuffle(dataS2)
     data   = pd.DataFrame({'nS1': dataS1, 'nS2': dataS2, 'event': range(nevt)})
-    maskS1 = icarcomp.selection_nS_mask_and_checking(data, icarcomp.type_of_signal.nS1)
-    maskS2 = icarcomp.selection_nS_mask_and_checking(data, icarcomp.type_of_signal.nS2, maskS1)
+    maskS1 = icarcomp.select_nS_mask_and_check(data, icarcomp.type_of_signal.nS1)
+    maskS2 = icarcomp.select_nS_mask_and_check(data, icarcomp.type_of_signal.nS2, maskS1)
 
     assert np.sum(maskS1) >= np.sum(maskS2)
     assert np.logical_not(maskS2[np.logical_not(maskS1)].all())
 
 
-def test_selection_nS_mask_and_checking_range_assertion():
+def test_select_nS_mask_and_check_range_assertion():
     nevt = int(1e4)
     ns1  = int(1e3)
     min_eff = 0.5
@@ -73,12 +73,12 @@ def test_selection_nS_mask_and_checking_range_assertion():
     eff    = ns1 / nevt
 
     with raises(core.ValueOutOfRange, match="values out of bounds"):
-                icarcomp.selection_nS_mask_and_checking(data,  icarcomp.type_of_signal.nS1,
-                                                   None,[min_eff, max_eff],
-                                                   icarcomp.Strictness.raise_error)
+                icarcomp.select_nS_mask_and_check(data,  icarcomp.type_of_signal.nS1,
+                                                  None,[min_eff, max_eff],
+                                                  icarcomp.Strictness.raise_error)
 
 @mark.parametrize("sigma", (0.1, 1, 5, 10, 20))
-def test_sigma_estimation(sigma):
+def test_estimate_sigma(sigma):
     nevt      = int(1e4)
     xrange    = [0, 1000]
     slope     = 100
@@ -87,5 +87,5 @@ def test_sigma_estimation(sigma):
     y         = slope * x + n0
     y         = np.random.normal(y, sigma)
     res_fit   = RANSACRegressor().fit(x.reshape(-1,1), y.reshape(-1, 1))
-    sigma_est = icarcomp.sigma_estimation(x, y, res_fit)
+    sigma_est = icarcomp.estimate_sigma(x, y, res_fit)
     np.testing.assert_allclose(sigma, sigma_est, rtol=0.1)

--- a/invisible_cities/reco/icaro_components_test.py
+++ b/invisible_cities/reco/icaro_components_test.py
@@ -6,6 +6,7 @@ from hypothesis.strategies import integers
 from hypothesis.strategies import floats
 from hypothesis            import given
 from pytest                import mark
+from pytest                import raises
 
 from .. core.testing_utils import assert_dataframes_equal
 from .. core               import core_functions   as core
@@ -65,14 +66,11 @@ def test_selection_nS_mask_and_checking_concatenating(ns1, ns2):
     assert( np.logical_not(maskS2[np.logical_not(maskS1)].all()))
 
 
-@given(integers(min_value = 1,
-                max_value = 1e4),
-       floats  (min_value = 0,
-                max_value = 0.9),
-       floats  (min_value = 0.1,
-                max_value = 1) )
-def test_selection_nS_mask_and_checking_range_assertion(ns1, lim1, lim2):
+def test_selection_nS_mask_and_checking_range_assertion():
     nevt = int(1e4)
+    ns1  = int(1e3)
+    min_eff = 0.5
+    max_eff = 1
     dataS1 = np.concatenate([np.zeros(nevt- ns1),
                              np.ones (ns1)])
     np.random.shuffle(dataS1)
@@ -80,10 +78,8 @@ def test_selection_nS_mask_and_checking_range_assertion(ns1, lim1, lim2):
     data   = pd.DataFrame({'nS1': dataS1, 'event': range(nevt)})
 
     eff = ns1 / 1e4
-    min_eff = min(lim1, lim2)
-    max_eff = max(lim1, lim2)
-    if (eff < min_eff) or (eff > max_eff):
-        npt.assert_raises(core.ValueOutOfRange,
-                          icarcomp.selection_nS_mask_and_checking,
-                          data,  icarcomp.type_of_signal.nS1, None,
-                          [min_eff, max_eff], icarcomp.Strictness.stop_proccess)
+
+    raises(core.ValueOutOfRange,
+           icarcomp.selection_nS_mask_and_checking,
+           data,  icarcomp.type_of_signal.nS1, None,
+           [min_eff, max_eff], icarcomp.Strictness.stop_proccess)

--- a/invisible_cities/reco/icaro_components_test.py
+++ b/invisible_cities/reco/icaro_components_test.py
@@ -81,10 +81,10 @@ def test_selection_nS_mask_and_checking_range_assertion():
 
     eff = ns1 / 1e4
 
-    raises(core.ValueOutOfRange,
-           icarcomp.selection_nS_mask_and_checking,
-           data,  icarcomp.type_of_signal.nS1, None,
-           [min_eff, max_eff], icarcomp.Strictness.stop_proccess)
+    with raises(core.ValueOutOfRange, match="values out of bounds"):
+           icarcomp.selection_nS_mask_and_checking(data,  icarcomp.type_of_signal.nS1,
+                                                   None,[min_eff, max_eff],
+                                                   icarcomp.Strictness.stop_proccess)
 
 @given(floats(min_value = 0.01,
               max_value = 20))

--- a/invisible_cities/reco/icaro_components_test.py
+++ b/invisible_cities/reco/icaro_components_test.py
@@ -24,7 +24,6 @@ def test_selection_nS_mask_and_checking_right_output(nsignals, signal):
     data = np.concatenate([np.zeros(nevt- nsignals), np.ones(nsignals)])
     np.random.shuffle(data)
     data = pd.DataFrame({'nS1': data, 'nS2': data, 'event': range(nevt)})
-
     mask = icarcomp.selection_nS_mask_and_checking(data, signal)
 
     assert np.sum(mask) == nsignals
@@ -34,12 +33,9 @@ def test_selection_nS_mask_and_checking_right_output(nsignals, signal):
                 max_value = 1e4))
 def test_selection_nS_mask_and_checking_consistency(nsignals):
     nevt = int(1e4)
-    data = np.concatenate([np.zeros(nevt- nsignals),
-                          np.ones  (nsignals)])
+    data = np.concatenate([np.zeros(nevt - nsignals), np.ones(nsignals)])
     np.random.shuffle(data)
-
-    data = pd.DataFrame({'nS1': data, 'event': range(nevt)})
-
+    data    = pd.DataFrame({'nS1': data, 'event': range(nevt)})
     mask    = icarcomp.selection_nS_mask_and_checking(data, icarcomp.type_of_signal.nS1)
     mask_re = icarcomp.selection_nS_mask_and_checking(data, icarcomp.type_of_signal.nS1, input_mask=mask)
     npt.assert_equal(mask, mask_re)
@@ -57,12 +53,11 @@ def test_selection_nS_mask_and_checking_concatenating(ns1, ns2):
                              np.ones (ns2)])
     np.random.shuffle(dataS1)
     np.random.shuffle(dataS2)
-
     data   = pd.DataFrame({'nS1': dataS1, 'nS2': dataS2, 'event': range(nevt)})
     maskS1 = icarcomp.selection_nS_mask_and_checking(data, icarcomp.type_of_signal.nS1)
     maskS2 = icarcomp.selection_nS_mask_and_checking(data, icarcomp.type_of_signal.nS2, maskS1)
 
-    assert np.sum(maskS1) >=  np.sum(maskS2)
+    assert np.sum(maskS1) >= np.sum(maskS2)
     assert np.logical_not(maskS2[np.logical_not(maskS1)].all())
 
 
@@ -74,13 +69,11 @@ def test_selection_nS_mask_and_checking_range_assertion():
     dataS1 = np.concatenate([np.zeros(nevt- ns1),
                              np.ones (ns1)])
     np.random.shuffle(dataS1)
-
     data   = pd.DataFrame({'nS1': dataS1, 'event': range(nevt)})
-
-    eff = ns1 / 1e4
+    eff    = ns1 / nevt
 
     with raises(core.ValueOutOfRange, match="values out of bounds"):
-           icarcomp.selection_nS_mask_and_checking(data,  icarcomp.type_of_signal.nS1,
+                icarcomp.selection_nS_mask_and_checking(data,  icarcomp.type_of_signal.nS1,
                                                    None,[min_eff, max_eff],
                                                    icarcomp.Strictness.raise_error)
 

--- a/invisible_cities/reco/icaro_components_test.py
+++ b/invisible_cities/reco/icaro_components_test.py
@@ -15,7 +15,7 @@ from .. core                import core_functions   as core
 
 from .                      import icaro_components as icarcomp
 
-@mark.parametrize("nsignals", [1, 100, 9999])
+@mark.parametrize("nsignals", [0, 1, 100, 9999, 10*1000])
 @mark.parametrize("signal"  , icarcomp.type_of_signal)
 def test_select_nS_mask_and_check_right_output(nsignals, signal):
     nevt = 10*1000
@@ -26,7 +26,7 @@ def test_select_nS_mask_and_check_right_output(nsignals, signal):
     assert np.count_nonzero(mask) == nsignals
 
 
-@mark.parametrize("nsignals", [1, 100, 9999])
+@mark.parametrize("nsignals", [1, 100, 9999, 10*1000])
 def test_select_nS_mask_and_check_consistency(nsignals):
     nevt = 10*1000
     data = np.concatenate([np.zeros(nevt - nsignals), np.ones(nsignals)])
@@ -37,8 +37,8 @@ def test_select_nS_mask_and_check_consistency(nsignals):
     npt.assert_equal(mask, mask_re)
 
 
-@mark.parametrize("ns1", [1, 100, 9999])
-@mark.parametrize("ns2", [1, 100, 9999])
+@mark.parametrize("ns1", [   1, 100, 9999, 10*1000])
+@mark.parametrize("ns2", [0, 1, 100, 9999, 10*1000])
 def test_select_nS_mask_and_check_concatenating(ns1, ns2):
     nevt   = 10*1000
     dataS1 = np.concatenate([np.zeros(nevt- ns1),

--- a/invisible_cities/reco/icaro_components_test.py
+++ b/invisible_cities/reco/icaro_components_test.py
@@ -16,7 +16,7 @@ from .. core                import core_functions   as core
 from .                      import icaro_components as icarcomp
 
 
-@mark.parametrize("signal", (icarcomp.type_of_signal.nS1, icarcomp.type_of_signal.nS2))
+@mark.parametrize("signal", icarcomp.type_of_signal)
 @given(nsignals= integers(min_value = 1,
                           max_value = 1e4))
 def test_select_nS_mask_and_check_right_output(nsignals, signal):

--- a/invisible_cities/reco/icaro_components_test.py
+++ b/invisible_cities/reco/icaro_components_test.py
@@ -82,7 +82,7 @@ def test_selection_nS_mask_and_checking_range_assertion():
     with raises(core.ValueOutOfRange, match="values out of bounds"):
            icarcomp.selection_nS_mask_and_checking(data,  icarcomp.type_of_signal.nS1,
                                                    None,[min_eff, max_eff],
-                                                   icarcomp.Strictness.stop_proccess)
+                                                   icarcomp.Strictness.raise_error)
 
 @mark.parametrize("sigma", (0.1, 1, 5, 10, 20))
 def test_sigma_estimation(sigma):

--- a/invisible_cities/reco/icaro_components_test.py
+++ b/invisible_cities/reco/icaro_components_test.py
@@ -18,9 +18,9 @@ from .                      import icaro_components as icarcomp
 
 @mark.parametrize("signal", icarcomp.type_of_signal)
 @given(nsignals= integers(min_value = 1,
-                          max_value = 1e4))
+                          max_value = 10*1000))
 def test_select_nS_mask_and_check_right_output(nsignals, signal):
-    nevt = int(1e4)
+    nevt = 10*1000
     data = np.concatenate([np.zeros(nevt- nsignals), np.ones(nsignals)])
     np.random.shuffle(data)
     data = pd.DataFrame({'nS1': data, 'nS2': data, 'event': range(nevt)})
@@ -30,9 +30,9 @@ def test_select_nS_mask_and_check_right_output(nsignals, signal):
 
 
 @given(integers(min_value = 1,
-                max_value = 1e4))
+                max_value = 10*1000))
 def test_select_nS_mask_and_check_consistency(nsignals):
-    nevt = int(1e4)
+    nevt = 10*1000
     data = np.concatenate([np.zeros(nevt - nsignals), np.ones(nsignals)])
     np.random.shuffle(data)
     data    = pd.DataFrame({'nS1': data, 'event': range(nevt)})
@@ -42,11 +42,11 @@ def test_select_nS_mask_and_check_consistency(nsignals):
 
 
 @given(integers(min_value = 1,
-                max_value = 1e4),
+                max_value = 10*1000),
        integers(min_value = 1,
-                max_value = 1e4))
+                max_value = 10*1000))
 def test_select_nS_mask_and_check_concatenating(ns1, ns2):
-    nevt = int(1e4)
+    nevt   = 10*1000
     dataS1 = np.concatenate([np.zeros(nevt- ns1),
                              np.ones (ns1)])
     dataS2 = np.concatenate([np.zeros(nevt- ns2),
@@ -62,12 +62,12 @@ def test_select_nS_mask_and_check_concatenating(ns1, ns2):
 
 
 def test_select_nS_mask_and_check_range_assertion():
-    nevt = int(1e4)
-    ns1  = int(1e3)
+    nevt    = 10*1000
+    ns1     = 1000
     min_eff = 0.5
     max_eff = 1
-    dataS1 = np.concatenate([np.zeros(nevt- ns1),
-                             np.ones (ns1)])
+    dataS1  = np.concatenate([np.zeros(nevt- ns1),
+                              np.ones (ns1)])
     np.random.shuffle(dataS1)
     data   = pd.DataFrame({'nS1': dataS1, 'event': range(nevt)})
     eff    = ns1 / nevt
@@ -79,7 +79,7 @@ def test_select_nS_mask_and_check_range_assertion():
 
 @mark.parametrize("sigma", (0.1, 1, 5, 10, 20))
 def test_estimate_sigma(sigma):
-    nevt      = int(1e4)
+    nevt      = 10*1000
     xrange    = [0, 1000]
     slope     = 100
     n0        = 100

--- a/invisible_cities/reco/icaro_components_test.py
+++ b/invisible_cities/reco/icaro_components_test.py
@@ -86,8 +86,7 @@ def test_selection_nS_mask_and_checking_range_assertion():
                                                    None,[min_eff, max_eff],
                                                    icarcomp.Strictness.stop_proccess)
 
-@given(floats(min_value = 0.01,
-              max_value = 20))
+@mark.parametrize("sigma", (0.1, 1, 5, 10, 20))
 def test_sigma_estimation(sigma):
     nevt      = int(1e4)
     xrange    = [0, 1000]

--- a/invisible_cities/reco/icaro_components_test.py
+++ b/invisible_cities/reco/icaro_components_test.py
@@ -34,9 +34,10 @@ def test_select_nS_mask_and_check_consistency(nsignals):
     data    = pd.DataFrame({'nS1': data, 'event': range(nevt)})
     mask    = icarcomp.select_nS_mask_and_check(data, icarcomp.type_of_signal.nS1)
     mask_re = icarcomp.select_nS_mask_and_check(data, icarcomp.type_of_signal.nS1, input_mask=mask)
-    npt.assert_equal(mask, mask_re)
+    npt.assert_equal(mask_re, mask)
 
-
+# The zero option for ns1 not contemplated since the function expects at a non
+# zero number of input events to filter.
 @mark.parametrize("ns1", [   1, 100, 9999, 10*1000])
 @mark.parametrize("ns2", [0, 1, 100, 9999, 10*1000])
 def test_select_nS_mask_and_check_concatenating(ns1, ns2):
@@ -67,9 +68,9 @@ def test_select_nS_mask_and_check_range_assertion():
     eff    = ns1 / nevt
 
     with raises(core.ValueOutOfRange, match="values out of bounds"):
-                icarcomp.select_nS_mask_and_check(data,  icarcomp.type_of_signal.nS1,
-                                                  None,[min_eff, max_eff],
-                                                  icarcomp.Strictness.raise_error)
+        icarcomp.select_nS_mask_and_check(data,  icarcomp.type_of_signal.nS1,
+                                          None,[min_eff, max_eff],
+                                          icarcomp.Strictness.raise_error)
 
 @mark.parametrize("sigma", (0.5, 1, 5, 10, 20))
 def test_estimate_sigma(sigma):
@@ -82,4 +83,4 @@ def test_estimate_sigma(sigma):
     y         = np.random.normal(y, sigma)
     res_fit   = RANSACRegressor().fit(x.reshape(-1,1), y.reshape(-1, 1))
     sigma_est = icarcomp.estimate_sigma(x, y, res_fit)
-    np.testing.assert_allclose(sigma, sigma_est, rtol=0.1)
+    npt.assert_allclose(sigma_est, sigma, rtol=0.1)

--- a/invisible_cities/reco/icaro_components_test.py
+++ b/invisible_cities/reco/icaro_components_test.py
@@ -61,7 +61,8 @@ def test_selection_nS_mask_and_checking_concatenating(ns1, ns2):
     maskS1 = icarcomp.selection_nS_mask_and_checking(data, icarcomp.type_of_signal.nS1)
     maskS2 = icarcomp.selection_nS_mask_and_checking(data, icarcomp.type_of_signal.nS2, maskS1)
 
-    assert_dataframes_equal(data[maskS2], data[maskS1][data[maskS1].nS2 ==1])
+    assert( np.sum(maskS1) >=  np.sum(maskS2))
+    assert( np.logical_not(maskS2[np.logical_not(maskS1)].all()))
 
 
 @given(integers(min_value = 1,

--- a/invisible_cities/reco/icaro_components_test.py
+++ b/invisible_cities/reco/icaro_components_test.py
@@ -52,7 +52,7 @@ def test_select_nS_mask_and_check_concatenating(ns1, ns2):
     maskS2 = icarcomp.select_nS_mask_and_check(data, icarcomp.type_of_signal.nS2, maskS1)
 
     assert np.count_nonzero(maskS1) >= np.count_nonzero(maskS2)
-    assert np.logical_not(maskS2[np.logical_not(maskS1)].all())
+    assert not maskS2[~maskS1].any()
 
 
 def test_select_nS_mask_and_check_range_assertion():

--- a/invisible_cities/reco/icaro_components_test.py
+++ b/invisible_cities/reco/icaro_components_test.py
@@ -15,22 +15,18 @@ from .. core                import core_functions   as core
 
 from .                      import icaro_components as icarcomp
 
-
-@mark.parametrize("signal", icarcomp.type_of_signal)
-@given(nsignals= integers(min_value = 1,
-                          max_value = 10*1000))
+@mark.parametrize("nsignals", [1, 100, 9999])
+@mark.parametrize("signal"  , icarcomp.type_of_signal)
 def test_select_nS_mask_and_check_right_output(nsignals, signal):
     nevt = 10*1000
     data = np.concatenate([np.zeros(nevt- nsignals), np.ones(nsignals)])
     np.random.shuffle(data)
     data = pd.DataFrame({'nS1': data, 'nS2': data, 'event': range(nevt)})
     mask = icarcomp.select_nS_mask_and_check(data, signal)
-
     assert np.count_nonzero(mask) == nsignals
 
 
-@given(integers(min_value = 1,
-                max_value = 10*1000))
+@mark.parametrize("nsignals", [1, 100, 9999])
 def test_select_nS_mask_and_check_consistency(nsignals):
     nevt = 10*1000
     data = np.concatenate([np.zeros(nevt - nsignals), np.ones(nsignals)])
@@ -41,10 +37,8 @@ def test_select_nS_mask_and_check_consistency(nsignals):
     npt.assert_equal(mask, mask_re)
 
 
-@given(integers(min_value = 1,
-                max_value = 10*1000),
-       integers(min_value = 1,
-                max_value = 10*1000))
+@mark.parametrize("ns1", [1, 100, 9999])
+@mark.parametrize("ns2", [1, 100, 9999])
 def test_select_nS_mask_and_check_concatenating(ns1, ns2):
     nevt   = 10*1000
     dataS1 = np.concatenate([np.zeros(nevt- ns1),
@@ -77,7 +71,7 @@ def test_select_nS_mask_and_check_range_assertion():
                                                   None,[min_eff, max_eff],
                                                   icarcomp.Strictness.raise_error)
 
-@mark.parametrize("sigma", (0.1, 1, 5, 10, 20))
+@mark.parametrize("sigma", (0.5, 1, 5, 10, 20))
 def test_estimate_sigma(sigma):
     nevt      = 10*1000
     xrange    = [0, 1000]

--- a/invisible_cities/reco/icaro_components_test.py
+++ b/invisible_cities/reco/icaro_components_test.py
@@ -1,0 +1,86 @@
+import numpy         as np
+import numpy.testing as npt
+import pandas        as pd
+
+from hypothesis.strategies import integers
+from hypothesis.strategies import floats
+from hypothesis            import given
+
+
+from .. core.testing_utils import assert_dataframes_equal
+from .. core               import core_functions   as core
+
+from .                     import icaro_components as icarcomp
+
+@given(integers(min_value = 1,
+                max_value = 1e4))
+def test_selection_nS_mask_and_checking_right_output(nsignals):
+    nevt = int(1e4)
+    data = np.concatenate([np.zeros(nevt- nsignals),
+                          np.ones  (nsignals)])
+    np.random.shuffle(data)
+
+    data = pd.DataFrame({'nS1': data, 'event': range(nevt)})
+
+    mask = icarcomp.selection_nS_mask_and_checking(data, icarcomp.type_of_signal.nS1)
+
+    assert np.sum(mask) == nsignals
+
+
+@given(integers(min_value = 1,
+                max_value = 1e4))
+def test_selection_nS_mask_and_checking_self_concatenating(nsignals):
+    nevt = int(1e4)
+    data = np.concatenate([np.zeros(nevt- nsignals),
+                          np.ones  (nsignals)])
+    np.random.shuffle(data)
+
+    data = pd.DataFrame({'nS1': data, 'event': range(nevt)})
+
+    mask    = icarcomp.selection_nS_mask_and_checking(data, icarcomp.type_of_signal.nS1)
+    mask_re = icarcomp.selection_nS_mask_and_checking(data, icarcomp.type_of_signal.nS1, input_mask=mask)
+    npt.assert_equal(mask, mask_re)
+
+
+@given(integers(min_value = 1,
+                max_value = 1e4),
+       integers(min_value = 1,
+                max_value = 1e4))
+def test_selection_nS_mask_and_checking_concatenating(ns1, ns2):
+    nevt = int(1e4)
+    dataS1 = np.concatenate([np.zeros(nevt- ns1),
+                             np.ones (ns1)])
+    dataS2 = np.concatenate([np.zeros(nevt- ns2),
+                             np.ones (ns2)])
+    np.random.shuffle(dataS1)
+    np.random.shuffle(dataS2)
+
+    data   = pd.DataFrame({'nS1': dataS1, 'nS2': dataS2, 'event': range(nevt)})
+    maskS1 = icarcomp.selection_nS_mask_and_checking(data, icarcomp.type_of_signal.nS1)
+    maskS2 = icarcomp.selection_nS_mask_and_checking(data, icarcomp.type_of_signal.nS2, maskS1)
+
+    assert_dataframes_equal(data[maskS2], data[maskS1][data[maskS1].nS2 ==1])
+
+
+@given(integers(min_value = 1,
+                max_value = 1e4),
+       floats  (min_value = 0,
+                max_value = 0.9),
+       floats  (min_value = 0.1,
+                max_value = 1) )
+def test_selection_nS_mask_and_checking_range_assertion(ns1, lim1, lim2):
+    nevt = int(1e4)
+    dataS1 = np.concatenate([np.zeros(nevt- ns1),
+                             np.ones (ns1)])
+    np.random.shuffle(dataS1)
+
+    data   = pd.DataFrame({'nS1': dataS1, 'event': range(nevt)})
+
+    eff = ns1 / 1e4
+    min_eff = min(lim1, lim2)
+    max_eff = max(lim1, lim2)
+    if (eff < min_eff) or (eff > max_eff):
+        npt.assert_raises(core.ValueOutOfRange,
+                          icarcomp.selection_nS_mask_and_checking,
+                          data,  icarcomp.type_of_signal.nS1, None,
+                          [min_eff, max_eff], icarcomp.Strictness.stop_proccess)

--- a/invisible_cities/reco/icaro_components_test.py
+++ b/invisible_cities/reco/icaro_components_test.py
@@ -26,7 +26,7 @@ def test_select_nS_mask_and_check_right_output(nsignals, signal):
     data = pd.DataFrame({'nS1': data, 'nS2': data, 'event': range(nevt)})
     mask = icarcomp.select_nS_mask_and_check(data, signal)
 
-    assert np.sum(mask) == nsignals
+    assert np.count_nonzero(mask) == nsignals
 
 
 @given(integers(min_value = 1,
@@ -57,7 +57,7 @@ def test_select_nS_mask_and_check_concatenating(ns1, ns2):
     maskS1 = icarcomp.select_nS_mask_and_check(data, icarcomp.type_of_signal.nS1)
     maskS2 = icarcomp.select_nS_mask_and_check(data, icarcomp.type_of_signal.nS2, maskS1)
 
-    assert np.sum(maskS1) >= np.sum(maskS2)
+    assert np.count_nonzero(maskS1) >= np.count_nonzero(maskS2)
     assert np.logical_not(maskS2[np.logical_not(maskS1)].all())
 
 

--- a/invisible_cities/reco/icaro_components_test.py
+++ b/invisible_cities/reco/icaro_components_test.py
@@ -5,31 +5,33 @@ import pandas        as pd
 from hypothesis.strategies import integers
 from hypothesis.strategies import floats
 from hypothesis            import given
-
+from pytest                import mark
 
 from .. core.testing_utils import assert_dataframes_equal
 from .. core               import core_functions   as core
 
 from .                     import icaro_components as icarcomp
 
-@given(integers(min_value = 1,
-                max_value = 1e4))
-def test_selection_nS_mask_and_checking_right_output(nsignals):
+
+@mark.parametrize("signal", (icarcomp.type_of_signal.nS1, icarcomp.type_of_signal.nS2))
+@given(nsignals= integers(min_value = 1,
+                          max_value = 1e4))
+def test_selection_nS_mask_and_checking_right_output(nsignals, signal):
     nevt = int(1e4)
     data = np.concatenate([np.zeros(nevt- nsignals),
                           np.ones  (nsignals)])
     np.random.shuffle(data)
 
-    data = pd.DataFrame({'nS1': data, 'event': range(nevt)})
+    data = pd.DataFrame({'nS1': data, 'nS2': data,'event': range(nevt)})
 
-    mask = icarcomp.selection_nS_mask_and_checking(data, icarcomp.type_of_signal.nS1)
+    mask = icarcomp.selection_nS_mask_and_checking(data, signal)
 
     assert np.sum(mask) == nsignals
 
 
 @given(integers(min_value = 1,
                 max_value = 1e4))
-def test_selection_nS_mask_and_checking_self_concatenating(nsignals):
+def test_selection_nS_mask_and_checking_consistency(nsignals):
     nevt = int(1e4)
     data = np.concatenate([np.zeros(nevt- nsignals),
                           np.ones  (nsignals)])

--- a/invisible_cities/types/symbols.py
+++ b/invisible_cities/types/symbols.py
@@ -78,6 +78,10 @@ class Strictness(AutoNameEnumBase):
     warning       = auto()
     stop_proccess = auto()
 
+class type_of_signal(AutoNameEnumBase):
+    nS1 = auto()
+    nS2 = auto()
+
 class NormStrategy(AutoNameEnumBase):
     mean   = auto()
     max    = auto()

--- a/invisible_cities/types/symbols.py
+++ b/invisible_cities/types/symbols.py
@@ -75,9 +75,9 @@ class MCTableType(AutoNameEnumBase):
 
 
 class Strictness(AutoNameEnumBase):
-    silent        = auto()
-    warning       = auto()
-    stop_proccess = auto()
+    silent      = auto()
+    warning     = auto()
+    raise_error = auto()
 
 class type_of_signal(AutoNameEnumBase):
     nS1 = auto()

--- a/invisible_cities/types/symbols.py
+++ b/invisible_cities/types/symbols.py
@@ -74,6 +74,10 @@ class MCTableType(AutoNameEnumBase):
     string_map       = auto()
 
 
+class Strictness(AutoNameEnumBase):
+    warning       = auto()
+    stop_proccess = auto()
+
 class NormStrategy(AutoNameEnumBase):
     mean   = auto()
     max    = auto()

--- a/invisible_cities/types/symbols.py
+++ b/invisible_cities/types/symbols.py
@@ -75,6 +75,7 @@ class MCTableType(AutoNameEnumBase):
 
 
 class Strictness(AutoNameEnumBase):
+    silent        = auto()
     warning       = auto()
     stop_proccess = auto()
 

--- a/manage.sh
+++ b/manage.sh
@@ -110,6 +110,7 @@ dependencies:
 - coverage     = 5.5
 - pip          = 21.2.4
 - setuptools   = 58.0.4
+- scikit-learn = 1.3.0
 - pip:
   - pytest-instafail==0.4.2
 EOF


### PR DESCRIPTION
This PR links to Issue #862 and presents a proposal for the set of functions to perform the data selection and checking for the preparation for the Kr map creation. However, there are a couple of things pending up for discussion:

- The band selection relies on the lt functions that we considered adding in the map_creation PR (since we don't think they belong in this PR  workflow), but this is convoluted. It may be worth adding a previous PR with those functions.
- The previous point makes the band selection function only a scheme of the final implementation, being the only function not tested for the present PR.
- The workflow related to implementing this function in the city was left for the general PR —or even a posterior PR—related to the city itself. We considered that this makes this one much clearer since it relates only to adding the functions. Thoughts?

