### PR TITLE
Improve utilities for structure comparison in tests

### DIFF
--- a/invisible_cities/core/testing_utils.py
+++ b/invisible_cities/core/testing_utils.py
@@ -87,17 +87,6 @@ def FLOAT_ARRAY(*args, **kwargs):
 def random_length_float_arrays(min_length =     0,
                                max_length =   100,
                                **kwargs          ):
-
-
-def _compare_dataframes(assertion, df1, df2, check_types=True, **kwargs):
-    assert sorted(df1.columns) == sorted(df2.columns), "DataFrames with different structure cannot be compared"
-
-    for col in df1.columns:
-        col1 = df1[col]
-        col2 = df2[col]
-        if check_types:
-            assert col1.dtype == col2.dtype
-        assertion(col1.values, col2.values, **kwargs)
     lengths = integers(min_length, max_length)
     return lengths.flatmap(lambda n: float_arrays(n, **kwargs))
 

--- a/invisible_cities/core/testing_utils.py
+++ b/invisible_cities/core/testing_utils.py
@@ -87,11 +87,6 @@ def FLOAT_ARRAY(*args, **kwargs):
 def random_length_float_arrays(min_length =     0,
                                max_length =   100,
                                **kwargs          ):
-    lengths = integers(min_length,
-                       max_length)
-
-    return lengths.flatmap(lambda n: float_arrays(       n,
-                                                  **kwargs))
 
 
 def _compare_dataframes(assertion, df1, df2, check_types=True, **kwargs):
@@ -103,6 +98,8 @@ def _compare_dataframes(assertion, df1, df2, check_types=True, **kwargs):
         if check_types:
             assert col1.dtype == col2.dtype
         assertion(col1.values, col2.values, **kwargs)
+    lengths = integers(min_length, max_length)
+    return lengths.flatmap(lambda n: float_arrays(n, **kwargs))
 
 
 def assert_dataframes_equal(df1, df2, **kwargs):

--- a/invisible_cities/core/testing_utils.py
+++ b/invisible_cities/core/testing_utils.py
@@ -128,18 +128,21 @@ def assert_PMap_equality(pmp0, pmp1):
         assert_Peak_equality(s2_0, s2_1)
 
 
+def _get_table_name(t):
+    return t.name if hasattr(t, "name") else "unknown"
+
 def assert_tables_equality(got_table, expected_table, rtol=1e-7, atol=0):
     table_got      =      got_table[:]
     table_expected = expected_table[:]
     # we keep both names to be as generic as possible
-    names          = got_table.name, expected_table.name
+    names          = _get_table_name(got_table), _get_table_name(expected_table)
 
     assert len(table_got      ) == len(table_expected      ), f"Tables {names} have different lengths"
     assert len(table_got.dtype) == len(table_expected.dtype), f"Tables {names} have different widths"
 
     if table_got.dtype.names is not None:
         for col_name in table_got.dtype.names:
-            assert col_name in table_expected.dtype.names, f"Column {col_name} missing in {expected_table.name}"
+            assert col_name in table_expected.dtype.names, f"Column {col_name} missing in {names[1]}"
 
             got      = table_got     [col_name]
             expected = table_expected[col_name]

--- a/invisible_cities/core/testing_utils.py
+++ b/invisible_cities/core/testing_utils.py
@@ -137,8 +137,9 @@ def assert_tables_equality(got_table, expected_table, rtol=1e-7, atol=0):
     # we keep both names to be as generic as possible
     names          = _get_table_name(got_table), _get_table_name(expected_table)
 
-    assert len(table_got      ) == len(table_expected      ), f"Tables {names} have different lengths"
-    assert len(table_got.dtype) == len(table_expected.dtype), f"Tables {names} have different widths"
+    shape_got      = len(table_got     ), len(table_got     .dtype)
+    shape_expected = len(table_expected), len(table_expected.dtype)
+    assert shape_got == shape_expected, f"Tables {names} have different shapes: {shape_got} vs. {shape_expected}"
 
     if table_got.dtype.names is not None:
         for col_name in table_got.dtype.names:

--- a/invisible_cities/core/testing_utils_test.py
+++ b/invisible_cities/core/testing_utils_test.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from pytest                       import mark
+from pytest                       import raises
 from flaky                        import flaky
 from hypothesis                   import given
 from hypothesis.strategies        import floats
@@ -41,3 +42,50 @@ def test_assert_tables_equality_withNaN():
     table = np.array([('Rex', 9, 81.0), ('Fido', 3, np.nan)],
                      dtype=[('name', 'U10'), ('age', 'i4'), ('weight', 'f4')])
     assert_tables_equality(table, table)
+
+
+@mark.parametrize("index value".split(), ((0, "three"), (1, 3), (2, 3.0)))
+def test_assert_tables_equality_fails_different_values(index, value):
+    # modify a value in the second row and check that the function
+    # picks up the difference
+    table1 = np.array([ ('one', 1, 1.0)
+                      , ('two', 2, 2.0)],
+                      dtype=[('text', 'U10'), ('integer', 'i4'), ('float', 'f4')])
+
+    table2 = table1.copy()
+    table2[1][index] = value
+    with raises(AssertionError):
+        assert_tables_equality(table1, table2)
+
+
+def test_assert_tables_equality_fails_different_names():
+    # modify the type of a column and check that the function picks up
+    # the difference
+    dtypes1 = [('text', 'U10'), ('integer', 'i4'), ('float', 'f4')]
+    table1  = np.array([ ('one', 1, 1.0)
+                       , ('two', 2, 2.0)],
+                       dtype=dtypes1)
+
+    dtypes2 = [('different_name', 'U10'), ('integer', 'i4'), ('float', 'f4')]
+    table2  = np.array([ ('one', 1, 1.0)
+                       , ('two', 2, 2.0)],
+                       dtype=dtypes2)
+
+    with raises(AssertionError):
+        assert_tables_equality(table1, table2)
+
+
+def test_assert_tables_equality_fails_different_values():
+    # modify the type of a column and check that the function picks up
+    # the difference
+    dtypes1 = [('text', 'U10'), ('integer', 'i4'), ('float', 'f4')]
+    table1  = np.array([ ('one', 1, 1.0)
+                       , ('two', 2, 2.0)],
+                       dtype=dtypes1)
+
+    dtypes2    = list(dtypes1)
+    dtypes2[1] = ("integer", "f4")
+    table2     = table1.copy().astype(dtypes2)
+
+    with raises(AssertionError):
+        assert_tables_equality(table1, table2)

--- a/invisible_cities/core/testing_utils_test.py
+++ b/invisible_cities/core/testing_utils_test.py
@@ -104,3 +104,36 @@ def test_assert_tables_equality_different_arrays(dtype):
     array2 = array1 + 1
     with raises(AssertionError):
         assert_tables_equality(array1, array2)
+
+
+@mark.parametrize(    "shape1  shape2".split()
+                 , ( ( (3, 4), (4, 4) )    # different lengths
+                   , ( (3, 3), (3, 4) )))  # different widths
+def test_assert_tables_equality_different_array_shapes(shape1, shape2):
+    array1 = np.ones(shape1)
+    array2 = np.ones(shape2)
+    with raises(AssertionError):
+        assert_tables_equality(array1, array2)
+
+
+def test_assert_tables_equality_different_table_shapes():
+    table1 = np.array([ (1, 1.0)
+                      , (2, 2.0)],
+                      dtype=[('integer', 'i4'), ('float', 'f4')])
+
+    table2 = np.array([ (1, 1.0)
+                      , (2, 2.0)
+                      , (3, 3.0)],
+                      dtype=[('integer', 'i4'), ('float', 'f4')])
+
+    table3 = np.array([ ('one', 1, 1.0)
+                      , ('two', 2, 2.0)],
+                      dtype=[('text', 'U10'), ('integer', 'i4'), ('float', 'f4')])
+
+    # different lengths
+    with raises(AssertionError):
+        assert_tables_equality(table1, table2)
+
+    # different widths
+    with raises(AssertionError):
+        assert_tables_equality(table1, table3)

--- a/invisible_cities/core/testing_utils_test.py
+++ b/invisible_cities/core/testing_utils_test.py
@@ -89,3 +89,18 @@ def test_assert_tables_equality_fails_different_values():
 
     with raises(AssertionError):
         assert_tables_equality(table1, table2)
+
+
+@mark.parametrize("dtype", (int, float))
+def test_assert_tables_equality_equal_arrays(dtype):
+    array1 = np.arange(20, dtype=dtype)
+    array2 = array1.copy()
+    assert_tables_equality(array1, array2)
+
+
+@mark.parametrize("dtype", (int, float))
+def test_assert_tables_equality_different_arrays(dtype):
+    array1 = np.arange(20, dtype=dtype)
+    array2 = array1 + 1
+    with raises(AssertionError):
+        assert_tables_equality(array1, array2)


### PR DESCRIPTION
When a table or a dataframe comparion fails in a test, we don't get much information. This PR adds a bit of information to the failure to help identify their causes.

This branch is currently on top of #895, the corresponding commits will be removed before merging.

Closes #840 