### PR TITLE
Fix type hint in esmeralda and beersheba

### DIFF
--- a/invisible_cities/cities/beersheba.py
+++ b/invisible_cities/cities/beersheba.py
@@ -45,10 +45,6 @@ from os   .path  import expandvars
 from scipy.stats import multivariate_normal
 from numpy       import nan_to_num
 
-from typing import Tuple
-from typing import List
-from typing import Optional
-
 from .  components import city
 from .  components import collect
 from .  components import copy_mc_info
@@ -91,6 +87,9 @@ from .. types.symbols          import DeconvolutionMode
 
 from .. core                   import system_of_units as units
 
+from typing import Tuple
+from typing import List
+from typing import Optional
 from typing import Union
 
 

--- a/invisible_cities/cities/beersheba.py
+++ b/invisible_cities/cities/beersheba.py
@@ -83,12 +83,15 @@ from .. io.         hits_io    import hits_writer
 from .. io. event_filter_io    import event_filter_writer
 from .. io.         kdst_io    import kdst_from_df_writer
 
+from .. types.ic_types         import NoneType
 from .. types.symbols          import HitEnergy
 from .. types.symbols          import InterpolationMethod
 from .. types.symbols          import CutType
 from .. types.symbols          import DeconvolutionMode
 
 from .. core                   import system_of_units as units
+
+from typing import Union
 
 
 # Temporary. The removal of the event model will fix this.
@@ -376,8 +379,8 @@ def beersheba( files_in         : OneOrManyFiles
              , threshold        : float
              , same_peak        : bool
              , deconv_params    : dict
-             , corrections_file : str
-             , apply_temp       : bool
+             , corrections_file : Union[ str, NoneType]
+             , apply_temp       : Union[bool, NoneType]
              ):
     """
     The city corrects Penthesilea hits energy and extracts topology information.

--- a/invisible_cities/cities/esmeralda.py
+++ b/invisible_cities/cities/esmeralda.py
@@ -56,6 +56,10 @@ from .. io.         hits_io import hits_writer
 from .. io.         kdst_io import kdst_from_df_writer
 from .. io.run_and_event_io import run_and_event_writer
 
+from .. types.ic_types import NoneType
+
+from typing import Union
+
 
 def hit_dropper(radius : float):
     def in_fiducial(hit : evm.Hit) -> bool:
@@ -80,8 +84,8 @@ def esmeralda( files_in         : OneOrManyFiles
              , same_peak        : bool
              , fiducial_r       : float
              , paolina_params   : dict
-             , corrections_file : str
-             , apply_temp       : bool
+             , corrections_file : Union[ str, NoneType]
+             , apply_temp       : Union[bool, NoneType]
              ):
     """
     The city applies a threshold to sipm hits and extracts


### PR DESCRIPTION
The corrections in esmeralda and beersheba are optional. The code assumed that `corrections_file = None` meant no corrections, but the type hints in the function signature did not allow that.

Note that we don't want to use default values in the cities' signatures to force the user to understand what they are doing. In this case, the optional status of the arguments related to energy corrections is reflected by the possibility of choosing `None` as a value.