### PR TITLE
Add lazy `PMap` reader

### DIFF
--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -570,7 +570,7 @@ def pmap_from_files(paths):
             for evtinfo, (evt, pmap) in zip(event_info, pmaps):
                 event_number, timestamp = evtinfo.fetch_all_fields()
                 if event_number != evt:
-                    raise RuntimeError("Inconsistent data: event number mismatch")
+                    raise InvalidInputFileStructure("Inconsistent data: event number mismatch")
                 yield dict(pmap=pmap, run_number=run_number,
                            event_number=event_number, timestamp=timestamp)
 

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -554,7 +554,7 @@ def wf_from_files(paths, wf_type):
 def pmap_from_files(paths):
     for path in paths:
         try:
-            pmaps = load_pmaps(path)
+            pmaps = load_pmaps(path, lazy=True)
         except tb.exceptions.NoSuchNodeError:
             continue
 
@@ -567,11 +567,11 @@ def pmap_from_files(paths):
             except IndexError:
                 continue
 
-            check_lengths(event_info, pmaps)
-
-            for evtinfo in event_info:
+            for evtinfo, (evt, pmap) in zip(event_info, pmaps):
                 event_number, timestamp = evtinfo.fetch_all_fields()
-                yield dict(pmap=pmaps[event_number], run_number=run_number,
+                if event_number != evt:
+                    raise RuntimeError("Inconsistent data: event number mismatch")
+                yield dict(pmap=pmap, run_number=run_number,
                            event_number=event_number, timestamp=timestamp)
 
 

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -287,6 +287,20 @@ def test_city_only_pass_default_detector_db_when_expected(config_tmpdir):
 
     dummy_city(**args)
 
+def test_pmap_from_files_event_number_mismatch_raises(KrMC_pmaps_filename, output_tmpdir):
+    filename = os.path.join(output_tmpdir, "test_pmap_from_files_event_number_mismatch_raises.h5")
+
+    # copy file and remove one row to produce a mismatch
+    with tb.open_file(KrMC_pmaps_filename) as file:
+        file.copy_file(filename)
+    with tb.open_file(filename, "r+") as file:
+        file.root.Run.events.remove_rows(2, 3) # remove 2nd event
+
+    generator = pmap_from_files([filename])
+    with raises(InvalidInputFileStructure, match="Inconsistent data: event number mismatch"):
+        next(generator)
+
+
 def test_hits_and_kdst_from_files(ICDATADIR):
     event_number = 1
     timestamp    = 0.

--- a/invisible_cities/io/pmaps_io.py
+++ b/invisible_cities/io/pmaps_io.py
@@ -78,8 +78,9 @@ def _make_tables(hdf5_file, compression):
     return pmp_tables
 
 
-def load_pmaps_as_df(filename):
-    return load_pmaps_as_df_eager(filename)
+def load_pmaps_as_df(filename, lazy=False):
+    loader = load_pmaps_as_df_lazy if lazy else load_pmaps_as_df_eager
+    return loader(filename)
 
 
 def load_pmaps_as_df_eager(filename):
@@ -115,8 +116,9 @@ def _build_ipmtdf_from_sumdf(sumdf):
     return ipmtdf
 
 
-def load_pmaps(filename):
-    return load_pmaps_eager(filename)
+def load_pmaps(filename, lazy=False):
+    loader = load_pmaps_lazy if lazy else load_pmaps_eager
+    return loader(filename)
 
 
 def load_pmaps_eager(filename):

--- a/invisible_cities/io/pmaps_io.py
+++ b/invisible_cities/io/pmaps_io.py
@@ -78,7 +78,7 @@ def _make_tables(hdf5_file, compression):
     return pmp_tables
 
 
-def load_pmaps_as_df(filename):
+def load_pmaps_as_df_eager(filename):
     with tb.open_file(filename, 'r') as h5f:
         pmap  = h5f.root.PMAPS
         to_df = pd.DataFrame.from_records
@@ -96,9 +96,9 @@ def _build_ipmtdf_from_sumdf(sumdf):
     ipmtdf['npmt'] = -1
     return ipmtdf
 
-def load_pmaps(filename):
+def load_pmaps_eager(filename):
     pmap_dict = {}
-    s1df, s2df, sidf, s1pmtdf, s2pmtdf = load_pmaps_as_df(filename)
+    s1df, s2df, sidf, s1pmtdf, s2pmtdf = load_pmaps_as_df_eager(filename)
     # Hack fix to allow loading pmaps without individual pmts
     if s1pmtdf is None: s1pmtdf = _build_ipmtdf_from_sumdf(s1df)
     if s2pmtdf is None: s2pmtdf = _build_ipmtdf_from_sumdf(s2df)

--- a/invisible_cities/io/pmaps_io.py
+++ b/invisible_cities/io/pmaps_io.py
@@ -78,6 +78,10 @@ def _make_tables(hdf5_file, compression):
     return pmp_tables
 
 
+def load_pmaps_as_df(filename):
+    return load_pmaps_as_df_eager(filename)
+
+
 def load_pmaps_as_df_eager(filename):
     with tb.open_file(filename, 'r') as h5f:
         pmap  = h5f.root.PMAPS
@@ -95,6 +99,11 @@ def _build_ipmtdf_from_sumdf(sumdf):
     ipmtdf = ipmtdf.rename(index=str, columns={'time': 'npmt'})
     ipmtdf['npmt'] = -1
     return ipmtdf
+
+
+def load_pmaps(filename):
+    return load_pmaps_eager(filename)
+
 
 def load_pmaps_eager(filename):
     pmap_dict = {}

--- a/invisible_cities/io/pmaps_io_test.py
+++ b/invisible_cities/io/pmaps_io_test.py
@@ -181,16 +181,16 @@ def test_store_pmap(output_tmpdir, KrMC_pmaps_dict):
         assert cols.ene  [:] == approx (s2_data.enes_sipm)
 
 
-def test_load_pmaps_as_df(KrMC_pmaps_filename, KrMC_pmaps_dfs):
+def test_load_pmaps_as_df_eager(KrMC_pmaps_filename, KrMC_pmaps_dfs):
     true_dfs = KrMC_pmaps_dfs
-    read_dfs = pmpio.load_pmaps_as_df(KrMC_pmaps_filename)
+    read_dfs = pmpio.load_pmaps_as_df_eager(KrMC_pmaps_filename)
     for read_df, true_df in zip(read_dfs, true_dfs):
         assert_dataframes_equal(read_df, true_df)
 
 
-def test_load_pmaps_as_df_without_ipmt(KrMC_pmaps_without_ipmt_filename, KrMC_pmaps_without_ipmt_dfs):
+def test_load_pmaps_as_df_eager_without_ipmt(KrMC_pmaps_without_ipmt_filename, KrMC_pmaps_without_ipmt_dfs):
     true_dfs = KrMC_pmaps_without_ipmt_dfs
-    read_dfs = pmpio.load_pmaps_as_df(KrMC_pmaps_without_ipmt_filename)
+    read_dfs = pmpio.load_pmaps_as_df_eager(KrMC_pmaps_without_ipmt_filename)
 
     # Indices 0, 1 and 2 correspond to the S1sum, S2sum and Si
     # dataframes. Indices 3 and 4 are the S1pmt and S2pmt dataframes
@@ -203,7 +203,7 @@ def test_load_pmaps_as_df_without_ipmt(KrMC_pmaps_without_ipmt_filename, KrMC_pm
 
 
 @given(stg.data())
-def test_load_pmaps(output_tmpdir, data):
+def test_load_pmaps_eager(output_tmpdir, data):
     pmap_filename  = os.path.join(output_tmpdir, "test_pmap_file.h5")
     event_numbers  = [2, 4, 6]
     pmt_ids        = [1, 6, 8]
@@ -214,7 +214,7 @@ def test_load_pmaps(output_tmpdir, data):
         write = pmpio.pmap_writer(output_file)
         list(map(write, true_pmaps, event_numbers))
 
-    read_pmaps = pmpio.load_pmaps(pmap_filename)
+    read_pmaps = pmpio.load_pmaps_eager(pmap_filename)
 
     assert len(read_pmaps) == len(true_pmaps)
     assert np.all(list(read_pmaps.keys()) == event_numbers)

--- a/invisible_cities/io/pmaps_io_test.py
+++ b/invisible_cities/io/pmaps_io_test.py
@@ -286,7 +286,7 @@ def test_load_pmaps_as_df_eager(two_pmaps):
         assert_dataframes_equal(read_df, true_df)
 
 
-def test_load_pmaps_as_df_lazy(KrMC_pmaps_filename, KrMC_pmaps_dfs):
+def test_load_pmaps_as_df_lazy(KrMC_pmaps_filename):
     """Ensure the lazy and non-lazy versions provide the same result"""
     dfs_eager = pmpio.load_pmaps_as_df_eager(KrMC_pmaps_filename)
     dfs_lazy  = pmpio.load_pmaps_as_df_lazy (KrMC_pmaps_filename)

--- a/invisible_cities/io/pmaps_io_test.py
+++ b/invisible_cities/io/pmaps_io_test.py
@@ -279,9 +279,9 @@ def test_store_pmap(output_tmpdir, KrMC_pmaps_dict):
         assert cols.ene  [:] == approx (s2_data.enes_sipm)
 
 
-def test_load_pmaps_as_df_eager(KrMC_pmaps_filename, KrMC_pmaps_dfs):
-    true_dfs = KrMC_pmaps_dfs
-    read_dfs = pmpio.load_pmaps_as_df_eager(KrMC_pmaps_filename)
+def test_load_pmaps_as_df_eager(two_pmaps):
+    filename, _, true_dfs = two_pmaps
+    read_dfs = pmpio.load_pmaps_as_df_eager(filename)
     for read_df, true_df in zip(read_dfs, true_dfs):
         assert_dataframes_equal(read_df, true_df)
 

--- a/invisible_cities/io/pmaps_io_test.py
+++ b/invisible_cities/io/pmaps_io_test.py
@@ -320,6 +320,18 @@ def test_load_pmaps_as_df_lazy(KrMC_pmaps_filename):
         assert_dataframes_equal(df_lazy, df_eager)
 
 
+@mark.parametrize("skip" , (0, 1, 2, 3))
+@mark.parametrize("nread", (0, 1, 2, 3))
+def test_load_pmaps_as_df_lazy_subset(KrMC_pmaps_filename, skip, nread):
+    """Ensure the lazy and non-lazy versions provide the same result"""
+    # concatenate all dfs from the same node
+    dfs_lazy  = pmpio.load_pmaps_as_df_lazy (KrMC_pmaps_filename, skip, nread)
+    dfs_lazy = [pd.concat(node_dfs, ignore_index=True) for node_dfs in zip(*dfs_lazy)]
+
+    for df in dfs_lazy:
+        assert df.event.nunique() == nread
+
+
 def test_load_pmaps_as_df(KrMC_pmaps_filename):
     """Ensure the output of the function is the expected one"""
     eager = pmpio.load_pmaps_as_df(KrMC_pmaps_filename, lazy=False)
@@ -369,6 +381,16 @@ def test_load_pmaps_lazy(KrMC_pmaps_filename):
     for evt, pmap_lazy in pmaps_lazy.items():
         assert evt in pmaps_eager
         assert_PMap_equality(pmap_lazy, pmaps_eager[evt])
+
+
+@mark.parametrize("skip" , (0, 1, 2, 3))
+@mark.parametrize("nread", (0, 1, 2, 3))
+def test_load_pmaps_lazy_subset(KrMC_pmaps_filename, skip, nread):
+    """Ensure the lazy and non-lazy versions provide the same result"""
+    # concatenate all dfs from the same node
+    pmaps_lazy  = pmpio.load_pmaps_lazy(KrMC_pmaps_filename, skip, nread)
+    pmaps_lazy = dict(pmaps_lazy)
+    assert len(pmaps_lazy) == nread
 
 
 def test_load_pmaps(KrMC_pmaps_filename):

--- a/invisible_cities/io/pmaps_io_test.py
+++ b/invisible_cities/io/pmaps_io_test.py
@@ -17,8 +17,12 @@ from ..core.testing_utils import assert_dataframes_equal
 from ..core.testing_utils import exactly
 from ..evm .pmaps         import S1
 from ..evm .pmaps         import S2
+from ..evm .pmaps         import PMap
 from ..evm .pmaps_test    import pmaps    as pmap_gen
 from .                    import pmaps_io as pmpio
+
+from typing import Generator
+from typing import Mapping
 
 
 pmaps_data = namedtuple("pmaps_data", """evt_numbers      peak_numbers
@@ -201,6 +205,18 @@ def test_load_pmaps_as_df_lazy(KrMC_pmaps_filename, KrMC_pmaps_dfs):
         assert_dataframes_equal(df_lazy, df_eager)
 
 
+def test_load_pmaps_as_df_eager_lazy(KrMC_pmaps_filename):
+    eager = pmpio.load_pmaps_as_df(KrMC_pmaps_filename, lazy=False)
+    lazy  = pmpio.load_pmaps_as_df(KrMC_pmaps_filename, lazy=True )
+    assert len(eager) == 5
+    assert all(isinstance(item, pd.DataFrame) for item in eager)
+
+    assert isinstance(lazy, Generator)
+    element = next(lazy)
+    assert len(element) == 5
+    assert all(isinstance(item, pd.DataFrame) for item in element)
+
+
 def test_load_pmaps_as_df_eager_without_ipmt(KrMC_pmaps_without_ipmt_filename, KrMC_pmaps_without_ipmt_dfs):
     true_dfs = KrMC_pmaps_without_ipmt_dfs
     read_dfs = pmpio.load_pmaps_as_df_eager(KrMC_pmaps_without_ipmt_filename)
@@ -247,6 +263,20 @@ def test_load_pmaps_lazy(KrMC_pmaps_filename):
     for evt, pmap_lazy in pmaps_lazy.items():
         assert evt in pmaps_eager
         assert_PMap_equality(pmap_lazy, pmaps_eager[evt])
+
+
+def test_load_pmaps_eager_lazy(KrMC_pmaps_filename):
+    eager = pmpio.load_pmaps(KrMC_pmaps_filename, lazy=False)
+    lazy  = pmpio.load_pmaps(KrMC_pmaps_filename, lazy=True )
+
+    assert isinstance(eager, Mapping)
+    element = next(iter(eager.values()))
+    assert isinstance(element, PMap)
+
+    assert isinstance(lazy, Generator)
+    element = next(lazy)
+    assert len(element) == 2 # event, pmap
+    assert isinstance(element[1], PMap)
 
 
 @mark.parametrize("signal_type", (S1, S2))

--- a/invisible_cities/io/pmaps_io_test.py
+++ b/invisible_cities/io/pmaps_io_test.py
@@ -312,6 +312,7 @@ def test_load_pmaps_as_df(KrMC_pmaps_filename):
     assert all(isinstance(item, pd.DataFrame) for item in element)
 
 
+@mark.skip(reason="Deprecated feature. Plus this test makes no sense. Compares the output with itself.")
 def test_load_pmaps_as_df_eager_without_ipmt(KrMC_pmaps_without_ipmt_filename, KrMC_pmaps_without_ipmt_dfs):
     true_dfs = KrMC_pmaps_without_ipmt_dfs
     read_dfs = pmpio.load_pmaps_as_df_eager(KrMC_pmaps_without_ipmt_filename)

--- a/invisible_cities/io/pmaps_io_test.py
+++ b/invisible_cities/io/pmaps_io_test.py
@@ -299,7 +299,8 @@ def test_load_pmaps_as_df_lazy(KrMC_pmaps_filename, KrMC_pmaps_dfs):
         assert_dataframes_equal(df_lazy, df_eager)
 
 
-def test_load_pmaps_as_df_eager_lazy(KrMC_pmaps_filename):
+def test_load_pmaps_as_df(KrMC_pmaps_filename):
+    """Ensure the output of the function is the expected one"""
     eager = pmpio.load_pmaps_as_df(KrMC_pmaps_filename, lazy=False)
     lazy  = pmpio.load_pmaps_as_df(KrMC_pmaps_filename, lazy=True )
     assert len(eager) == 5
@@ -348,7 +349,8 @@ def test_load_pmaps_lazy(KrMC_pmaps_filename):
         assert_PMap_equality(pmap_lazy, pmaps_eager[evt])
 
 
-def test_load_pmaps_eager_lazy(KrMC_pmaps_filename):
+def test_load_pmaps(KrMC_pmaps_filename):
+    """Ensure the output of the function is the expected one"""
     eager = pmpio.load_pmaps(KrMC_pmaps_filename, lazy=False)
     lazy  = pmpio.load_pmaps(KrMC_pmaps_filename, lazy=True )
 

--- a/invisible_cities/io/pmaps_io_test.py
+++ b/invisible_cities/io/pmaps_io_test.py
@@ -323,7 +323,7 @@ def test_load_pmaps_as_df_lazy(KrMC_pmaps_filename):
 @mark.parametrize("skip" , (0, 1, 2, 3))
 @mark.parametrize("nread", (0, 1, 2, 3))
 def test_load_pmaps_as_df_lazy_subset(KrMC_pmaps_filename, skip, nread):
-    """Ensure the lazy and non-lazy versions provide the same result"""
+    """Ensure the reader provides the expected number of events"""
     # concatenate all dfs from the same node
     dfs_lazy  = pmpio.load_pmaps_as_df_lazy (KrMC_pmaps_filename, skip, nread)
     dfs_lazy = [pd.concat(node_dfs, ignore_index=True) for node_dfs in zip(*dfs_lazy)]
@@ -386,7 +386,7 @@ def test_load_pmaps_lazy(KrMC_pmaps_filename):
 @mark.parametrize("skip" , (0, 1, 2, 3))
 @mark.parametrize("nread", (0, 1, 2, 3))
 def test_load_pmaps_lazy_subset(KrMC_pmaps_filename, skip, nread):
-    """Ensure the lazy and non-lazy versions provide the same result"""
+    """Ensure the reader provides the expected number of events"""
     # concatenate all dfs from the same node
     pmaps_lazy  = pmpio.load_pmaps_lazy(KrMC_pmaps_filename, skip, nread)
     pmaps_lazy = dict(pmaps_lazy)

--- a/invisible_cities/io/pmaps_io_test.py
+++ b/invisible_cities/io/pmaps_io_test.py
@@ -20,6 +20,7 @@ from ..evm .pmaps         import S2
 from ..evm .pmaps         import PMap
 from ..evm .pmaps_test    import pmaps    as pmap_gen
 from .                    import pmaps_io as pmpio
+from .                    import run_and_event_io as reio
 
 from typing import Generator
 from typing import Mapping
@@ -242,6 +243,10 @@ def test_load_pmaps_eager(output_tmpdir, data):
     with tb.open_file(pmap_filename, "w") as output_file:
         write = pmpio.pmap_writer(output_file)
         list(map(write, true_pmaps, event_numbers))
+
+        write = reio.run_and_event_writer(output_file)
+        for event_number in event_numbers:
+            write(0, event_number, 0)
 
     read_pmaps = pmpio.load_pmaps_eager(pmap_filename)
 


### PR DESCRIPTION
Cities that read `PMap`s consume a large amount of RAM because all events are kept in memory simultaneously. This PR adds new functions to read the `PMap`s on an event-by-event basis, in a lazy manner. The old readers have been renamed using the suffix `_eager` for clarity, while the new ones contain the suffix `_lazy`. The names of the old readers have been reused in the interfacing functions that allow the user to switch between the lazy and the eager readers. The readers' default to the eager mode for backward compatibility. However, the cities will read them lazily to avoid large memory allocations.

Moreover, the lazy versions contain two arguments to read a subset of all pmaps. These are `skip`, and `n`, which will skip the first `skip` events and read the following `n` events.

This PR has been tested in production mode.

