### PR TITLE
Add a protection for possible mismatch in sensor IDs

### DIFF
--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -465,13 +465,11 @@ def mcsensors_from_file(paths     : List[str],
                                                        run_no     = run_number)
 
         if not is_oldformat_file(file_name):
-
             nexus_sns_pos = pd.read_hdf(file_name, 'MC/sns_positions')
-            sns_labels    = np.array([name.casefold() for name in nexus_sns_pos.sensor_name.values])
-            pmt_condition = np.argwhere(['Pmt'.casefold() in lbl for lbl in sns_labels]).flatten()
-            nexus_pmt_ids = nexus_sns_pos.sensor_id.values[pmt_condition]
+            pmt_condition = nexus_sns_pos.sensor_name.str.casefold().str.contains('pmt')
+            nexus_pmt_ids = nexus_sns_pos[pmt_condition].sensor_id
 
-            if not all(x in pmt_ids for x in nexus_pmt_ids):
+            if not nexus_pmt_ids.isin(pmt_ids).all():
                 raise SensorIDMismatch('Some PMT IDs in nexus file do not appear in database')
 
 

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -464,15 +464,15 @@ def mcsensors_from_file(paths     : List[str],
                                                        db_file    = db_file   ,
                                                        run_no     = run_number)
 
-        sns_pos_tbl = 'MC/sensor_positions' if is_oldformat_file(file_name) else 'MC/sns_positions'
+        if not is_oldformat_file(file_name):
 
-        nexus_sns_pos = pd.read_hdf(file_name, sns_pos_tbl)
-        sns_labels    = np.array([name.casefold() for name in nexus_sns_pos.sensor_name.values])
-        pmt_condition = np.argwhere(['Pmt'.casefold() in lbl for lbl in sns_labels]).flatten()
-        nexus_pmt_ids = nexus_sns_pos.sensor_id.values[pmt_condition]
+            nexus_sns_pos = pd.read_hdf(file_name, 'MC/sns_positions')
+            sns_labels    = np.array([name.casefold() for name in nexus_sns_pos.sensor_name.values])
+            pmt_condition = np.argwhere(['Pmt'.casefold() in lbl for lbl in sns_labels]).flatten()
+            nexus_pmt_ids = nexus_sns_pos.sensor_id.values[pmt_condition]
 
-        if not all(x in pmt_ids for x in nexus_pmt_ids):
-            raise SensorIDMismatch('Some PMT IDs in nexus file do not appear in database')
+            if not all(x in pmt_ids for x in nexus_pmt_ids):
+                raise SensorIDMismatch('Some PMT IDs in nexus file do not appear in database')
 
 
         for evt in mcinfo_io.get_event_numbers_in_file(file_name):

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -467,9 +467,11 @@ def mcsensors_from_file(paths     : List[str],
         sns_pos_tbl = 'MC/sensor_positions' if is_oldformat_file(file_name) else 'MC/sns_positions'
 
         nexus_sns_pos = pd.read_hdf(file_name, sns_pos_tbl)
-        nexus_pmt_ids = nexus_sns_pos[nexus_sns_pos.sensor_id < 100].sensor_id ## sensors with IDs below 100 are PMTs, the rest are SiPMs
+        sns_labels    = np.array([name.casefold() for name in nexus_sns_pos.sensor_name.values])
+        pmt_condition = np.argwhere(['Pmt'.casefold() in lbl for lbl in sns_labels]).flatten()
+        nexus_pmt_ids = nexus_sns_pos.sensor_id.values[pmt_condition]
 
-        if not nexus_pmt_ids.isin(pmt_ids).all():
+        if not all(x in pmt_ids for x in nexus_pmt_ids):
             raise SensorIDMismatch('Some PMT IDs in nexus file do not appear in database')
 
 

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -466,8 +466,8 @@ def mcsensors_from_file(paths     : List[str],
 
         sns_pos_tbl = 'MC/sensor_positions' if is_oldformat_file(file_name) else 'MC/sns_positions'
 
-        nexus_sns_pos       = pd.read_hdf(file_name, sns_pos_tbl)
-        nexus_pmt_ids       = nexus_sns_pos[nexus_sns_pos.sensor_id < 100].sensor_id ## sensors with IDs below 100 are PMTs, the rest are SiPMs
+        nexus_sns_pos = pd.read_hdf(file_name, sns_pos_tbl)
+        nexus_pmt_ids = nexus_sns_pos[nexus_sns_pos.sensor_id < 100].sensor_id ## sensors with IDs below 100 are PMTs, the rest are SiPMs
 
         if not nexus_pmt_ids.isin(pmt_ids).all():
             raise SensorIDMismatch('Some PMT IDs in nexus file do not appear in database')

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -463,14 +463,13 @@ def mcsensors_from_file(paths     : List[str],
                                                        return_raw = False     ,
                                                        db_file    = db_file   ,
                                                        run_no     = run_number)
-        sns_pos_tbl = 'MC/sns_positions'
-        if is_oldformat_file(file_name): sns_pos_tbl = 'MC/sensor_positions'
+
+        sns_pos_tbl = 'MC/sensor_positions' if is_oldformat_file(file_name) else 'MC/sns_positions'
 
         nexus_sns_pos       = pd.read_hdf(file_name, sns_pos_tbl)
-        nexus_pmt_ids       = nexus_sns_pos[nexus_sns_pos.sensor_id < 100].sensor_id.values
-        nexus_pmt_arg_in_db = np.argwhere([sid in pmt_ids for sid in nexus_pmt_ids])
+        nexus_pmt_ids       = nexus_sns_pos[nexus_sns_pos.sensor_id < 100].sensor_id ## sensors with IDs below 100 are PMTs, the rest are SiPMs
 
-        if len(nexus_pmt_ids) != len(nexus_pmt_arg_in_db):
+        if not nexus_pmt_ids.isin(pmt_ids).all():
             raise SensorIDMismatch('Some PMT IDs in nexus file do not appear in database')
 
 

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -13,6 +13,7 @@ from pytest import warns
 
 from .. core.configure     import configure
 from .. core.exceptions    import InvalidInputFileStructure
+from .. core.exceptions    import          SensorIDMismatch
 from .. core.testing_utils import    assert_tables_equality
 from .. core               import system_of_units as units
 from .. types.symbols      import WfType
@@ -421,3 +422,15 @@ def test_check_max_time_units():
 
     with raises(ValueError):
         check_max_time(max_time, buffer_length)
+
+def test_read_wrong_pmt_ids(ICDATADIR):
+    """
+    Check if an error is raised when wrong PMT IDs are read from nexus file
+    """
+    file_in    = os.path.join(ICDATADIR, "nexus_next100_full_wrong_PMT_IDs.h5")
+    run_number = 0
+    rate       = 0.5
+
+    with raises(SensorIDMismatch):
+        sns_gen = mcsensors_from_file([file_in], 'next100', run_number, rate)
+        _ = next(sns_gen)

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -425,12 +425,13 @@ def test_check_max_time_units():
 
 def test_read_wrong_pmt_ids(ICDATADIR):
     """
-    Check if an error is raised when wrong PMT IDs are read from nexus file
+    The input file of this test contains sensor IDs that are not present in the database.
+    This should raise an error and this test check that it is actually raised.
     """
     file_in    = os.path.join(ICDATADIR, "nexus_next100_full_wrong_PMT_IDs.h5")
     run_number = 0
     rate       = 0.5
 
+    sns_gen = mcsensors_from_file([file_in], 'next100', run_number, rate)
     with raises(SensorIDMismatch):
-        sns_gen = mcsensors_from_file([file_in], 'next100', run_number, rate)
-        _ = next(sns_gen)
+        next(sns_gen)

--- a/invisible_cities/core/exceptions.py
+++ b/invisible_cities/core/exceptions.py
@@ -52,3 +52,6 @@ class TimeEvolutionTableMissing(ICException):
 
 class MCEventNotFound(ICException):
     """ Requested event missing from input file """
+
+class SensorIDMismatch(ICException):
+    pass

--- a/invisible_cities/database/test_data/nexus_next100_full_wrong_PMT_IDs.h5
+++ b/invisible_cities/database/test_data/nexus_next100_full_wrong_PMT_IDs.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72cbc709e6e36089087cf3dd48857e26cc6caa9df78fb2e7613604431827ad4a
+size 49168256


### PR DESCRIPTION
This PR adds a protection that raises an error if the nexus file has PMT IDs which are not in the MySQL database.
Closes #779.