### PR TITLE
Add data-mc ratios to detsim

### DIFF
--- a/invisible_cities/cities/detsim.py
+++ b/invisible_cities/cities/detsim.py
@@ -152,19 +152,21 @@ def bin_edges_getter(pmt_width, sipm_width):
 
 @city
 def detsim( *
-          , files_in       : OneOrManyFiles
-          , file_out       : str
-          , event_range    : EventRangeType
-          , print_mod      : int
-          , compression    : str
-          , detector_db    : str
-          , run_number     : int
-          , s1_lighttable  : str
-          , s2_lighttable  : str
-          , sipm_psf       : str
-          , buffer_params  : dict
-          , physics_params : dict
-          , rate           : float
+          , files_in           : OneOrManyFiles
+          , file_out           : str
+          , event_range        : EventRangeType
+          , print_mod          : int
+          , compression        : str
+          , detector_db        : str
+          , run_number         : int
+          , s1_lighttable      : str
+          , s2_lighttable      : str
+          , sipm_psf           : str
+          , buffer_params      : dict
+          , physics_params     : dict
+          , rate               : float
+          , data_mc_ratio_pmt  : float
+          , data_mc_ratio_sipm : float
           ):
 
     buffer_params_  = buffer_params .copy()
@@ -178,8 +180,8 @@ def detsim( *
     # derived parameters
     datapmt  = db.DataPMT (detector_db, run_number)
     datasipm = db.DataSiPM(detector_db, run_number)
-    lt_pmt   = LT_PMT (fname=os.path.expandvars(s2_lighttable))
-    lt_sipm  = LT_SiPM(fname=os.path.expandvars(sipm_psf), sipm_database=datasipm)
+    lt_pmt   = LT_PMT (fname=os.path.expandvars(s2_lighttable), data_mc_ratio=data_mc_ratio_pmt )
+    lt_sipm  = LT_SiPM(fname=os.path.expandvars(sipm_psf)     , data_mc_ratio=data_mc_ratio_sipm, sipm_database=datasipm)
     el_gap   = lt_sipm.el_gap_width
 
     filter_delayed_hits = fl.map(filter_hits_after_max_time(buffer_params_["max_time"]),

--- a/invisible_cities/config/detsim.conf
+++ b/invisible_cities/config/detsim.conf
@@ -36,3 +36,6 @@ compression = "ZLIB4"
 print_mod = 1
 
 rate = 0.5 * hertz
+
+data_mc_ratio_pmt  = 1
+data_mc_ratio_sipm = 1

--- a/invisible_cities/config/detsim_next100.conf
+++ b/invisible_cities/config/detsim_next100.conf
@@ -36,3 +36,6 @@ compression = "ZLIB4"
 print_mod = 1
 
 rate = 0.5 * hertz
+
+data_mc_ratio_pmt  = 1
+data_mc_ratio_sipm = 1

--- a/invisible_cities/detsim/light_tables_c.pyx
+++ b/invisible_cities/detsim/light_tables_c.pyx
@@ -107,7 +107,7 @@ cdef class LT_SiPM(LightTable):
         double inv_bin
         double active_r2
 
-    def __init__(self, *, fname, sipm_database, el_gap_width=None, active_radius=None):
+    def __init__(self, *, fname, sipm_database, el_gap_width=None, active_radius=None, data_mc_ratio=1):
         lt_df, config_df, el_gap, active_r = read_lt(fname, 'PSF', el_gap_width, active_radius)
         lt_df.set_index('dist_xy', inplace=True)
         self.el_gap_width  = el_gap
@@ -116,7 +116,7 @@ cdef class LT_SiPM(LightTable):
 
         el_pitch  = float(config_df.loc["pitch_z"].value) * units.mm
         self.zbins_    = get_el_bins(el_pitch, el_gap)
-        self.values    = np.array(lt_df.values/len(self.zbins_), order='C', dtype=np.double)
+        self.values    = np.array(lt_df.values/len(self.zbins_) * data_mc_ratio, order='C', dtype=np.double)
         self.psf_bin   = float(lt_df.index[1]-lt_df.index[0]) * units.mm #index of psf is the distance to the sensor in mm
         self.inv_bin   = 1./self.psf_bin # compute this once to speed up the get_values_ calls
 
@@ -207,7 +207,7 @@ cdef class LT_PMT(LightTable):
         double ymin
         double active_r2
 
-    def __init__(self, *, fname, el_gap_width=None, active_radius=None):
+    def __init__(self, *, fname, el_gap_width=None, active_radius=None, data_mc_ratio=1):
         lt_df, config_df, el_gap, active_r = read_lt(fname, 'LT', el_gap_width, active_radius)
         self.el_gap_width  = el_gap
         self.active_radius = active_r
@@ -224,7 +224,7 @@ cdef class LT_PMT(LightTable):
         values_aux, (xmin, xmax), (ymin, ymax)  = self.__extend_lt_bounds(lt_df, config_df, columns, bin_x, bin_y)
         lenz = len(self.zbins)
         # add dimension for z partitions (1 in case of this table)
-        self.values = np.asarray(np.repeat(values_aux, lenz, axis=-1), dtype=np.double, order='C')
+        self.values = np.asarray(np.repeat(values_aux, lenz, axis=-1) * data_mc_ratio, dtype=np.double, order='C')
         self.xmin = xmin
         self.ymin = ymin
         # calculate inverse to speed up calls of get_values_

--- a/invisible_cities/detsim/light_tables_c.pyx
+++ b/invisible_cities/detsim/light_tables_c.pyx
@@ -108,6 +108,8 @@ cdef class LT_SiPM(LightTable):
         double active_r2
 
     def __init__(self, *, fname, sipm_database, el_gap_width=None, active_radius=None, data_mc_ratio=1):
+        if data_mc_ratio <= 0: raise ValueError("LT_SiPM: data_mc_ratio must be greater than 0")
+
         lt_df, config_df, el_gap, active_r = read_lt(fname, 'PSF', el_gap_width, active_radius)
         lt_df.set_index('dist_xy', inplace=True)
         self.el_gap_width  = el_gap
@@ -208,6 +210,8 @@ cdef class LT_PMT(LightTable):
         double active_r2
 
     def __init__(self, *, fname, el_gap_width=None, active_radius=None, data_mc_ratio=1):
+        if data_mc_ratio <= 0: raise ValueError("LT_PMT: data_mc_ratio must be greater than 0")
+
         lt_df, config_df, el_gap, active_r = read_lt(fname, 'LT', el_gap_width, active_radius)
         self.el_gap_width  = el_gap
         self.active_radius = active_r


### PR DESCRIPTION
The C++ version of detsim allowed us to scale the PMTs light collection efficiency to match data. This PR introduces this functionality again, this time for PMTs and SiPMs independently.

Although there is some redundancy in this[^1], it keeps it extra flexible for the future.

[^1]: It would be enough to fix the el gain to match either the PMTs or the SiPMs LCE and scale up the other one