### PR TITLE
Remove default binning

### DIFF
--- a/invisible_cities/cities/buffy.py
+++ b/invisible_cities/cities/buffy.py
@@ -23,6 +23,8 @@ import warnings
 from typing import Callable
 from typing import     List
 
+from argparse import Namespace
+
 from .. core                   import        system_of_units as units
 from .. core  .configure       import         EventRangeType
 from .. core  .configure       import         OneOrManyFiles
@@ -65,9 +67,9 @@ def buffy( files_in          : OneOrManyFiles
     try:
         pmt_wid, sipm_wid = pmt_and_sipm_bin_width_safe_(files_in)
     except tb.exceptions.NoSuchNodeError:
-        return dict(events_in   = 0,
-                    events_resp = 0,
-                    evtnum_list = [])
+        return Namespace(events_in   = 0,
+                         events_resp = 0,
+                         evtnum_list = [])
 
     nsamp_pmt         = int(buffer_length /  pmt_wid)
     nsamp_sipm        = int(buffer_length / sipm_wid)

--- a/invisible_cities/cities/buffy.py
+++ b/invisible_cities/cities/buffy.py
@@ -62,7 +62,13 @@ def buffy( files_in          : OneOrManyFiles
 
     max_time          = check_max_time(max_time, buffer_length)
     npmt, nsipm       = get_n_sensors(detector_db, run_number)
-    pmt_wid, sipm_wid = pmt_and_sipm_bin_width_safe_(files_in)
+    try:
+        pmt_wid, sipm_wid = pmt_and_sipm_bin_width_safe_(files_in)
+    except tb.exceptions.NoSuchNodeError:
+        return dict(events_in   = 0,
+                    events_resp = 0,
+                    evtnum_list = [])
+
     nsamp_pmt         = int(buffer_length /  pmt_wid)
     nsamp_sipm        = int(buffer_length / sipm_wid)
 
@@ -162,4 +168,5 @@ def pmt_and_sipm_bin_width_safe_(files_in: List[str]):
         except (tb.HDF5ExtError, tb.NoSuchNodeError) as e:
             warnings.warn(f' no useful bin widths: {0}'.format(e), UserWarning)
             continue
-    return 25 * units.ns, 1 * units.mus
+
+    raise tb.NoSuchNodeError

--- a/invisible_cities/cities/buffy_test.py
+++ b/invisible_cities/cities/buffy_test.py
@@ -125,7 +125,7 @@ def test_buffy_filters_empty(config_tmpdir, ICDATADIR):
 
         evt_filter = h5out.root.Filters.detected_events.read()
         assert len(evt_filter) == nevt
-        assert len(evt_filter[evt_filter['passed'] == True]) == 2
+        assert np.count_nonzero(evt_filter['passed']) == 2
 
 
 @mark.parametrize("fn_first fn_second".split(),

--- a/invisible_cities/cities/buffy_test.py
+++ b/invisible_cities/cities/buffy_test.py
@@ -109,11 +109,14 @@ def test_buffy_filters_empty(config_tmpdir, ICDATADIR):
     assert buffy_result.events_resp.n_passed == n_passed
     with tb.open_file(file_out) as h5out:
 
+        assert h5out.root.Run.events.shape == (2,)
+
         assert hasattr(h5out.root        ,         'Filters')
         assert hasattr(h5out.root.Filters, 'detected_events')
 
         evt_filter = h5out.root.Filters.detected_events.read()
         assert len(evt_filter) == nevt
+        assert len(evt_filter[evt_filter['passed'] == True]) == 2
 
 
 def test_buffy_exact_result(config_tmpdir, ICDATADIR):

--- a/invisible_cities/cities/buffy_test.py
+++ b/invisible_cities/cities/buffy_test.py
@@ -105,7 +105,6 @@ def test_buffy_filters_empty(config_tmpdir, ICDATADIR):
         warnings.simplefilter("ignore", category=UserWarning)
         buffy_result = buffy(**conf)
 
-    print(buffy_result.events_in, buffy_result.events_resp.n_passed)
     assert buffy_result.events_in            == nevt
     assert buffy_result.events_resp.n_passed == n_passed
     with tb.open_file(file_out) as h5out:

--- a/invisible_cities/cities/buffy_test.py
+++ b/invisible_cities/cities/buffy_test.py
@@ -86,13 +86,10 @@ def test_buffy_no_file_without_sns_response(config_tmpdir, ICDATADIR):
     conf = configure('buffy invisible_cities/config/buffy.conf'.split())
     conf.update(dict(files_in=file_in, file_out=file_out, event_range=nevt))
 
-    try:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UserWarning)
         buffy(**conf)
-    except:
-        if not os.path.exists(file_out):
-            assert True
-        else:
-            assert False
+    assert not os.path.exists(file_out)
 
 
 def test_buffy_filters_empty(config_tmpdir, ICDATADIR):

--- a/invisible_cities/cities/buffy_test.py
+++ b/invisible_cities/cities/buffy_test.py
@@ -90,8 +90,11 @@ def test_buffy_no_file_without_sns_response(config_tmpdir, ICDATADIR):
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=UserWarning)
-        buffy(**conf)
+        buffy_result = buffy(**conf)
     assert not os.path.exists(file_out)
+    assert buffy_result.events_in   == 0
+    assert buffy_result.events_resp == 0
+    assert buffy_result.evtnum_list == []
 
 
 def test_buffy_filters_empty(config_tmpdir, ICDATADIR):

--- a/invisible_cities/cities/buffy_test.py
+++ b/invisible_cities/cities/buffy_test.py
@@ -72,31 +72,21 @@ def test_buffy_kr(config_tmpdir, full_sim_file):
         assert np.all(sipm_integ[sipm_nonzero] == sns_sums[sns_sums.index > 12])
 
 
-def test_buffy_filters_empty(config_tmpdir, ICDATADIR):
+def test_buffy_no_file_without_sns_response(config_tmpdir, ICDATADIR):
     file_in  = os.path.join(ICDATADIR, 'nexus_new_kr83m_fast.oldformat.sim.h5')
-    file_out = os.path.join(config_tmpdir, 'filtered_empty.buffers.h5')
+    file_out = os.path.join(config_tmpdir, 'no_file.h5')
 
     nevt = 2
     conf = configure('buffy invisible_cities/config/buffy.conf'.split())
     conf.update(dict(files_in=file_in, file_out=file_out, event_range=nevt))
 
-    # Warning expected since no MC tables present.
-    # Suppress since irrelevant in test.
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", category=UserWarning)
-        buffy_result = buffy(**conf)
-
-    assert buffy_result.events_in            == nevt
-    assert buffy_result.events_resp.n_passed == 0
-    with tb.open_file(file_out) as h5out:
-        assert h5out.root.Run.events.shape == (0,)
-
-        assert hasattr(h5out.root        ,         'Filters')
-        assert hasattr(h5out.root.Filters, 'detected_events')
-
-        evt_filter = h5out.root.Filters.detected_events.read()
-        assert len(evt_filter) == nevt
-        assert not np.any(evt_filter['passed'])
+    try:
+        buffy(**conf)
+    except:
+        if not os.path.exists(file_out):
+            assert True
+        else:
+            assert False
 
 
 def test_buffy_exact_result(config_tmpdir, ICDATADIR):

--- a/invisible_cities/cities/buffy_test.py
+++ b/invisible_cities/cities/buffy_test.py
@@ -5,6 +5,8 @@ import warnings
 import numpy  as np
 import tables as tb
 
+from pytest import raises
+
 from .. core                   import           system_of_units as units
 from .. core    .configure     import                 configure
 from .. core    .testing_utils import    assert_tables_equality
@@ -74,7 +76,7 @@ def test_buffy_kr(config_tmpdir, full_sim_file):
 
 def test_buffy_no_file_without_sns_response(config_tmpdir, ICDATADIR):
     file_in  = os.path.join(ICDATADIR, 'nexus_new_kr83m_fast.oldformat.sim.h5')
-    file_out = os.path.join(config_tmpdir, 'no_file.h5')
+    file_out = os.path.join(config_tmpdir, 'test_buffy_no_file_without_sns_response.h5')
 
     nevt = 2
     conf = configure('buffy invisible_cities/config/buffy.conf'.split())
@@ -90,17 +92,20 @@ def test_buffy_no_file_without_sns_response(config_tmpdir, ICDATADIR):
 
 
 def test_buffy_filters_empty(config_tmpdir, ICDATADIR):
-    file_in  = os.path.join(ICDATADIR, 'nexus_new_kr83m_*.oldformat.sim.h5')
-    #file_in  = os.path.join(ICDATADIR, 'nexus_new_kr83m_full.oldformat.sim.h5')
-    file_out = os.path.join(config_tmpdir, 'filtered_empty.buffers.h5')
+    """
+    Check that events without sensor response are filtered out.
+    We use a fast simulation file to mimic events with no sensor response.
+    """
+    files_in = os.path.join(ICDATADIR, 'nexus_new_kr83m_*.oldformat.sim.h5')
+    file_out = os.path.join(config_tmpdir, 'test_buffy_filters_empty.h5')
 
     nevt     = 4
     n_passed = 2
     conf = configure('buffy invisible_cities/config/buffy.conf'.split())
-    conf.update(dict(files_in=file_in, file_out=file_out, event_range=nevt))
+    conf.update(dict(files_in=files_in, file_out=file_out, event_range=nevt))
 
-    # Exception expected since no MC sensor response is present.
-    # Suppress since irrelevant in test.
+    # Exception expected since no MC sensor response is present
+    # in one of the files. Suppress since irrelevant in test.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=UserWarning)
         buffy_result = buffy(**conf)

--- a/invisible_cities/cities/buffy_test.py
+++ b/invisible_cities/cities/buffy_test.py
@@ -99,7 +99,8 @@ def test_buffy_filters_empty(config_tmpdir, ICDATADIR):
     Check that events without sensor response are filtered out.
     We use a fast simulation file to mimic events with no sensor response.
     """
-    files_in = os.path.join(ICDATADIR, 'nexus_new_kr83m_*.oldformat.sim.h5')
+    files_in = [os.path.join(ICDATADIR, 'nexus_new_kr83m_full.oldformat.sim.h5'),
+                os.path.join(ICDATADIR, 'nexus_new_kr83m_fast.oldformat.sim.h5')]
     file_out = os.path.join(config_tmpdir, 'test_buffy_filters_empty.h5')
 
     nevt     = 4

--- a/invisible_cities/cities/buffy_test.py
+++ b/invisible_cities/cities/buffy_test.py
@@ -75,6 +75,10 @@ def test_buffy_kr(config_tmpdir, full_sim_file):
 
 
 def test_buffy_no_file_without_sns_response(config_tmpdir, ICDATADIR):
+    """
+    Check that if a file has no sensor response, the code raises an exception
+    and no output file is created.
+    """
     file_in  = os.path.join(ICDATADIR, 'nexus_new_kr83m_fast.oldformat.sim.h5')
     file_out = os.path.join(config_tmpdir, 'test_buffy_no_file_without_sns_response.h5')
 

--- a/invisible_cities/cities/buffy_test.py
+++ b/invisible_cities/cities/buffy_test.py
@@ -6,6 +6,8 @@ import numpy  as np
 import tables as tb
 
 from pytest import raises
+from pytest import mark
+from pytest import param
 
 from .. core                   import           system_of_units as units
 from .. core    .configure     import                 configure
@@ -123,6 +125,31 @@ def test_buffy_filters_empty(config_tmpdir, ICDATADIR):
         evt_filter = h5out.root.Filters.detected_events.read()
         assert len(evt_filter) == nevt
         assert len(evt_filter[evt_filter['passed'] == True]) == 2
+
+
+@mark.parametrize("fn_first fn_second".split(),
+                  (param("nexus_new_kr83m_fast.oldformat.sim.h5",
+                         "nexus_new_kr83m_full.oldformat.sim.h5", marks=mark.xfail),
+                  ("nexus_new_kr83m_full.oldformat.sim.h5",
+                   "nexus_new_kr83m_fast.oldformat.sim.h5")))
+def test_buffy_empty_file(config_tmpdir, ICDATADIR, fn_first, fn_second):
+    """
+    Check that the code works even if the first file to be read has
+    no sensor response.
+    """
+    file_in_first  = os.path.join(ICDATADIR,  fn_first)
+    file_in_second = os.path.join(ICDATADIR, fn_second)
+    file_out       = os.path.join(config_tmpdir, 'test_buffy_empty_file.h5')
+
+    nevt = 4
+    conf = configure('buffy invisible_cities/config/buffy.conf'.split())
+    conf.update(dict(files_in=[file_in_first, file_in_second], file_out=file_out, event_range=nevt))
+
+    # Exception expected since no MC sensor response is present
+    # in one of the files. Suppress since irrelevant in test.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UserWarning)
+        buffy(**conf)
 
 
 def test_buffy_exact_result(config_tmpdir, ICDATADIR):

--- a/invisible_cities/cities/buffy_test.py
+++ b/invisible_cities/cities/buffy_test.py
@@ -89,6 +89,34 @@ def test_buffy_no_file_without_sns_response(config_tmpdir, ICDATADIR):
             assert False
 
 
+def test_buffy_filters_empty(config_tmpdir, ICDATADIR):
+    file_in  = os.path.join(ICDATADIR, 'nexus_new_kr83m_*.oldformat.sim.h5')
+    #file_in  = os.path.join(ICDATADIR, 'nexus_new_kr83m_full.oldformat.sim.h5')
+    file_out = os.path.join(config_tmpdir, 'filtered_empty.buffers.h5')
+
+    nevt     = 4
+    n_passed = 2
+    conf = configure('buffy invisible_cities/config/buffy.conf'.split())
+    conf.update(dict(files_in=file_in, file_out=file_out, event_range=nevt))
+
+    # Exception expected since no MC sensor response is present.
+    # Suppress since irrelevant in test.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UserWarning)
+        buffy_result = buffy(**conf)
+
+    print(buffy_result.events_in, buffy_result.events_resp.n_passed)
+    assert buffy_result.events_in            == nevt
+    assert buffy_result.events_resp.n_passed == n_passed
+    with tb.open_file(file_out) as h5out:
+
+        assert hasattr(h5out.root        ,         'Filters')
+        assert hasattr(h5out.root.Filters, 'detected_events')
+
+        evt_filter = h5out.root.Filters.detected_events.read()
+        assert len(evt_filter) == nevt
+
+
 def test_buffy_exact_result(config_tmpdir, ICDATADIR):
     np.random.seed(27)
 

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -190,6 +190,8 @@ def index_tables(file_out):
     -checks if any columns in the tables have been marked to be indexed by writers
     -indexes those columns
     """
+    if not os.path.exists(file_out):
+        return
     with tb.open_file(file_out, 'r+') as h5out:
         for table in h5out.walk_nodes(classname='Table'):        # Walk over all tables in h5out
             if 'columns_to_index' not in table.attrs:  continue  # Check for columns to index

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -131,7 +131,8 @@ def city(city_function):
         # TODO There were deamons! self.daemons = tuple(map(summon_daemon, kwds.get('daemons', [])))
 
         result = check_annotations(city_function)(**vars(conf))
-        index_tables(conf.file_out)
+        if os.path.exists(conf.file_out):
+            index_tables(conf.file_out)
         return result
     return proxy
 
@@ -190,8 +191,6 @@ def index_tables(file_out):
     -checks if any columns in the tables have been marked to be indexed by writers
     -indexes those columns
     """
-    if not os.path.exists(file_out):
-        return
     with tb.open_file(file_out, 'r+') as h5out:
         for table in h5out.walk_nodes(classname='Table'):        # Walk over all tables in h5out
             if 'columns_to_index' not in table.attrs:  continue  # Check for columns to index

--- a/invisible_cities/database/test_data/nexus_new_kr83m_a_full.oldformat.sim.h5
+++ b/invisible_cities/database/test_data/nexus_new_kr83m_a_full.oldformat.sim.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fdb9c0c02e04590f264417a2e381dc5af093bacd0b079c73aa43be1d9ed10e83
+size 74351

--- a/invisible_cities/database/test_data/nexus_new_kr83m_a_full.oldformat.sim.h5
+++ b/invisible_cities/database/test_data/nexus_new_kr83m_a_full.oldformat.sim.h5
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fdb9c0c02e04590f264417a2e381dc5af093bacd0b079c73aa43be1d9ed10e83
-size 74351


### PR DESCRIPTION
This PR removes the assignment of a default time binning to sensors, when no sensor response is found in the bunch of files being processed. The city will crash, instead.
Also, a test is modified to account for this change and another one is added.

Closes #857 