### PR TITLE
Remove repeated and not-used variable from result

### DIFF
--- a/invisible_cities/cities/phyllis.py
+++ b/invisible_cities/cities/phyllis.py
@@ -135,8 +135,7 @@ def phyllis( files_in         : OneOrManyFiles
 
             result = dict(events_in   = event_count     .future,
                           spe         = accumulate_light.future,
-                          dark        = accumulate_dark .future,
-                          event_count =      event_count.future)
+                          dark        = accumulate_dark .future)
         )
 
         write_hist(table_name = 'pmt_spe' )(out.spe )

--- a/invisible_cities/cities/trude.py
+++ b/invisible_cities/cities/trude.py
@@ -122,8 +122,7 @@ def trude( files_in         : OneOrManyFiles
 
             result = dict(events_in   = event_count     .future,
                           spe         = accumulate_light.future,
-                          dark        = accumulate_dark .future,
-                          event_count =      event_count.future)
+                          dark        = accumulate_dark .future)
         )
 
         write_hist(table_name = "sipm_spe" )(out.spe )


### PR DESCRIPTION
This PR removes an unnecessary variable from two cities, which was repeated.
Closes issue #705.