### PR TITLE
Store configuration parameters

### DIFF
--- a/invisible_cities/cities/cities_test.py
+++ b/invisible_cities/cities/cities_test.py
@@ -87,6 +87,28 @@ def test_city_output_file_is_compressed(config_tmpdir, ICDATADIR, city):
 
 @mark.filterwarnings("ignore::UserWarning")
 @mark.parametrize("city", all_cities)
+def test_city_output_contains_configuration(config_tmpdir, city):
+    file_out    = os.path.join(config_tmpdir, f"{city}_configuration.h5")
+    config_file = 'dummy invisible_cities/config/{}.conf'.format(city)
+
+    conf = configure(config_file.split())
+    conf.update(dict( file_out    = file_out
+                    , event_range = 0))
+
+    module_name   = f'invisible_cities.cities.{city}'
+    city_function = getattr(import_module(module_name), city)
+
+    city_function(**conf)
+
+    with tb.open_file(file_out) as file:
+        assert "config" in file.root
+        assert city     in file.root.config
+        table = getattr(file.root.config, city)
+        assert len(table[:]) > 0
+
+
+@mark.filterwarnings("ignore::UserWarning")
+@mark.parametrize("city", all_cities)
 def test_city_missing_detector_db(city):
     # use default config file
     config_file = 'dummy invisible_cities/config/{}.conf'.format(city)

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -135,8 +135,11 @@ def city(city_function):
         conf.event_range  = event_range(conf)
         # TODO There were deamons! self.daemons = tuple(map(summon_daemon, kwds.get('daemons', [])))
 
-        result = check_annotations(city_function)(**vars(conf))
+        args   = vars(conf)
+        result = check_annotations(city_function)(**args)
         if os.path.exists(conf.file_out):
+            write_city_configuration(conf.file_out, city_function.__name__, args)
+            copy_cities_configuration(conf.files_in[0], conf.file_out)
             index_tables(conf.file_out)
         return result
     return proxy

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -221,7 +221,9 @@ def write_city_configuration( filename : str
 
 def copy_cities_configuration( file_in : str, file_out : str):
     with tb.open_file(file_in, "r") as fin:
-        if "config" not in fin.root: return
+        if "config" not in fin.root:
+            warnings.warn("Input file does not contain /config group", UserWarning)
+            return
 
         with tb.open_file(file_out, "a") as fout:
             if "config" not in fout.root:

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -203,6 +203,30 @@ def index_tables(file_out):
                 table.colinstances[colname].create_index()
 
 
+def write_city_configuration( filename : str
+                            , city_name: str
+                            , args     : dict):
+    args = {k: str(v) for k,v in args.items()}
+
+    with tb.open_file(filename, "a") as file:
+        df = (pd.Series(args)
+                .to_frame()
+                .reset_index()
+                .rename(columns={"index": "variable", 0: "value"}))
+        df_writer(file, df, "config", city_name, f"configuration for {city_name}", str_col_length=300)
+
+
+def copy_cities_configuration( file_in : str, file_out : str):
+    with tb.open_file(file_in, "r") as fin:
+        if "config" not in fin.root: return
+
+        with tb.open_file(file_out, "a") as fout:
+            if "config" not in fout.root:
+                fout.create_group(fout.root, "config")
+            for table in fin.root.config:
+                fin.copy_node(table, fout.root.config, recursive=True)
+
+
 def _check_invalid_event_range_spec(er):
     return (len(er) not in (1, 2)                   or
             (len(er) == 2 and EventRange.all in er) or

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -504,3 +504,12 @@ def test_copy_cities_configuration(config_tmpdir):
         assert var in df2.index
         assert str(value) == df1.value.loc[var]
         assert str(value) == df2.value.loc[var]
+
+
+def test_copy_cities_configuration_warns_when_nothing_to_copy(ICDATADIR, config_tmpdir):
+    # any file without config group will do
+    filename1  = os.path.join(    ICDATADIR, "electrons_40keV_z25_RWF.h5")
+    filename2  = os.path.join(config_tmpdir, "test_copy_cities_configuration_warns.h5")
+
+    with warns(UserWarning):
+        copy_cities_configuration(filename1, filename2)

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -511,5 +511,5 @@ def test_copy_cities_configuration_warns_when_nothing_to_copy(ICDATADIR, config_
     filename1  = os.path.join(    ICDATADIR, "electrons_40keV_z25_RWF.h5")
     filename2  = os.path.join(config_tmpdir, "test_copy_cities_configuration_warns.h5")
 
-    with warns(UserWarning):
+    with warns(UserWarning, match="Input file does not contain /config group"):
         copy_cities_configuration(filename1, filename2)


### PR DESCRIPTION
This PR stores the city configuration in the output file for bookkeeping purposes. It also propagates the configuration from previous cities further down the chain.

Closes #837 
 