### PR TITLE
Modify detsim to read nexus files with int instead of strings

### DIFF
--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -617,14 +617,8 @@ def MC_hits_from_files(files_in : List[str], rate: float) -> Generator:
         except tb.exceptions.NoSuchNodeError:
             continue
 
-        strings = False
-
         l_type = hits_df.dtypes['label']
-        if l_type == np.int32:
-            map_df = load_mcstringmap(filename)
-        else:
-            strings = True
-
+        map_df = load_mcstringmap(filename) if l_type == np.int32 else None
 
         for evt, hits in hits_df.groupby(level=0):
             yield dict(event_number = evt,
@@ -635,8 +629,8 @@ def MC_hits_from_files(files_in : List[str], rate: float) -> Generator:
                        time         = hits.time  .values,
                        label        = hits.label .values,
                        timestamp    = timestamp(evt),
-                       name         = map_df.name.values if not strings else "",
-                       name_id      = map_df.index.values if not strings else 0)
+                       name         = map_df.name .values if map_df is not None else "",
+                       name_id      = map_df.index.values if map_df is not None else  0)
 
 
 @check_annotations

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -618,35 +618,23 @@ def MC_hits_from_files(files_in : List[str], rate: float) -> Generator:
             continue
 
         strings = False
-        try:
+        if type(hits_df.iloc[0].label) is not str:
             map_df = load_mcstringmap(filename)
-        except:
+        else:
             strings = True
 
-        if strings:
-            for evt, hits in hits_df.groupby(level=0):
-                yield dict(event_number = evt,
-                           x            = hits.x     .values,
-                           y            = hits.y     .values,
-                           z            = hits.z     .values,
-                           energy       = hits.energy.values,
-                           time         = hits.time  .values,
-                           label        = hits.label .values,
-                           timestamp    = timestamp(evt),
-                           name         = "",
-                           name_id      = 0)
-        else:
-            for evt, hits in hits_df.groupby(level=0):
-                yield dict(event_number = evt,
-                           x            = hits.x     .values,
-                           y            = hits.y     .values,
-                           z            = hits.z     .values,
-                           energy       = hits.energy.values,
-                           time         = hits.time  .values,
-                           label        = hits.label .values,
-                           timestamp    = timestamp(evt),
-                           name         = map_df.name.values,
-                           name_id      = map_df.name_id.values)
+
+        for evt, hits in hits_df.groupby(level=0):
+            yield dict(event_number = evt,
+                       x            = hits.x     .values,
+                       y            = hits.y     .values,
+                       z            = hits.z     .values,
+                       energy       = hits.energy.values,
+                       time         = hits.time  .values,
+                       label        = hits.label .values,
+                       timestamp    = timestamp(evt),
+                       name         = map_df.name.values if not strings else "",
+                       name_id      = map_df.name_id.values if not strings else 0)
 
 
 @check_annotations

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -64,6 +64,7 @@ from .. io     .event_filter_io   import       event_filter_writer
 from .. io     .pmaps_io          import               pmap_writer
 from .. io     .rwf_io            import             buffer_writer
 from .. io     .mcinfo_io         import            load_mchits_df
+from .. io     .mcinfo_io         import          load_mcstringmap
 from .. io     .dst_io            import                 df_writer
 from .. types  .ic_types          import                  NoneType
 from .. types  .ic_types          import                        xy
@@ -615,15 +616,37 @@ def MC_hits_from_files(files_in : List[str], rate: float) -> Generator:
             hits_df = load_mchits_df(filename)
         except tb.exceptions.NoSuchNodeError:
             continue
-        for evt, hits in hits_df.groupby(level=0):
-            yield dict(event_number = evt,
-                       x            = hits.x     .values,
-                       y            = hits.y     .values,
-                       z            = hits.z     .values,
-                       energy       = hits.energy.values,
-                       time         = hits.time  .values,
-                       label        = hits.label .values,
-                       timestamp    = timestamp(evt))
+
+        strings = False
+        try:
+            map_df = load_mcstringmap(filename)
+        except:
+            strings = True
+
+        if strings:
+            for evt, hits in hits_df.groupby(level=0):
+                yield dict(event_number = evt,
+                           x            = hits.x     .values,
+                           y            = hits.y     .values,
+                           z            = hits.z     .values,
+                           energy       = hits.energy.values,
+                           time         = hits.time  .values,
+                           label        = hits.label .values,
+                           timestamp    = timestamp(evt),
+                           name         = "",
+                           name_id      = 0)
+        else:
+            for evt, hits in hits_df.groupby(level=0):
+                yield dict(event_number = evt,
+                           x            = hits.x     .values,
+                           y            = hits.y     .values,
+                           z            = hits.z     .values,
+                           energy       = hits.energy.values,
+                           time         = hits.time  .values,
+                           label        = hits.label .values,
+                           timestamp    = timestamp(evt),
+                           name         = map_df.name.values,
+                           name_id      = map_df.name_id.values)
 
 
 @check_annotations

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -618,7 +618,9 @@ def MC_hits_from_files(files_in : List[str], rate: float) -> Generator:
             continue
 
         strings = False
-        if type(hits_df.iloc[0].label) is not str:
+
+        l_type = hits_df.dtypes['label']
+        if l_type == np.int32 :
             map_df = load_mcstringmap(filename)
         else:
             strings = True
@@ -634,7 +636,7 @@ def MC_hits_from_files(files_in : List[str], rate: float) -> Generator:
                        label        = hits.label .values,
                        timestamp    = timestamp(evt),
                        name         = map_df.name.values if not strings else "",
-                       name_id      = map_df.name_id.values if not strings else 0)
+                       name_id      = map_df.index.values if not strings else 0)
 
 
 @check_annotations

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -620,7 +620,7 @@ def MC_hits_from_files(files_in : List[str], rate: float) -> Generator:
         strings = False
 
         l_type = hits_df.dtypes['label']
-        if l_type == np.int32 :
+        if l_type == np.int32:
             map_df = load_mcstringmap(filename)
         else:
             strings = True

--- a/invisible_cities/cities/detsim.py
+++ b/invisible_cities/cities/detsim.py
@@ -74,18 +74,17 @@ def hits_selector(active_only: bool=True):
             function that select the hits depending on :active_only: parameter
     """
     def select_hits(x, y, z, energy, time, label, name, name_id):
-        if len(label) == 0:
-            return [], [], [], [], [], []
-        if type(label[0]) == str:
-            sel = (label == "ACTIVE")
-            if not active_only:
-                sel =  sel | (label == "BUFFER")
+
+        if label.dtype == np.int32 :
+            active = name_id[name == "ACTIVE"][0]
+            buff   = name_id[name == "BUFFER"][0]
         else:
-            active_id = name_id[name == "ACTIVE"][0]
-            sel = (label == active_id)
-            if not active_only:
-                buffer_id = name_id[name == "BUFFER"][0]
-                sel =  sel | (label == buffer_id)
+            active = 'ACTIVE'
+            buff   = 'BUFFER'
+
+        sel = (label == active)
+        if not active_only:
+            sel =  sel | (label == buff)
 
         return x[sel], y[sel], z[sel], energy[sel], time[sel], label[sel]
     return select_hits

--- a/invisible_cities/cities/detsim.py
+++ b/invisible_cities/cities/detsim.py
@@ -75,7 +75,7 @@ def hits_selector(active_only: bool=True):
     """
     def select_hits(x, y, z, energy, time, label, name, name_id):
 
-        if label.dtype == np.int32 :
+        if label.dtype == np.int32:
             active = name_id[name == "ACTIVE"][0]
             buff   = name_id[name == "BUFFER"][0]
         else:

--- a/invisible_cities/cities/detsim.py
+++ b/invisible_cities/cities/detsim.py
@@ -73,10 +73,20 @@ def hits_selector(active_only: bool=True):
         :select_hits: Callable
             function that select the hits depending on :active_only: parameter
     """
-    def select_hits(x, y, z, energy, time, label):
-        sel = (label == "ACTIVE")
-        if not active_only:
-            sel =  sel | (label == "BUFFER")
+    def select_hits(x, y, z, energy, time, label, name, name_id):
+        if len(label) == 0:
+            return [], [], [], [], [], []
+        if type(label[0]) == str:
+            sel = (label == "ACTIVE")
+            if not active_only:
+                sel =  sel | (label == "BUFFER")
+        else:
+            active_id = name_id[name == "ACTIVE"][0]
+            sel = (label == active_id)
+            if not active_only:
+                buffer_id = name_id[name == "BUFFER"][0]
+                sel =  sel | (label == buffer_id)
+
         return x[sel], y[sel], z[sel], energy[sel], time[sel], label[sel]
     return select_hits
 
@@ -178,10 +188,10 @@ def detsim( *
                                  out  = ('x', 'y', 'z', 'energy', 'time', 'label'))
 
     select_s1_candidate_hits = fl.map(hits_selector(False),
-                                item = ('x', 'y', 'z', 'energy', 'time', 'label'))
+                                item = ('x', 'y', 'z', 'energy', 'time', 'label', 'name', 'name_id'))
 
     select_active_hits = fl.map(hits_selector(True),
-                                args = ('x', 'y', 'z', 'energy', 'time', 'label'),
+                                args = ('x', 'y', 'z', 'energy', 'time', 'label', 'name', 'name_id'),
                                 out = ('x_a', 'y_a', 'z_a', 'energy_a', 'time_a', 'labels_a'))
 
     filter_events_no_active_hits = fl.map(lambda x:np.any(x),

--- a/invisible_cities/cities/detsim_test.py
+++ b/invisible_cities/cities/detsim_test.py
@@ -261,3 +261,13 @@ def test_detsim_buffer_times(ICDATADIR, output_tmpdir):
 
     assert tstart == np.floor(s2_tmin / buffer_params["sipm_width"]) * buffer_params["sipm_width"]
     assert tend   == np.floor(s2_tmax / buffer_params["sipm_width"]) * buffer_params["sipm_width"]
+
+
+def test_detsim_hits_without_strings(ICDATADIR, output_tmpdir):
+    PATH_IN  = os.path.join(ICDATADIR    , "nexus_next100_nostrings.h5")
+    PATH_OUT = os.path.join(output_tmpdir, "detsim_nostrings.h5")
+    conf = configure('detsim $ICTDIR/invisible_cities/config/detsim.conf'.split())
+    conf.update(dict(files_in    = PATH_IN,
+                     file_out    = PATH_OUT,
+                     run_number  = 0))
+    result = detsim(**conf)

--- a/invisible_cities/cities/detsim_test.py
+++ b/invisible_cities/cities/detsim_test.py
@@ -266,8 +266,10 @@ def test_detsim_buffer_times(ICDATADIR, output_tmpdir):
 def test_detsim_hits_without_strings(ICDATADIR, output_tmpdir):
     PATH_IN  = os.path.join(ICDATADIR    , "nexus_next100_nostrings.h5")
     PATH_OUT = os.path.join(output_tmpdir, "detsim_nostrings.h5")
-    conf = configure('detsim $ICTDIR/invisible_cities/config/detsim.conf'.split())
+    conf = configure('detsim $ICTDIR/invisible_cities/config/detsim_next100.conf'.split())
     conf.update(dict(files_in    = PATH_IN,
                      file_out    = PATH_OUT,
                      run_number  = 0))
     result = detsim(**conf)
+
+    assert result.evtnum_list == [0, 1]

--- a/invisible_cities/cities/detsim_test.py
+++ b/invisible_cities/cities/detsim_test.py
@@ -272,4 +272,6 @@ def test_detsim_hits_without_strings(ICDATADIR, output_tmpdir):
                      run_number  = 0))
     result = detsim(**conf)
 
+    pd.read_hdf(PATH_OUT, 'MC/string_map')
+
     assert result.evtnum_list == [0, 1]

--- a/invisible_cities/cities/detsim_test.py
+++ b/invisible_cities/cities/detsim_test.py
@@ -271,7 +271,7 @@ def test_detsim_hits_without_strings(ICDATADIR, output_tmpdir):
                      file_out    = PATH_OUT,
                      run_number  = 0))
     result = detsim(**conf)
-
-    pd.read_hdf(PATH_OUT, 'MC/string_map')
-
     assert result.evtnum_list == [0, 1]
+
+    df = pd.read_hdf(PATH_OUT, 'MC/string_map')
+    assert not df.empty

--- a/invisible_cities/config/detsim_next100.conf
+++ b/invisible_cities/config/detsim_next100.conf
@@ -1,4 +1,4 @@
-files_in = "$ICDIR/database/test_data/nexus_new_kr83m_fast.newformat.sim.h5"
+files_in = "$ICDIR/database/test_data/nexus_next100_nostrings.h5"
 file_out = "/tmp/detsim_out.h5"
 
 event_range = all

--- a/invisible_cities/config/detsim_next100.conf
+++ b/invisible_cities/config/detsim_next100.conf
@@ -1,0 +1,38 @@
+files_in = "$ICDIR/database/test_data/nexus_new_kr83m_fast.newformat.sim.h5"
+file_out = "/tmp/detsim_out.h5"
+
+event_range = all
+
+detector_db = "next100"
+run_number = 0
+
+s1_lighttable = "$ICDIR/database/test_data/NEXT100_S1_LT.h5"
+s2_lighttable = "$ICDIR/database/test_data/NEXT100_S2_LT.h5"
+sipm_psf      = "$ICDIR/database/test_data/NEXT100_PSF.h5"
+
+physics_params = dict(ws = 39.2 * eV,
+                      wi = 22.4 * eV,
+                      fano_factor = 0.15,
+                      conde_policarpo_factor = 1.00,
+                      drift_velocity         = 1.00 * mm / mus,
+                      lifetime               = 12 * ms,
+                      transverse_diffusion   = 1.20 * mm / cm**0.5,
+                      longitudinal_diffusion = 0.30 * mm / cm**0.5,
+                      el_gain                = 365,
+                      el_drift_velocity      = 2.5 * mm / mus)
+
+
+buffer_params = dict(pmt_width   = 100 * ns,
+                     sipm_width  =   1 * mus,
+                     max_time    =  10 * ms,
+                     length      = 800 * mus,
+                     pre_trigger = 100 * mus,
+                     trigger_thr =   0)
+
+# compression library
+compression = "ZLIB4"
+
+# How frequently to print events
+print_mod = 1
+
+rate = 0.5 * hertz

--- a/invisible_cities/database/test_data/NEXT100_PSF.h5
+++ b/invisible_cities/database/test_data/NEXT100_PSF.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:220ed1a5c93c331a34b796019b2b18c2feb5d8b49705e7696aa418f1f29ff9b5
+size 47664

--- a/invisible_cities/database/test_data/NEXT100_S1_LT.h5
+++ b/invisible_cities/database/test_data/NEXT100_S1_LT.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73fcf8d7551d16565c8894cb219309ed5434a9d8e07329d323c5aafcd5efbbd1
+size 4448797

--- a/invisible_cities/database/test_data/NEXT100_S2_LT.h5
+++ b/invisible_cities/database/test_data/NEXT100_S2_LT.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:520a1251fe109f158323a504b8f67bcc15999ed998529119425c08d61dc6f6d7
+size 791308

--- a/invisible_cities/database/test_data/nexus_next100_nostrings.h5
+++ b/invisible_cities/database/test_data/nexus_next100_nostrings.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d49277f8618a3b07304c22e72037435d00bbf1db4a7a06efd93cca2d119f8626
+size 47724672

--- a/invisible_cities/io/mcinfo_io.py
+++ b/invisible_cities/io/mcinfo_io.py
@@ -966,4 +966,6 @@ def load_mcstringmap(file_name : str) -> pd.DataFrame:
     -------
     pd.DataFrame with the int-string pairs within the file.
     """
-    return pd.read_hdf(file_name, 'MC/string_map')
+    map_df = pd.read_hdf(file_name, 'MC/string_map')
+    map_df.set_index('name_id', inplace=True)
+    return map_df

--- a/invisible_cities/io/mcinfo_io.py
+++ b/invisible_cities/io/mcinfo_io.py
@@ -200,6 +200,9 @@ def read_mc_tables(file_in : str                        ,
         elif tbl is MCTableType.event_mapping        :
             evt_map = load_mcevent_mapping(file_in)
             tbl_dict[tbl] = evt_map[evt_map.event_id.isin(evt_arr)]
+        elif tbl is MCTableType.string_map           :
+            str_map = load_mcstringmap(file_in)
+            tbl_dict[tbl] = str_map
         else                                         :
             raise TypeError("MC table has no reader")
     return tbl_dict
@@ -948,3 +951,19 @@ def _read_mchit_info(h5f, event_range=(0, int(1e9))) -> Mapping[int, Sequence[MC
         all_events[evt_number] = hits
 
     return all_events
+
+
+def load_mcstringmap(file_name : str) -> pd.DataFrame:
+    """
+    Load the map between ints and strings to a pd.DataFrame
+
+    parameters
+    ----------
+    file_name : str
+                Name of the file containing MC info.
+
+    returns
+    -------
+    pd.DataFrame with the int-string pairs within the file.
+    """
+    return pd.read_hdf(file_name, 'MC/string_map')

--- a/invisible_cities/types/symbols.py
+++ b/invisible_cities/types/symbols.py
@@ -65,6 +65,7 @@ class MCTableType(AutoNameEnumBase):
     sns_positions    = auto()
     sns_response     = auto()
     waveforms        = auto()
+    string_map       = auto()
 
 
 class NormStrategy(AutoNameEnumBase):


### PR DESCRIPTION
This PR modifies a few functions all over the code, to deal with nexus files with `int` instead of `string` in some columns of their dataframes.
The main modification is in the `detsim` city, in the selection of hits in active or buffer, but a few other functions needed to be updated, too.
A test has been added to prove that the code works.

Closes #869.