### PR TITLE
Change the last remaining event types to int64

### DIFF
--- a/invisible_cities/io/hits_io.py
+++ b/invisible_cities/io/hits_io.py
@@ -34,7 +34,7 @@ def hits_from_df (dst : pd.DataFrame, skip_NN : bool = False) -> Dict[int, HitCo
     times = getattr(dst, 'time', [-1]*len(dst))
     for (event, time) , df in dst.groupby(['event', times]):
         #pandas is not consistent with numpy dtypes so we have to change it by hand
-        event = np.int32(event)
+        event = np.int64(event)
         hits  = []
         for i, row in df.iterrows():
             Q = getattr(row,'Q', row.E)

--- a/invisible_cities/types/ic_types.py
+++ b/invisible_cities/types/ic_types.py
@@ -118,7 +118,7 @@ class AutoNameEnumBase(Enum):
 
 
 
-types_dict_summary = OrderedDict({'event'     : np.int32  , 'evt_energy' : np.float64, 'evt_charge'    : np.float64,
+types_dict_summary = OrderedDict({'event'     : np.int64  , 'evt_energy' : np.float64, 'evt_charge'    : np.float64,
                                   'evt_ntrks' : int       , 'evt_nhits'  : int       , 'evt_x_avg'     : np.float64,
                                   'evt_y_avg' : np.float64, 'evt_z_avg'  : np.float64, 'evt_r_avg'     : np.float64,
                                   'evt_x_min' : np.float64, 'evt_y_min'  : np.float64, 'evt_z_min'     : np.float64,
@@ -128,7 +128,7 @@ types_dict_summary = OrderedDict({'event'     : np.int32  , 'evt_energy' : np.fl
 
 
 
-types_dict_tracks = OrderedDict({'event'           : np.int32  , 'trackID'       : int       , 'energy'      : np.float64,
+types_dict_tracks = OrderedDict({'event'           : np.int64  , 'trackID'       : int       , 'energy'      : np.float64,
                                  'length'          : np.float64, 'numb_of_voxels': int       , 'numb_of_hits': int       ,
                                  'numb_of_tracks'  : int       , 'x_min'         : np.float64, 'y_min'       : np.float64,
                                  'z_min'           : np.float64, 'r_min'         : np.float64, 'x_max'       : np.float64,


### PR DESCRIPTION
This PR changes the last items of `int32` types assigned to the event ID. Since PR #820, all event IDs should be `int64`, to deal with large background productions. These items probably escaped our attention at the time of that PR.
This PR closes #838.