### PR TITLE
Handle hitless events post Sophronia

### DIFF
--- a/invisible_cities/cities/beersheba.py
+++ b/invisible_cities/cities/beersheba.py
@@ -95,9 +95,10 @@ from typing import Union
 
 
 # Temporary. The removal of the event model will fix this.
-from collections import defaultdict
 def hitc_to_df_(hitc):
-    columns = defaultdict(list)
+    columns = "event time npeak Xpeak Ypeak nsipm X Y Xrms Yrms Z Q E Qc Ec track_id Ep".split()
+    columns = {col:[] for col in columns}
+
     for hit in hitc.hits:
         columns["event"   ].append(hitc.event)
         columns["time"    ].append(hitc.time)

--- a/invisible_cities/cities/beersheba_test.py
+++ b/invisible_cities/cities/beersheba_test.py
@@ -188,6 +188,9 @@ def test_beersheba_filters_empty_dfs(beersheba_config, config_tmpdir):
     assert df.passed.tolist() == [False]
 
 
+@mark.filterwarnings("ignore:Event .* does not contain hits")
+@mark.filterwarnings("ignore:dataframe contains strings longer than allowed")
+@mark.filterwarnings("ignore:Input file does not contain /config group")
 def test_beersheba_does_not_crash_with_no_hits(beersheba_config, Th228_hits_missing, config_tmpdir):
     path_out  = os.path.join(config_tmpdir, "beersheba_does_not_crash_with_no_hits.h5")
     beersheba_config.update(dict( files_in    = Th228_hits_missing

--- a/invisible_cities/cities/beersheba_test.py
+++ b/invisible_cities/cities/beersheba_test.py
@@ -1,4 +1,6 @@
 import os
+import shutil
+
 import numpy  as np
 import tables as tb
 import pandas as pd
@@ -185,3 +187,22 @@ def test_beersheba_filters_empty_dfs(beersheba_config, config_tmpdir):
 
     df = dio.load_dst(path_out, "Filters", "nohits")
     assert df.passed.tolist() == [False]
+
+
+def test_beersheba_does_not_crash_with_no_hits(beersheba_config, Th228_hits, config_tmpdir):
+    path_in   = os.path.join(config_tmpdir, "beersheba_does_not_crash_with_no_hits_input.h5")
+    path_out  = os.path.join(config_tmpdir, "beersheba_does_not_crash_with_no_hits_output.h5")
+    beersheba_config.update(dict( files_in    = path_in
+                                , file_out    = path_out
+                                , event_range = 1))
+
+    # copy file and remove the hits from the first event
+    shutil.copy(Th228_hits, path_in)
+    with tb.open_file(path_in, "r+") as file:
+        first_evt = file.root.Run.events[0][0]
+        evt_rows  = [row[0] == first_evt for row in file.root.RECO.Events]
+        n_delete  = sum(evt_rows)
+        file.root.RECO.Events.remove_rows(0, n_delete)
+
+    # just test that it doesn't crash
+    beersheba(**beersheba_config)

--- a/invisible_cities/cities/beersheba_test.py
+++ b/invisible_cities/cities/beersheba_test.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 
 import numpy  as np
 import tables as tb
@@ -189,20 +188,11 @@ def test_beersheba_filters_empty_dfs(beersheba_config, config_tmpdir):
     assert df.passed.tolist() == [False]
 
 
-def test_beersheba_does_not_crash_with_no_hits(beersheba_config, Th228_hits, config_tmpdir):
-    path_in   = os.path.join(config_tmpdir, "beersheba_does_not_crash_with_no_hits_input.h5")
-    path_out  = os.path.join(config_tmpdir, "beersheba_does_not_crash_with_no_hits_output.h5")
-    beersheba_config.update(dict( files_in    = path_in
+def test_beersheba_does_not_crash_with_no_hits(beersheba_config, Th228_hits_missing, config_tmpdir):
+    path_out  = os.path.join(config_tmpdir, "beersheba_does_not_crash_with_no_hits.h5")
+    beersheba_config.update(dict( files_in    = Th228_hits_missing
                                 , file_out    = path_out
                                 , event_range = 1))
-
-    # copy file and remove the hits from the first event
-    shutil.copy(Th228_hits, path_in)
-    with tb.open_file(path_in, "r+") as file:
-        first_evt = file.root.Run.events[0][0]
-        evt_rows  = [row[0] == first_evt for row in file.root.RECO.Events]
-        n_delete  = sum(evt_rows)
-        file.root.RECO.Events.remove_rows(0, n_delete)
 
     # just test that it doesn't crash
     beersheba(**beersheba_config)

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -602,6 +602,7 @@ def hits_and_kdst_from_files( paths : List[str]
                 if len(hits):
                     hits = hits[event_number]
                 else:
+                    warnings.warn(f"Event {event_number} does not contain hits", UserWarning)
                     hits = HitCollection(event_number, timestamp, [])
                 yield dict(hits = hits,
                            kdst = kdst_df.loc[kdst_df.event==event_number],

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -594,12 +594,16 @@ def hits_and_kdst_from_files( paths : List[str]
             except (tb.exceptions.NoSuchNodeError, IndexError):
                 continue
 
-            check_lengths(event_info, hits_df.event.unique())
+            check_lengths(event_info, kdst_df.event.unique())
 
             for evtinfo in event_info:
                 event_number, timestamp = evtinfo.fetch_all_fields()
                 hits = hits_from_df(hits_df.loc[hits_df.event == event_number])
-                yield dict(hits = hits[event_number],
+                if len(hits):
+                    hits = hits[event_number]
+                else:
+                    hits = HitCollection(event_number, timestamp, [])
+                yield dict(hits = hits,
                            kdst = kdst_df.loc[kdst_df.event==event_number],
                            run_number = run_number,
                            event_number = event_number,

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 
 import numpy as np
 import tables as tb
@@ -295,20 +294,10 @@ def test_hits_and_kdst_from_files(ICDATADIR):
 
 
 @mark.filterwarnings("ignore:Event .* does not contain hits")
-def test_hits_and_kdst_from_files_missing_hits(Th228_hits, config_tmpdir):
-    path_in = os.path.join(config_tmpdir, "hits_and_kdst_from_files_missing_hits.h5")
+def test_hits_and_kdst_from_files_missing_hits(Th228_hits_missing, config_tmpdir):
+    n_events_true = len(pd.read_hdf(Th228_hits_missing, "/Run/events"))
 
-    # copy file and remove the hits from the first event
-    shutil.copy(Th228_hits, path_in)
-    with tb.open_file(path_in, "r+") as file:
-        n_events_true = file.root.Run.events.shape[0]
-
-        first_evt = file.root.Run.events[0][0]
-        evt_rows  = [row[0] == first_evt for row in file.root.RECO.Events]
-        n_delete  = sum(evt_rows)
-        file.root.RECO.Events.remove_rows(0, n_delete)
-
-    generator = hits_and_kdst_from_files([path_in], "RECO", "Events")
+    generator = hits_and_kdst_from_files([Th228_hits_missing], "RECO", "Events")
     n_events  = sum(1 for _ in generator)
     assert n_events == n_events_true
 

--- a/invisible_cities/cities/esmeralda_test.py
+++ b/invisible_cities/cities/esmeralda_test.py
@@ -3,6 +3,8 @@ import shutil
 import numpy  as np
 import tables as tb
 
+from pytest import mark
+
 from .. core                 import system_of_units as units
 from .. io                   import dst_io      as dio
 from .  esmeralda            import esmeralda
@@ -202,6 +204,8 @@ def test_esmeralda_filters_events_with_too_many_hits(esmeralda_config, Th228_tra
     assert            filter_output.passed.tolist() == evt_pass
 
 
+@mark.filterwarnings("ignore:Event .* does not contain hits")
+@mark.filterwarnings("ignore:Input file does not contain /config group")
 def test_esmeralda_does_not_crash_with_no_hits(esmeralda_config, Th228_hits_missing, config_tmpdir):
     path_out  = os.path.join(config_tmpdir, "esmeralda_does_not_crash_with_no_hits.h5")
     esmeralda_config.update(dict( files_in    = Th228_hits_missing

--- a/invisible_cities/cities/esmeralda_test.py
+++ b/invisible_cities/cities/esmeralda_test.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import numpy  as np
 import tables as tb
 
@@ -199,3 +200,22 @@ def test_esmeralda_filters_events_with_too_many_hits(esmeralda_config, Th228_tra
     assert (summary.evt_ntrks > 0        ).tolist() == evt_pass
     assert (summary.evt_nhits < nhits_max).tolist() == evt_pass
     assert            filter_output.passed.tolist() == evt_pass
+
+
+def test_esmeralda_does_not_crash_with_no_hits(esmeralda_config, Th228_hits, config_tmpdir):
+    path_in   = os.path.join(config_tmpdir, "esmeralda_does_not_crash_with_no_hits_input.h5")
+    path_out  = os.path.join(config_tmpdir, "esmeralda_does_not_crash_with_no_hits_output.h5")
+    esmeralda_config.update(dict( files_in    = path_in
+                                , file_out    = path_out
+                                , event_range = 1))
+
+    # copy file and remove the hits from the first event
+    shutil.copy(Th228_hits, path_in)
+    with tb.open_file(path_in, "r+") as file:
+        first_evt = file.root.Run.events[0][0]
+        evt_rows  = [row[0] == first_evt for row in file.root.RECO.Events]
+        n_delete  = sum(evt_rows)
+        file.root.RECO.Events.remove_rows(0, n_delete)
+
+    # just test that it doesn't crash
+    esmeralda(**esmeralda_config)

--- a/invisible_cities/cities/esmeralda_test.py
+++ b/invisible_cities/cities/esmeralda_test.py
@@ -202,20 +202,11 @@ def test_esmeralda_filters_events_with_too_many_hits(esmeralda_config, Th228_tra
     assert            filter_output.passed.tolist() == evt_pass
 
 
-def test_esmeralda_does_not_crash_with_no_hits(esmeralda_config, Th228_hits, config_tmpdir):
-    path_in   = os.path.join(config_tmpdir, "esmeralda_does_not_crash_with_no_hits_input.h5")
-    path_out  = os.path.join(config_tmpdir, "esmeralda_does_not_crash_with_no_hits_output.h5")
-    esmeralda_config.update(dict( files_in    = path_in
+def test_esmeralda_does_not_crash_with_no_hits(esmeralda_config, Th228_hits_missing, config_tmpdir):
+    path_out  = os.path.join(config_tmpdir, "esmeralda_does_not_crash_with_no_hits.h5")
+    esmeralda_config.update(dict( files_in    = Th228_hits_missing
                                 , file_out    = path_out
                                 , event_range = 1))
-
-    # copy file and remove the hits from the first event
-    shutil.copy(Th228_hits, path_in)
-    with tb.open_file(path_in, "r+") as file:
-        first_evt = file.root.Run.events[0][0]
-        evt_rows  = [row[0] == first_evt for row in file.root.RECO.Events]
-        n_delete  = sum(evt_rows)
-        file.root.RECO.Events.remove_rows(0, n_delete)
 
     # just test that it doesn't crash
     esmeralda(**esmeralda_config)

--- a/invisible_cities/cities/sophronia_test.py
+++ b/invisible_cities/cities/sophronia_test.py
@@ -110,6 +110,25 @@ def test_sophronia_filters_events_with_only_nn_hits(config_tmpdir, sophronia_con
         assert     output_file.root.Filters.s12_selector[0][1]
         assert not output_file.root.Filters.valid_hit   [0][1]
 
-        # Check that it's present in /Run/events, but not in /RECO/Events
+
+def test_sophronia_keeps_hitless_events(config_tmpdir, sophronia_config):
+    """
+    Run with a high q threshold so all hits are discarded (turned into NN).
+    Check that these events are still in the /Run/events output, but not in
+    the /RECO/events output.
+    """
+    path_out = os.path.join(config_tmpdir, 'test_sophronia_keeps_hitless_events.h5')
+    config   = dict(**sophronia_config)
+    config.update(dict( file_out    = path_out
+                      , q_thr       = 1e4 * pes
+                      , event_range = 1 ))
+
+    sophronia(**config)
+
+    with tb.open_file(config["files_in"]) as input_file:
+        event_number = input_file.root.Run.events[0][0]
+
+    with tb.open_file(path_out) as output_file:
+        assert len(output_file.root.Run.events) == 1
         assert event_number == output_file.root.Run.events[0][0]
         assert event_number not in output_file.root.RECO.Events.col("event")

--- a/invisible_cities/cities/sophronia_test.py
+++ b/invisible_cities/cities/sophronia_test.py
@@ -7,6 +7,7 @@ from .. core.testing_utils   import assert_tables_equality
 from .. core.system_of_units import pes
 from .  sophronia            import sophronia
 
+
 def test_sophronia_runs(sophronia_config, config_tmpdir):
     path_out = os.path.join(config_tmpdir, 'sophronia_runs.h5')
     nevt_req = 1
@@ -97,6 +98,9 @@ def test_sophronia_filters_events_with_only_nn_hits(config_tmpdir, sophronia_con
 
     sophronia(**config)
 
+    with tb.open_file(config["files_in"]) as input_file:
+        event_number = input_file.root.Run.events[0][0]
+
     with tb.open_file(path_out) as output_file:
         # Check that the event passes the s12_selector, which is
         # applied earlier. Then check it doesn't pass the valid_hit
@@ -105,3 +109,7 @@ def test_sophronia_filters_events_with_only_nn_hits(config_tmpdir, sophronia_con
         # (event_number, passed_flag)
         assert     output_file.root.Filters.s12_selector[0][1]
         assert not output_file.root.Filters.valid_hit   [0][1]
+
+        # Check that it's present in /Run/events, but not in /RECO/Events
+        assert event_number == output_file.root.Run.events[0][0]
+        assert event_number not in output_file.root.RECO.Events.col("event")

--- a/invisible_cities/conftest.py
+++ b/invisible_cities/conftest.py
@@ -1,6 +1,9 @@
 import os
 import pytest
+import shutil
+
 import numpy  as np
+import tables as tb
 
 from pandas      import DataFrame
 from collections import namedtuple
@@ -635,6 +638,19 @@ def Th228_deco_separate(ICDATADIR):
     filename = "228Th_10evt_deco_separate.h5"
     filename = os.path.join(ICDATADIR, filename)
     return filename
+
+
+@pytest.fixture(scope="session")
+def Th228_hits_missing(Th228_hits):
+    """Copy input file and remove the hits from the first event"""
+    outpath = Th228_hits.replace(".h5", "_missing_hits.h5")
+    shutil.copy(Th228_hits, outpath)
+    with tb.open_file(outpath, "r+") as file:
+        first_evt = file.root.Run.events[0][0]
+        evt_rows  = [row[0] == first_evt for row in file.root.RECO.Events]
+        n_delete  = sum(evt_rows)
+        file.root.RECO.Events.remove_rows(0, n_delete)
+    return outpath
 
 
 @pytest.fixture(scope="session")

--- a/invisible_cities/conftest.py
+++ b/invisible_cities/conftest.py
@@ -641,9 +641,10 @@ def Th228_deco_separate(ICDATADIR):
 
 
 @pytest.fixture(scope="session")
-def Th228_hits_missing(Th228_hits):
+def Th228_hits_missing(Th228_hits, config_tmpdir):
     """Copy input file and remove the hits from the first event"""
-    outpath = Th228_hits.replace(".h5", "_missing_hits.h5")
+    outpath = os.path.basename(Th228_hits).replace(".h5", "_missing_hits.h5")
+    outpath = os.path.join(config_tmpdir, outpath)
     shutil.copy(Th228_hits, outpath)
     with tb.open_file(outpath, "r+") as file:
         first_evt = file.root.Run.events[0][0]


### PR DESCRIPTION
As discussed in #897, we implement a solution to hitless events in Esmeralda and Beersheba. Hitless events are preserved in the `/Run/events` table but are (naturally) missing in `/RECO/Events`.

Closes #897.