### PR TITLE
Fix non-interpolated deconvolution

### DIFF
--- a/invisible_cities/reco/deconv_functions_test.py
+++ b/invisible_cities/reco/deconv_functions_test.py
@@ -179,15 +179,18 @@ def test_deconvolution_input_interpolation_method(data_hdst, new_grid_1mm, inter
     input image that results in round numbers.
     """
     hdst = load_dst(data_hdst, 'RECO', 'Events')
-    hdst = hdst[(hdst.event == 3021916) & (hdst.npeak == 0) & (hdst.Q>40)]
+    hdst = hdst[(hdst.event == 3021916) & (hdst.npeak == 0)]
+    hdst = hdst.groupby(list("XY")).Q.sum().reset_index().loc[lambda df: df.Q>40]
 
-    deconvolve = deconvolution_input([10., 10.], new_grid_1mm, interp_method)
-    output     = deconvolve((hdst.X, hdst.Y), hdst.Q)
+    interpolator = deconvolution_input([10., 10.], new_grid_1mm, interp_method)
+    output       = interpolator((hdst.X, hdst.Y), hdst.Q)
 
-    assert output[0].shape == (70, 100)
-    assert len(output[1])  == 2
-    assert output[1][0].shape == (7000,)
-    assert output[1][1].shape == (7000,)
+    shape     = 120, 120
+    nelements = shape[0] * shape[1]
+    assert output[0].shape    == shape
+    assert len(output[1])     == 2
+    assert output[1][0].shape == (nelements,)
+    assert output[1][1].shape == (nelements,)
 
 
 def test_deconvolve(data_hdst, data_hdst_deconvolved):

--- a/invisible_cities/reco/deconv_functions_test.py
+++ b/invisible_cities/reco/deconv_functions_test.py
@@ -151,7 +151,11 @@ def new_grid_1mm():
     return det_grid
 
 
-def test_deconvolution_input(data_hdst, data_hdst_deconvolved, new_grid_1mm):
+def test_deconvolution_input_exact_result(data_hdst, data_hdst_deconvolved, new_grid_1mm):
+    """
+    Compare the output of the deconvolution with a reference output
+    stored in a file.
+    """
     ref_interpolation = np.load(data_hdst_deconvolved)
 
     hdst   = load_dst(data_hdst, 'RECO', 'Events')
@@ -170,7 +174,9 @@ def test_deconvolution_input(data_hdst, data_hdst_deconvolved, new_grid_1mm):
 @mark.parametrize("interp_method", InterpolationMethod)
 def test_deconvolution_input_interpolation_method(data_hdst, new_grid_1mm, interp_method):
     """
-    Check that it runs with all interpolation methods
+    Check that it runs with all interpolation methods.
+    Select one event/peak from input and apply a cut to obtain an
+    input image that results in round numbers.
     """
     hdst = load_dst(data_hdst, 'RECO', 'Events')
     hdst = hdst[(hdst.event == 3021916) & (hdst.npeak == 0) & (hdst.Q>40)]

--- a/invisible_cities/reco/deconv_functions_test.py
+++ b/invisible_cities/reco/deconv_functions_test.py
@@ -184,12 +184,6 @@ def test_deconvolution_input_interpolation_method(data_hdst, new_grid_1mm, inter
     assert output[1][1].shape == (7000,)
 
 
-@mark.parametrize("interp_method", InterpolationMethod.__members__)
-def test_deconvolution_input_wrong_interpolation_method_raises(data_hdst, data_hdst_deconvolved, interp_method):
-    with raises(ValueError):
-        deconvolution_input([10., 10.], [1., 1.], interp_method)
-
-
 def test_deconvolve(data_hdst, data_hdst_deconvolved):
     ref_interpolation = np.load (data_hdst_deconvolved)
 

--- a/invisible_cities/reco/deconv_functions_test.py
+++ b/invisible_cities/reco/deconv_functions_test.py
@@ -199,6 +199,12 @@ def test_deconvolution_input_interpolation_method(data_hdst_first_peak, new_grid
     assert output[1][1].shape == (nelements,)
 
 
+@mark.parametrize("interp_method", InterpolationMethod.__members__)
+def test_deconvolution_input_wrong_interpolation_method_raises(interp_method):
+    with raises(ValueError):
+        deconvolution_input([10., 10.], [1., 1.], interp_method)
+
+
 #TODO: use data_hdst_first_peak and new_grid_1mm here too, if possible
 def test_deconvolve(data_hdst, data_hdst_deconvolved):
     ref_interpolation = np.load (data_hdst_deconvolved)


### PR DESCRIPTION
The output of the deconvolution without interpolation produces an image with a different size than with interpolation.

Fixes #905.

