### PR TITLE
Add catch for NaN values in iteration checker.

### DIFF
--- a/invisible_cities/reco/deconv_functions.py
+++ b/invisible_cities/reco/deconv_functions.py
@@ -306,7 +306,7 @@ def richardson_lucy(image, psf, iterations=50, iter_thr=0.):
         im_deconv *= convolve_method(relative_blur, psf_mirror, 'same')
 
         with np.errstate(divide='ignore', invalid='ignore'):
-            rel_diff = np.sum(np.divide(((im_deconv/im_deconv.max() - ref_image)**2), ref_image))
+            rel_diff = np.sum(np.nan_to_num(np.divide(((im_deconv/im_deconv.max() - ref_image)**2), ref_image)))
         if rel_diff < iter_thr: ### Break if a given threshold is reached.
             break
 

--- a/invisible_cities/reco/deconv_functions.py
+++ b/invisible_cities/reco/deconv_functions.py
@@ -306,7 +306,7 @@ def richardson_lucy(image, psf, iterations=50, iter_thr=0.):
         im_deconv *= convolve_method(relative_blur, psf_mirror, 'same')
 
         with np.errstate(divide='ignore', invalid='ignore'):
-            rel_diff = np.sum(np.nan_to_num(np.divide(((im_deconv/im_deconv.max() - ref_image)**2), ref_image)))
+            rel_diff = np.nansum(np.divide(((im_deconv/im_deconv.max() - ref_image)**2), ref_image))
         if rel_diff < iter_thr: ### Break if a given threshold is reached.
             break
 


### PR DESCRIPTION
This PR adds a simple 'NaN removal' component to the iteration threshold checker. 

I found that across certain z-slices the threshold checker would produce divisions with small floating point denominators, causing a `NaN` value to appear in the `rel_diff` array. 

Using `np.sum()` on an array with a `NaN` value defaults the output to `NaN`, breaking the threshold checker. This change sets said `NaN` values to zero.