### PR TITLE
Silence warnings produced in test suite

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -24,12 +24,25 @@ jobs:
     # - name: Fix Conda permissions on macOS
     #   run: sudo chown -R $UID $CONDA
     #   if: runner.os == 'macOS'
+
     - name: Install IC
       run: |
         source $CONDA/etc/profile.d/conda.sh
         source manage.sh work_in_python_version_no_tests ${{ matrix.python-version }}
+
+
     - name: Run tests
       run: |
+        set -o pipefail # necessary for test failure to propagate to `tee`
         source $CONDA/etc/profile.d/conda.sh
         source manage.sh work_in_python_version_no_tests ${{ matrix.python-version }}
-        PYTEST_ADDOPTS=--color=yes HYPOTHESIS_PROFILE=travis-ci bash manage.sh run_tests_par
+        PYTEST_ADDOPTS=--color=yes HYPOTHESIS_PROFILE=travis-ci bash manage.sh run_tests_par | tee pytest_output
+
+    - name: Warning summary
+      run: |
+        ./scripts/check_warnings pytest_output | tee warnings
+        if [ -s warnings ]; then
+            echo "::warning ::There are warnings raised in the test suite"
+        else
+            echo "No warnings were raised."
+        fi

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -38,6 +38,50 @@ jobs:
         source manage.sh work_in_python_version_no_tests ${{ matrix.python-version }}
         PYTEST_ADDOPTS=--color=yes HYPOTHESIS_PROFILE=travis-ci bash manage.sh run_tests_par | tee pytest_output
 
+    - name: Test warning-catching script
+      run: |
+        source $CONDA/etc/profile.d/conda.sh
+        source manage.sh work_in_python_version_no_tests ${{ matrix.python-version }}
+
+        # write dummy tests
+        cat > dummy.py <<EOF
+        from warnings import warn
+        def test_warn():
+          warn("bla bla bla", UserWarning)
+        def test_pass():
+          pass
+        EOF
+
+        echo "###################################"
+        cat dummy.py
+        echo "###################################"
+
+        pytest dummy.py -k "warn" > warn
+        pytest dummy.py -k "pass" > pass
+
+        echo "-------- output with warn ---------"
+        ./scripts/check_warnings warn | tee output_warn
+        echo "-----------------------------------"
+        if [ ! -s output_warn ]; then
+            msg="The `check_warnings` script has not detected existing warnings."
+            echo $msg
+            echo "::warning ::$msg"
+        else
+            echo "The warning was found!"
+        fi
+
+        echo "------- output without warn -------"
+        ./scripts/check_warnings pass | tee output_pass
+        echo "-----------------------------------"
+        if [ -s output_pass ]; then
+            msg="The `check_warnings` script detected non-existing warnings."
+            echo $msg
+            echo "::warning ::$msg"
+        else
+            echo "No warnings found (as expected)!"
+        fi
+
+
     - name: Warning summary
       run: |
         ./scripts/check_warnings pytest_output | tee warnings

--- a/invisible_cities/calib/calib_sensors_functions.py
+++ b/invisible_cities/calib/calib_sensors_functions.py
@@ -19,7 +19,7 @@ def scipy_mode(x, axis=0):
     Scipy implementation of the mode (runs very slow).
     Returns a column vector.
     """
-    m, c = stats.mode(x, axis=axis)
+    m, c = stats.mode(x, axis=axis, keepdims=True)
     return m
 
 

--- a/invisible_cities/cities/beersheba_test.py
+++ b/invisible_cities/cities/beersheba_test.py
@@ -56,6 +56,8 @@ def test_distribute_energy(ICDATADIR):
     assert np.isclose (true_dst1.E.sum(), true_dst2.E.sum())
 
 
+@ignore_warning.no_config_group
+@ignore_warning.str_length
 @ignore_warning.not_kdst
 def test_beersheba_contains_all_tables(beersheba_config, config_tmpdir):
     path_out = os.path.join(config_tmpdir, "beersheba_contains_all_tables.h5")
@@ -73,6 +75,8 @@ def test_beersheba_contains_all_tables(beersheba_config, config_tmpdir):
             assert node in h5out.root
 
 
+@ignore_warning.no_config_group
+@ignore_warning.str_length
 @ignore_warning.not_kdst
 @mark.parametrize("deco", DeconvolutionMode)
 @mark.slow
@@ -104,6 +108,8 @@ def test_beersheba_exact_result( deco
                 assert_tables_equality(got, expected, rtol=1e-6)
 
 
+@ignore_warning.no_config_group
+@ignore_warning.str_length
 @ignore_warning.not_kdst
 @mark.slow
 def test_beersheba_exact_result_with_satkill( ICDATADIR
@@ -146,6 +152,8 @@ def test_beersheba_only_ndim_2_is_valid(beersheba_config, ndim, config_tmpdir):
         beersheba(**beersheba_config)
 
 
+@ignore_warning.no_config_group
+@ignore_warning.str_length
 def test_beersheba_copies_kdst(beersheba_config, Th228_hits, config_tmpdir):
     path_out = os.path.join(config_tmpdir, "beersheba_copies_kdst.h5")
     beersheba_config.update(dict( file_out    = path_out
@@ -158,6 +166,8 @@ def test_beersheba_copies_kdst(beersheba_config, Th228_hits, config_tmpdir):
     assert expected_events == got_events
 
 
+@ignore_warning.no_config_group
+@ignore_warning.str_length
 def test_beersheba_thresholds_hits(beersheba_config, config_tmpdir):
     path_out  = os.path.join(config_tmpdir, "beersheba_thresholds_hits.h5")
     threshold = 15 * units.pes
@@ -171,6 +181,8 @@ def test_beersheba_thresholds_hits(beersheba_config, config_tmpdir):
     assert np.all(df.Q >= threshold)
 
 
+@ignore_warning.no_config_group
+@ignore_warning.str_length
 def test_beersheba_filters_empty_dfs(beersheba_config, config_tmpdir):
     path_out = os.path.join(config_tmpdir, "beersheba_filters_empty_dfs.h5")
     q_cut    = 1e8 * units.pes
@@ -191,6 +203,7 @@ def test_beersheba_filters_empty_dfs(beersheba_config, config_tmpdir):
 
 @ignore_warning.no_config_group
 @ignore_warning.str_length
+@ignore_warning.not_kdst
 @ignore_warning.no_hits
 def test_beersheba_does_not_crash_with_no_hits(beersheba_config, Th228_hits_missing, config_tmpdir):
     path_out  = os.path.join(config_tmpdir, "beersheba_does_not_crash_with_no_hits.h5")

--- a/invisible_cities/cities/beersheba_test.py
+++ b/invisible_cities/cities/beersheba_test.py
@@ -14,6 +14,7 @@ from .  beersheba          import create_deconvolution_df
 from .  beersheba          import distribute_energy
 from .. core.testing_utils import assert_dataframes_close
 from .. core.testing_utils import assert_tables_equality
+from .. core.testing_utils import ignore_warning
 from .. types.symbols      import HitEnergy
 from .. types.symbols      import DeconvolutionMode
 from .. types.symbols      import CutType
@@ -55,7 +56,7 @@ def test_distribute_energy(ICDATADIR):
     assert np.isclose (true_dst1.E.sum(), true_dst2.E.sum())
 
 
-@mark.filterwarnings("ignore:.*not of kdst type.*:UserWarning")
+@ignore_warning.not_kdst
 def test_beersheba_contains_all_tables(beersheba_config, config_tmpdir):
     path_out = os.path.join(config_tmpdir, "beersheba_contains_all_tables.h5")
     beersheba_config.update(dict( file_out    = path_out
@@ -72,7 +73,7 @@ def test_beersheba_contains_all_tables(beersheba_config, config_tmpdir):
             assert node in h5out.root
 
 
-@mark.filterwarnings("ignore:.*not of kdst type.*:UserWarning")
+@ignore_warning.not_kdst
 @mark.parametrize("deco", DeconvolutionMode)
 @mark.slow
 def test_beersheba_exact_result( deco
@@ -103,7 +104,7 @@ def test_beersheba_exact_result( deco
                 assert_tables_equality(got, expected, rtol=1e-6)
 
 
-@mark.filterwarnings("ignore:.*not of kdst type.*:UserWarning")
+@ignore_warning.not_kdst
 @mark.slow
 def test_beersheba_exact_result_with_satkill( ICDATADIR
                                             , beersheba_config
@@ -188,9 +189,9 @@ def test_beersheba_filters_empty_dfs(beersheba_config, config_tmpdir):
     assert df.passed.tolist() == [False]
 
 
-@mark.filterwarnings("ignore:Event .* does not contain hits")
-@mark.filterwarnings("ignore:dataframe contains strings longer than allowed")
-@mark.filterwarnings("ignore:Input file does not contain /config group")
+@ignore_warning.no_config_group
+@ignore_warning.str_length
+@ignore_warning.no_hits
 def test_beersheba_does_not_crash_with_no_hits(beersheba_config, Th228_hits_missing, config_tmpdir):
     path_out  = os.path.join(config_tmpdir, "beersheba_does_not_crash_with_no_hits.h5")
     beersheba_config.update(dict( files_in    = Th228_hits_missing

--- a/invisible_cities/cities/berenice_test.py
+++ b/invisible_cities/cities/berenice_test.py
@@ -8,9 +8,11 @@ from numpy.testing import assert_array_equal
 from .  berenice           import berenice
 from .. core.configure     import configure
 from .. core.testing_utils import assert_tables_equality
+from .. core.testing_utils import ignore_warning
 from .. types.symbols      import all_events
 
 
+@ignore_warning.no_config_group
 def test_berenice_sipmdarkcurrent(config_tmpdir, ICDATADIR):
     PATH_IN   = os.path.join(ICDATADIR    , 'sipmdarkcurrentdata.h5' )
     PATH_OUT  = os.path.join(config_tmpdir, 'sipmdarkcurrentdata_HIST.h5')
@@ -41,6 +43,7 @@ def test_berenice_sipmdarkcurrent(config_tmpdir, ICDATADIR):
         assert np.all(ch_in_sipm == ch_out_sipm)
 
 
+@ignore_warning.no_config_group
 def test_berenice_exact_result(ICDATADIR, output_tmpdir):
     file_in     = os.path.join(ICDATADIR    ,             "sipmdarkcurrentdata.h5")
     file_out    = os.path.join(output_tmpdir,            "exact_result_berenice.h5")

--- a/invisible_cities/cities/buffy_test.py
+++ b/invisible_cities/cities/buffy_test.py
@@ -12,12 +12,14 @@ from pytest import param
 from .. core                   import           system_of_units as units
 from .. core    .configure     import                 configure
 from .. core    .testing_utils import    assert_tables_equality
+from .. core    .testing_utils import            ignore_warning
 from .. database               import                   load_db
 from .. io      .mcinfo_io     import load_mcsensor_response_df
 
 from .  buffy import buffy
 
 
+@ignore_warning.no_config_group
 def test_buffy_kr(config_tmpdir, full_sim_file):
     file_in  = full_sim_file
     file_out = os.path.join(config_tmpdir, 'Kr_fullsim.buffers.h5')
@@ -156,6 +158,7 @@ def test_buffy_empty_file(config_tmpdir, ICDATADIR, fn_first, fn_second):
         buffy(**conf)
 
 
+@ignore_warning.no_config_group
 def test_buffy_exact_result(config_tmpdir, ICDATADIR):
     np.random.seed(27)
 
@@ -182,6 +185,7 @@ def test_buffy_exact_result(config_tmpdir, ICDATADIR):
                 assert_tables_equality(got, expected)
 
 
+@ignore_warning.no_config_group
 def test_buffy_splits_event(config_tmpdir, ICDATADIR):
     file_in  = os.path.join(ICDATADIR                              ,
                             'nexus_new_kr83m_full.newformat.sim.h5')

--- a/invisible_cities/cities/cities_test.py
+++ b/invisible_cities/cities/cities_test.py
@@ -117,6 +117,7 @@ def test_city_output_contains_configuration(config_tmpdir, city):
         assert len(table[:]) > 0
 
 
+@ignore_warning.no_config_group
 def test_cities_carry_on_configuration_from_previous_ones(ICDATADIR, config_tmpdir):
     rwf_file   = os.path.join(    ICDATADIR, "electrons_40keV_ACTIVE_10evts_RWF.h5")
     pmaps_file = os.path.join(config_tmpdir, f"test_cities_carry_on_configuration_pmaps.h5")

--- a/invisible_cities/cities/cities_test.py
+++ b/invisible_cities/cities/cities_test.py
@@ -8,7 +8,9 @@ import tables as tb
 from pytest import mark
 from pytest import raises
 
-from .. core.configure      import configure
+from .. core.configure     import configure
+from .. core.testing_utils import ignore_warning
+
 
 online_cities  = "irene dorothea sophronia esmeralda beersheba isaura".split()
 mc_cities      = "buffy detsim diomira hypathia".split()
@@ -17,7 +19,10 @@ all_cities     = sorted(online_cities + mc_cities + other_cities)
 all_cities_with_event_range = sorted(set(all_cities).difference(set(["eutropia"])))
 
 
-@mark.filterwarnings("ignore::UserWarning")
+@ignore_warning.no_config_group
+@ignore_warning.no_mc_tables
+@ignore_warning.not_kdst
+@ignore_warning.str_length
 @mark.parametrize("city", online_cities)
 def test_city_empty_input_file(config_tmpdir, ICDATADIR, city):
     # All cities run in the online reconstruction chain must run on an
@@ -37,7 +42,9 @@ def test_city_empty_input_file(config_tmpdir, ICDATADIR, city):
     city_function(**conf)
 
 
-@mark.filterwarnings("ignore::UserWarning")
+@ignore_warning.no_config_group
+@ignore_warning.not_kdst
+@ignore_warning.str_length
 @mark.parametrize("city", all_cities_with_event_range)
 def test_city_null_event_range(config_tmpdir, ICDATADIR, city):
     # All cities must run with event_range = 0
@@ -54,8 +61,9 @@ def test_city_null_event_range(config_tmpdir, ICDATADIR, city):
     city_function(**conf)
 
 
-
-@mark.filterwarnings("ignore::UserWarning")
+@ignore_warning.no_config_group
+@ignore_warning.not_kdst
+@ignore_warning.str_length
 @mark.parametrize("city", all_cities)
 def test_city_output_file_is_compressed(config_tmpdir, ICDATADIR, city):
     file_out    = os.path.join(config_tmpdir, f"{city}_compression.h5")
@@ -85,7 +93,9 @@ def test_city_output_file_is_compressed(config_tmpdir, ICDATADIR, city):
     assert checked_nodes > 2
 
 
-@mark.filterwarnings("ignore::UserWarning")
+@ignore_warning.no_config_group
+@ignore_warning.not_kdst
+@ignore_warning.str_length
 @mark.parametrize("city", all_cities)
 def test_city_output_contains_configuration(config_tmpdir, city):
     file_out    = os.path.join(config_tmpdir, f"{city}_configuration.h5")
@@ -137,7 +147,6 @@ def test_cities_carry_on_configuration_from_previous_ones(ICDATADIR, config_tmpd
             assert len(table[:]) > 0
 
 
-@mark.filterwarnings("ignore::UserWarning")
 @mark.parametrize("city", all_cities)
 def test_city_missing_detector_db(city):
     # use default config file

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -16,6 +16,7 @@ from .. core.exceptions    import InvalidInputFileStructure
 from .. core.exceptions    import          SensorIDMismatch
 from .. core.exceptions    import              NoInputFiles
 from .. core.testing_utils import    assert_tables_equality
+from .. core.testing_utils import            ignore_warning
 from .. core               import system_of_units as units
 from .. evm.event_model    import Cluster
 from .. evm.event_model    import Hit
@@ -120,7 +121,7 @@ def write_config_file(filename, **kwargs):
                      , ["electrons_511keV_z250_RWF.h5" , "electrons_1250keV_z250_RWF.h5", "electrons_2500keV_z250_RWF.h5"] )
                    )
                  )
-@mark.filterwarnings("ignore:files_in contains repeated values")
+@ignore_warning.repeated_files
 def test_city_files_in(case_, files_in, expected, config_tmpdir, ICDATADIR):
     """
     Check that all possible files_in inputs are handled properly:
@@ -299,7 +300,7 @@ def test_hits_and_kdst_from_files(ICDATADIR):
     assert type(output['kdst'])     == pd.DataFrame
 
 
-@mark.filterwarnings("ignore:Event .* does not contain hits")
+@ignore_warning.no_hits
 def test_hits_and_kdst_from_files_missing_hits(Th228_hits_missing, config_tmpdir):
     n_events_true = len(pd.read_hdf(Th228_hits_missing, "/Run/events"))
 
@@ -407,8 +408,7 @@ def test_create_timestamp_greater_with_greater_eventnumber():
     assert     timestamp_1(evt_no_1)  <  timestamp_2(evt_no_2)
 
 
-@mark.filterwarnings("ignore:Zero rate"    )
-@mark.filterwarnings("ignore:Negative rate")
+@ignore_warning.unphysical_rate
 def test_create_timestamp_physical_rate():
     """
     Check the rate is always physical.
@@ -427,7 +427,7 @@ def test_create_timestamp_physical_rate():
 
 
 
-@mark.filterwarnings("ignore:`max_time` shorter than `buffer_length`")
+@ignore_warning.max_time_short
 def test_check_max_time_eg_buffer_length():
     """
     Check if `max_time` is always equal or greater

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -121,6 +121,7 @@ def write_config_file(filename, **kwargs):
                      , ["electrons_511keV_z250_RWF.h5" , "electrons_1250keV_z250_RWF.h5", "electrons_2500keV_z250_RWF.h5"] )
                    )
                  )
+@ignore_warning.no_config_group
 @ignore_warning.repeated_files
 def test_city_files_in(case_, files_in, expected, config_tmpdir, ICDATADIR):
     """
@@ -163,6 +164,7 @@ def test_city_files_in(case_, files_in, expected, config_tmpdir, ICDATADIR):
     assert sorted(result) == sorted(expected)
 
 
+@ignore_warning.no_config_group
 @mark.parametrize("order", ((0,1), (1,0)))
 def test_city_keeps_input_file_ordering(ICDATADIR, config_tmpdir, order):
     files_in = [ os.path.join(ICDATADIR, "electrons_511keV_z250_RWF.h5")

--- a/invisible_cities/cities/detsim_test.py
+++ b/invisible_cities/cities/detsim_test.py
@@ -10,8 +10,9 @@ from .. core.configure import configure
 from .. io.dst_io      import load_dst
 from .. types.symbols  import all_events
 from .. core.testing_utils import assert_tables_equality
+from .. core.testing_utils import ignore_warning
 
-
+@ignore_warning.no_config_group
 def test_detsim_contains_all_tables(ICDATADIR, output_tmpdir):
 
     PATH_IN  = os.path.join(ICDATADIR    , "nexus_new_kr83m_fast.newformat.sim.h5")
@@ -40,6 +41,8 @@ def test_detsim_contains_all_tables(ICDATADIR, output_tmpdir):
         assert sipmrd.shape == (1, 1792, n_sipm)
 
 
+@ignore_warning.no_config_group
+@ignore_warning.delayed_hits
 def test_detsim_filter_active_hits(ICDATADIR, output_tmpdir):
     # the first event in test file labels are set to NO_ACTIVE
     PATH_IN  = os.path.join(ICDATADIR    , "nexus_new_kr83m_fast.newformat.sim.noactive.h5")
@@ -58,6 +61,8 @@ def test_detsim_filter_active_hits(ICDATADIR, output_tmpdir):
         np.testing.assert_array_equal(filters["passed"], [False, True])
 
 
+@ignore_warning.no_config_group
+@ignore_warning.delayed_hits
 def test_detsim_filter_dark_events(ICDATADIR, output_tmpdir):
     # this file contains delayed hits that are filtered out
     # leaving a very low energy hit that does not produce electrons
@@ -80,6 +85,7 @@ def test_detsim_filter_dark_events(ICDATADIR, output_tmpdir):
         np.testing.assert_array_equal(filters["passed"], [False])
 
 
+@ignore_warning.no_config_group
 def test_detsim_filter_empty_waveforms(ICDATADIR, output_tmpdir):
     # the first event radius is slighty above NEW active radius of 208.0 mm
     PATH_IN  = os.path.join(ICDATADIR, "nexus_new_kr83m_fast.newformat.sim.emptywfs.h5")
@@ -101,6 +107,7 @@ def test_detsim_filter_empty_waveforms(ICDATADIR, output_tmpdir):
         np.testing.assert_array_equal(filters["passed"], [False, True])
 
 
+@ignore_warning.no_config_group
 def test_detsim_empty_input_file(ICDATADIR, output_tmpdir):
 
     PATH_IN  = os.path.join(ICDATADIR    , "empty_mcfile.h5")
@@ -115,6 +122,7 @@ def test_detsim_empty_input_file(ICDATADIR, output_tmpdir):
     assert result.evtnum_list == []
 
 
+@ignore_warning.no_config_group
 def test_detsim_exact(ICDATADIR, output_tmpdir):
 
     PATH_IN   = os.path.join(ICDATADIR    , "nexus_new_kr83m_fast.newformat.sim.h5")
@@ -149,6 +157,7 @@ def test_detsim_exact(ICDATADIR, output_tmpdir):
                 assert_tables_equality(got, expected)
 
 
+@ignore_warning.no_config_group
 def test_detsim_exact_time_translation(ICDATADIR, output_tmpdir):
 
     PATH_IN   = os.path.join(ICDATADIR    , "nexus_new_kr83m_fast.newformat.sim.h5")
@@ -190,6 +199,7 @@ def test_detsim_exact_time_translation(ICDATADIR, output_tmpdir):
                 assert_tables_equality(got, expected)
 
 
+@ignore_warning.no_config_group
 def test_detsim_buffer_times(ICDATADIR, output_tmpdir):
     """This test checks that the signal is properly placed in the buffer.
     In particular:
@@ -263,6 +273,7 @@ def test_detsim_buffer_times(ICDATADIR, output_tmpdir):
     assert tend   == np.floor(s2_tmax / buffer_params["sipm_width"]) * buffer_params["sipm_width"]
 
 
+@ignore_warning.no_config_group
 def test_detsim_hits_without_strings(ICDATADIR, output_tmpdir):
     PATH_IN  = os.path.join(ICDATADIR    , "nexus_next100_nostrings.h5")
     PATH_OUT = os.path.join(output_tmpdir, "detsim_nostrings.h5")

--- a/invisible_cities/cities/diomira_test.py
+++ b/invisible_cities/cities/diomira_test.py
@@ -9,6 +9,7 @@ from pytest import raises
 from .. core.configure     import                 configure
 from .. core.testing_utils import   assert_dataframes_close
 from .. core.testing_utils import    assert_tables_equality
+from .. core.testing_utils import            ignore_warning
 from .. database           import                   load_db
 
 from .. io  .mcinfo_io     import get_event_numbers_in_file
@@ -46,6 +47,7 @@ def test_diomira_identify_bug(ICDATADIR):
             assert np.sum(pmtwf[i]) == 0
 
 
+@ignore_warning.no_config_group
 @mark.slow
 def test_diomira_copy_mc_and_offset(ICDATADIR, config_tmpdir):
     PATH_IN  = os.path.join(ICDATADIR    , 'electrons_40keV_z250_MCRD.h5')
@@ -82,6 +84,7 @@ def test_diomira_copy_mc_and_offset(ICDATADIR, config_tmpdir):
                                     hits_out                  )
 
 
+@ignore_warning.no_config_group
 @mark.slow
 def test_diomira_mismatch_between_input_and_database(ICDATADIR, output_tmpdir):
     file_in  = os.path.join(ICDATADIR    , 'electrons_40keV_z250_MCRD.h5')
@@ -125,6 +128,8 @@ def test_diomira_trigger_on_masked_pmt_raises_ValueError(ICDATADIR, output_tmpdi
     with raises(ValueError):
         diomira(**conf)
 
+
+@ignore_warning.no_config_group
 def test_diomira_read_multiple_files(ICDATADIR, output_tmpdir):
     file_in     = os.path.join(ICDATADIR                                       ,
                                "Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts*.MCRD.h5")
@@ -164,6 +169,7 @@ def test_diomira_read_multiple_files(ICDATADIR, output_tmpdir):
     assert_dataframes_close(all_particle_in, particles_out)
 
 
+@ignore_warning.no_config_group
 def test_diomira_exact_result(ICDATADIR, output_tmpdir):
     file_in     = os.path.join(ICDATADIR                                      ,
                                "Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts.MCRD.h5")
@@ -197,6 +203,7 @@ def test_diomira_exact_result(ICDATADIR, output_tmpdir):
                 assert_tables_equality(got, expected)
 
 
+@ignore_warning.no_config_group
 def test_diomira_can_fix_random_seed(output_tmpdir):
     file_out    = os.path.join(output_tmpdir, "exact_result_diomira.h5")
 
@@ -227,7 +234,7 @@ def test_diomira_reproduces_singlepe(ICDATADIR, output_tmpdir):
     pmt_gain = load_db.DataPMT('new', run_no).adc_to_pes.values
     with tb.open_file(file_out) as h5saved:
         pmt_sum_adc = np.sum(h5saved.root.RD.pmtblr, axis=2)
-        
+
         bins        = np.arange(-50, 50, 0.5)
         bin_centres = np.repeat(shift_to_bin_centers(bins)[np.newaxis, :],
                                 len(pmt_gain), 0)

--- a/invisible_cities/cities/dorothea_test.py
+++ b/invisible_cities/cities/dorothea_test.py
@@ -8,6 +8,7 @@ from pytest                  import mark
 from .. io.dst_io            import load_dst
 from .. core.testing_utils   import assert_dataframes_close
 from .. core.testing_utils   import assert_tables_equality
+from .. core.testing_utils   import ignore_warning
 from .. core.configure       import configure
 from .. core.system_of_units import pes, mm, mus, ns
 from .. types.symbols        import all_events
@@ -15,6 +16,7 @@ from .. types.symbols        import all_events
 from .  dorothea import dorothea
 
 
+@ignore_warning.no_config_group
 def test_dorothea_KrMC(config_tmpdir, KrMC_pmaps_filename, KrMC_kdst):
     # NB: avoid taking defaults for PATH_IN and PATH_OUT
     # since they are in general test-specific
@@ -48,6 +50,7 @@ def test_dorothea_KrMC(config_tmpdir, KrMC_pmaps_filename, KrMC_kdst):
     assert_dataframes_close(dst, df_true, check_dtype=False, rtol=1e-2)
 
 
+@ignore_warning.no_config_group
 def test_dorothea_filter_events(config_tmpdir, Kr_pmaps_run4628_filename):
     PATH_IN =  Kr_pmaps_run4628_filename
 
@@ -103,6 +106,7 @@ def test_dorothea_filter_events(config_tmpdir, Kr_pmaps_run4628_filename):
     assert np.all(dst.s2_peak.values == s2_peak_pass)
 
 
+@ignore_warning.no_config_group
 @mark.parametrize("include_mc", (False, True))
 def test_dorothea_contains_all_tables(ICDATADIR, output_tmpdir, include_mc):
 
@@ -132,6 +136,7 @@ def test_dorothea_contains_all_tables(ICDATADIR, output_tmpdir, include_mc):
         assert not ("MC/particles"    in h5out.root) ^ include_mc
 
 
+@ignore_warning.no_config_group
 @mark.parametrize("include_mc", (False, True))
 def test_dorothea_exact_result(ICDATADIR, output_tmpdir, include_mc):
     tables = ("DST/Events", "Filters/s12_selector", "Run/events", "Run/runInfo")
@@ -159,6 +164,7 @@ def test_dorothea_exact_result(ICDATADIR, output_tmpdir, include_mc):
                 assert_tables_equality(got, expected)
 
 
+@ignore_warning.no_config_group
 def test_dorothea_empty_input_file(config_tmpdir, ICDATADIR):
     # Dorothea must run on an empty file without raising any exception
     # The input file has the complete structure of a PMAP but no events.

--- a/invisible_cities/cities/esmeralda_test.py
+++ b/invisible_cities/cities/esmeralda_test.py
@@ -12,6 +12,7 @@ from .. core.testing_utils   import assert_tables_equality
 from .. core.testing_utils   import ignore_warning
 
 
+@ignore_warning.no_config_group
 def test_esmeralda_runs(esmeralda_config, config_tmpdir):
     path_out = os.path.join(config_tmpdir, 'esmeralda_runs.h5')
     nevt_req = 1
@@ -22,6 +23,7 @@ def test_esmeralda_runs(esmeralda_config, config_tmpdir):
     assert cnt.events_in == nevt_req
 
 
+@ignore_warning.no_config_group
 def test_esmeralda_contains_all_tables(esmeralda_config, config_tmpdir):
     path_out = os.path.join(config_tmpdir, 'esmeralda_contains_all_tables.h5')
     nevt_req = 1
@@ -43,6 +45,7 @@ def test_esmeralda_contains_all_tables(esmeralda_config, config_tmpdir):
             assert node in h5out.root
 
 
+@ignore_warning.no_config_group
 def test_esmeralda_thresholds_hits(esmeralda_config, config_tmpdir):
     path_out  = os.path.join(config_tmpdir, "esmeralda_thresholds_hits.h5")
     threshold = 50 * units.pes
@@ -56,6 +59,7 @@ def test_esmeralda_thresholds_hits(esmeralda_config, config_tmpdir):
     assert np.all(df.Q >= threshold)
 
 
+@ignore_warning.no_config_group
 def test_esmeralda_drops_external_hits(esmeralda_config, config_tmpdir):
     path_out   = os.path.join(config_tmpdir, "esmeralda_drops_external_hits.h5")
     fiducial_r = 450 * units.mm;
@@ -69,6 +73,7 @@ def test_esmeralda_drops_external_hits(esmeralda_config, config_tmpdir):
     assert np.all(df.X**2 + df.Y**2 <= fiducial_r**2)
 
 
+@ignore_warning.no_config_group
 def test_esmeralda_filters_events_threshold(esmeralda_config, config_tmpdir):
     path_out = os.path.join(config_tmpdir, "esmeralda_filters_events_threshold.h5")
     esmeralda_config.update(dict( file_out    = path_out
@@ -97,6 +102,7 @@ def test_esmeralda_filters_events_threshold(esmeralda_config, config_tmpdir):
     assert  df_events .evt_number.drop_duplicates().tolist() == evt_all
 
 
+@ignore_warning.no_config_group
 def test_esmeralda_exact_result(esmeralda_config, Th228_tracks, config_tmpdir):
     path_out  = os.path.join(config_tmpdir, "esmeralda_exact_result.h5")
     esmeralda_config["file_out"] = path_out
@@ -121,6 +127,7 @@ def test_esmeralda_exact_result(esmeralda_config, Th228_tracks, config_tmpdir):
 
 
 #if the first analyzed events has no overlap in blob buggy esmeralda will cast all overlap energy to integers
+@ignore_warning.no_config_group
 def test_esmeralda_blob_overlap_float_dtype(esmeralda_config, Th228_tracks, config_tmpdir):
     path_out = os.path.join(config_tmpdir, "esmeralda_blob_overlap_float_dtype.h5")
 
@@ -133,6 +140,7 @@ def test_esmeralda_blob_overlap_float_dtype(esmeralda_config, Th228_tracks, conf
     assert tracks.ovlp_blob_energy.dtype == float
 
 
+@ignore_warning.no_config_group
 def test_esmeralda_tracks_have_correct_number_of_hits(esmeralda_config, Th228_tracks, config_tmpdir):
     path_out = os.path.join(config_tmpdir, "esmeralda_summary_gives_correct_number_of_hits.h5")
     nevt_req = 3
@@ -150,6 +158,7 @@ def test_esmeralda_tracks_have_correct_number_of_hits(esmeralda_config, Th228_tr
         assert sum(track.numb_of_hits) == len(ev_phits)
 
 
+@ignore_warning.no_config_group
 def test_esmeralda_all_hits_after_drop_voxels(esmeralda_config, Th228_hits, config_tmpdir):
     path_out   = os.path.join(config_tmpdir, "esmeralda_all_hits_after_drop_voxels.h5")
     nevt_req   = 2
@@ -177,6 +186,7 @@ def test_esmeralda_all_hits_after_drop_voxels(esmeralda_config, Th228_hits, conf
 
 
 #TODO: refactor paolina to include this as a filter
+@ignore_warning.no_config_group
 def test_esmeralda_filters_events_with_too_many_hits(esmeralda_config, Th228_tracks, config_tmpdir):
     path_out  = os.path.join(config_tmpdir, "esmeralda_filters_events_with_too_many_hits.h5")
     nevt_req  = 2

--- a/invisible_cities/cities/esmeralda_test.py
+++ b/invisible_cities/cities/esmeralda_test.py
@@ -9,6 +9,7 @@ from .. core                 import system_of_units as units
 from .. io                   import dst_io      as dio
 from .  esmeralda            import esmeralda
 from .. core.testing_utils   import assert_tables_equality
+from .. core.testing_utils   import ignore_warning
 
 
 def test_esmeralda_runs(esmeralda_config, config_tmpdir):
@@ -204,8 +205,8 @@ def test_esmeralda_filters_events_with_too_many_hits(esmeralda_config, Th228_tra
     assert            filter_output.passed.tolist() == evt_pass
 
 
-@mark.filterwarnings("ignore:Event .* does not contain hits")
-@mark.filterwarnings("ignore:Input file does not contain /config group")
+@ignore_warning.no_hits
+@ignore_warning.no_config_group
 def test_esmeralda_does_not_crash_with_no_hits(esmeralda_config, Th228_hits_missing, config_tmpdir):
     path_out  = os.path.join(config_tmpdir, "esmeralda_does_not_crash_with_no_hits.h5")
     esmeralda_config.update(dict( files_in    = Th228_hits_missing

--- a/invisible_cities/cities/eutropia_test.py
+++ b/invisible_cities/cities/eutropia_test.py
@@ -10,6 +10,7 @@ from .. cities.eutropia        import eutropia
 from .. core  .configure       import configure
 from .. core  .system_of_units import mm
 from .. core  .testing_utils   import assert_tables_equality
+from .. core  .testing_utils   import ignore_warning
 
 
 @fixture(scope="module")
@@ -28,6 +29,7 @@ def fast_psf_config(ICDATADIR):
                )
 
 
+@ignore_warning.no_config_group
 def test_eutropia_contains_tables(fast_psf_config, output_tmpdir):
     output_filename = os.path.join(output_tmpdir, "psf_tables.h5")
     conf = configure('eutropia $ICTDIR/invisible_cities/config/eutropia.conf'.split())
@@ -45,6 +47,7 @@ def test_eutropia_contains_tables(fast_psf_config, output_tmpdir):
         assert "events"  in file.root.Run
 
 
+@ignore_warning.no_config_group
 def test_eutropia_output_types(fast_psf_config, output_tmpdir):
     output_filename = os.path.join(output_tmpdir, "psf_tables.h5")
     conf = configure('eutropia $ICTDIR/invisible_cities/config/eutropia.conf'.split())
@@ -58,6 +61,7 @@ def test_eutropia_output_types(fast_psf_config, output_tmpdir):
     assert np.all(df.dtypes.values == dtypes)
 
 
+@ignore_warning.no_config_group
 def test_eutropia_run_info(fast_psf_config, output_tmpdir):
     output_filename = os.path.join(output_tmpdir, "psf_events.h5")
     conf = configure('eutropia $ICTDIR/invisible_cities/config/eutropia.conf'.split())
@@ -75,6 +79,7 @@ def test_eutropia_run_info(fast_psf_config, output_tmpdir):
                 assert all(got == expected)
 
 
+@ignore_warning.no_config_group
 def test_eutropia_centers(output_tmpdir):
     file_out    = os.path.join(output_tmpdir, "psf_centers.h5")
 
@@ -97,6 +102,7 @@ def test_eutropia_centers(output_tmpdir):
         assert np.in1d(table.col("z"), z_centers).all()
 
 
+@ignore_warning.no_config_group
 def test_eutropia_exact_result(ICDATADIR, output_tmpdir):
     file_out    = os.path.join(output_tmpdir, "exact_result_eutropia.h5")
     true_output = os.path.join(ICDATADIR    , "exact_result_eutropia.h5")

--- a/invisible_cities/cities/hypathia_test.py
+++ b/invisible_cities/cities/hypathia_test.py
@@ -5,10 +5,12 @@ import numpy  as np
 
 from .. core.configure import configure
 from .. core.testing_utils  import assert_tables_equality
+from .. core.testing_utils  import ignore_warning
 
 from . hypathia import hypathia
 
 
+@ignore_warning.no_config_group
 def test_hypathia_exact_result(ICDATADIR, output_tmpdir):
     file_in     = os.path.join(ICDATADIR    ,      "Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts.MCRD.h5")
     file_out    = os.path.join(output_tmpdir,                          "exact_result_hypathia.h5")

--- a/invisible_cities/cities/irene_test.py
+++ b/invisible_cities/cities/irene_test.py
@@ -15,6 +15,7 @@ from .. core.configure      import configure
 from .. core.testing_utils  import exactly
 from .. core.testing_utils  import assert_dataframes_close
 from .. core.testing_utils  import assert_tables_equality
+from .. core.testing_utils  import ignore_warning
 from .. types.ic_types      import minmax
 from .. io.run_and_event_io import read_run_and_event
 from .. evm.ic_containers   import S12Params as S12P
@@ -61,6 +62,7 @@ def unpack_s12params(s12params):
                 s2_lmax         = s2par.length.max)
 
 
+@ignore_warning.no_config_group
 @mark.slow
 @mark.parametrize("thr_sipm_type thr_sipm_value".split(),
                   ((SiPMThreshold.common    , 3.5 ),
@@ -105,6 +107,7 @@ def test_irene_electrons_40keV(config_tmpdir, ICDATADIR, s12params,
             np.testing.assert_array_equal(evts_in, evts_out)
 
 
+@ignore_warning.no_config_group
 @mark.slow
 @mark.serial
 def test_irene_run_2983(config_tmpdir, ICDIR, s12params):
@@ -130,6 +133,7 @@ def test_irene_run_2983(config_tmpdir, ICDIR, s12params):
     assert nrequired == cnt.events_in
 
 
+@ignore_warning.no_config_group
 @mark.slow # not slow itself, but depends on a slow test
 @mark.serial
 def test_irene_runinfo_run_2983(config_tmpdir, ICDATADIR):
@@ -179,6 +183,7 @@ def test_irene_output_file_structure(config_tmpdir):
         assert "runInfo"      in h5out.root.Run
 
 
+@ignore_warning.no_config_group
 def test_empty_events_issue_81(config_tmpdir, ICDATADIR, s12params):
     # NB: explicit PATH_OUT
     PATH_IN  = os.path.join(ICDATADIR    , 'irene_bug_Kr_ACTIVE_7bar_RWF.h5')
@@ -200,6 +205,7 @@ def test_empty_events_issue_81(config_tmpdir, ICDATADIR, s12params):
     assert cnt.  over_thr.n_failed == 1
 
 
+@ignore_warning.no_config_group
 def test_irene_empty_pmap_output(ICDATADIR, output_tmpdir, s12params):
     file_in  = os.path.join(ICDATADIR    , "kr_rwf_0_0_7bar_NEXT_v1_00_05_v0.9.2_20171011_krmc_diomira_3evt.h5")
     file_out = os.path.join(output_tmpdir, "kr_rwf_0_0_7bar_NEXT_v1_00_05_v0.9.2_20171011_pmaps_3evt.h5")
@@ -224,6 +230,7 @@ def test_irene_empty_pmap_output(ICDATADIR, output_tmpdir, s12params):
             assert got == exactly(expected)
 
 
+@ignore_warning.no_config_group
 def test_irene_read_multiple_files(ICDATADIR, output_tmpdir, s12params):
     file_in     = os.path.join(ICDATADIR                                       ,
                                "Tl_v1_00_05_nexus_v5_02_08_7bar_RWF_5evts_*.h5")
@@ -264,6 +271,7 @@ def test_irene_read_multiple_files(ICDATADIR, output_tmpdir, s12params):
     assert_dataframes_close(all_particle_in, particles_out)
 
 
+@ignore_warning.no_config_group
 def test_irene_trigger_type(config_tmpdir, ICDATADIR, s12params):
     PATH_IN  = os.path.join(ICDATADIR    ,       '6229_000_trg_type.h5')
     PATH_OUT = os.path.join(config_tmpdir, 'pmaps_6229_000_trg_type.h5')
@@ -289,6 +297,7 @@ def test_irene_trigger_type(config_tmpdir, ICDATADIR, s12params):
             np.testing.assert_array_equal(trigger_in, trigger_out)
 
 
+@ignore_warning.no_config_group
 def test_irene_trigger_channels(config_tmpdir, ICDATADIR, s12params):
     PATH_IN  = os.path.join(ICDATADIR    ,       '6229_000_trg_channels.h5')
     PATH_OUT = os.path.join(config_tmpdir, 'pmaps_6229_000_trg_channels.h5')
@@ -314,6 +323,7 @@ def test_irene_trigger_channels(config_tmpdir, ICDATADIR, s12params):
             np.testing.assert_array_equal(trigger_in, trigger_out)
 
 
+@ignore_warning.no_config_group
 def test_irene_exact_result(ICDATADIR, output_tmpdir):
     file_in     = os.path.join(ICDATADIR    , "Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts.RWF.h5")
     file_out    = os.path.join(output_tmpdir,                        "exact_result_irene.h5")
@@ -343,6 +353,7 @@ def test_irene_exact_result(ICDATADIR, output_tmpdir):
                 assert_tables_equality(got, expected)
 
 
+@ignore_warning.no_config_group
 def test_irene_filters_empty_pmaps(ICDATADIR, output_tmpdir):
     file_in  = os.path.join(ICDATADIR                                     ,
                             "Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts.RWF.h5")
@@ -395,6 +406,7 @@ def test_irene_empty_input_file(config_tmpdir, ICDATADIR):
 
 
 
+@ignore_warning.no_config_group
 def test_irene_sequential_times(config_tmpdir, ICDATADIR):
 
     PATH_IN  = os.path.join(ICDATADIR    , 'single_evt_nonseqtime_rwf.h5')
@@ -446,6 +458,7 @@ def test_error_when_different_sample_widths(ICDATADIR, config_tmpdir):
     assert str(error.value) == msg
 
 
+@ignore_warning.no_config_group
 def test_irene_other_sample_widths(ICDATADIR, config_tmpdir):
     ## Tests irene works when running with other sample frequencies
     file_in     = os.path.join(ICDATADIR,               'run_2983.h5')

--- a/invisible_cities/cities/isaura_test.py
+++ b/invisible_cities/cities/isaura_test.py
@@ -13,6 +13,7 @@ from .. core.testing_utils   import assert_tables_equality
 from .. core.testing_utils   import ignore_warning
 
 
+@ignore_warning.no_config_group
 @ignore_warning.not_kdst
 def test_isaura_contains_all_tables(ICDATADIR, output_tmpdir):
 
@@ -36,6 +37,7 @@ def test_isaura_contains_all_tables(ICDATADIR, output_tmpdir):
 
 
 
+@ignore_warning.no_config_group
 def test_isaura_empty_input_file(ICDATADIR, output_tmpdir):
 
     PATH_IN  = os.path.join(ICDATADIR    , "empty_file.h5")
@@ -51,6 +53,7 @@ def test_isaura_empty_input_file(ICDATADIR, output_tmpdir):
     assert result.evtnum_list == []
 
 
+@ignore_warning.no_config_group
 @ignore_warning.not_kdst
 def test_isaura_exact(ICDATADIR, output_tmpdir):
 
@@ -81,6 +84,7 @@ def test_isaura_exact(ICDATADIR, output_tmpdir):
                 assert_tables_equality(obtained, expected)
 
 
+@ignore_warning.no_config_group
 @ignore_warning.not_kdst
 def test_isaura_conserves_energy(ICDATADIR, output_tmpdir):
 
@@ -107,6 +111,7 @@ def test_isaura_conserves_energy(ICDATADIR, output_tmpdir):
     np.testing.assert_allclose(dhits_energy, devents_energy)
 
 
+@ignore_warning.no_config_group
 def test_isaura_copy_kdst(ICDATADIR, output_tmpdir):
 
     PATH_IN  = os.path.join(ICDATADIR    , "test_deconv_NEW_v1.2.0_bg.h5")

--- a/invisible_cities/cities/isaura_test.py
+++ b/invisible_cities/cities/isaura_test.py
@@ -10,9 +10,10 @@ from .. io.dst_io      import load_dst
 from .. types.symbols  import all_events
 
 from .. core.testing_utils   import assert_tables_equality
+from .. core.testing_utils   import ignore_warning
 
 
-@mark.filterwarnings("ignore:.*not of kdst type.*:UserWarning")
+@ignore_warning.not_kdst
 def test_isaura_contains_all_tables(ICDATADIR, output_tmpdir):
 
     PATH_IN  = os.path.join(ICDATADIR    , "test_Xe2nu_NEW_exact_deconvolution_joint.NEWMC.h5")
@@ -50,7 +51,7 @@ def test_isaura_empty_input_file(ICDATADIR, output_tmpdir):
     assert result.evtnum_list == []
 
 
-@mark.filterwarnings("ignore:.*not of kdst type.*:UserWarning")
+@ignore_warning.not_kdst
 def test_isaura_exact(ICDATADIR, output_tmpdir):
 
     PATH_IN   = os.path.join(ICDATADIR    , "exact_Kr_deconvolution_with_MC.h5")
@@ -80,7 +81,7 @@ def test_isaura_exact(ICDATADIR, output_tmpdir):
                 assert_tables_equality(obtained, expected)
 
 
-@mark.filterwarnings("ignore:.*not of kdst type.*:UserWarning")
+@ignore_warning.not_kdst
 def test_isaura_conserves_energy(ICDATADIR, output_tmpdir):
 
     PATH_IN  = os.path.join(ICDATADIR    , "exact_Kr_deconvolution_with_MC.h5")

--- a/invisible_cities/cities/isidora_test.py
+++ b/invisible_cities/cities/isidora_test.py
@@ -8,8 +8,10 @@ from pytest import mark
 from .  isidora            import isidora
 from .. core.configure     import configure
 from .. core.testing_utils import assert_tables_equality
+from .. core.testing_utils import ignore_warning
 from .. types.symbols      import all_events
 
+@ignore_warning.no_config_group
 @mark.slow
 def test_isidora_electrons_40keV(config_tmpdir, ICDATADIR):
     # NB: avoid taking defaults for PATH_IN and PATH_OUT
@@ -39,6 +41,7 @@ def test_isidora_electrons_40keV(config_tmpdir, ICDATADIR):
             np.testing.assert_array_equal(evts_in, evts_out)
 
 
+@ignore_warning.no_config_group
 def test_isidora_exact_result(ICDATADIR, output_tmpdir):
     file_in     = os.path.join(ICDATADIR                                     ,
                                "Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts.RWF.h5")

--- a/invisible_cities/cities/penthesilea_test.py
+++ b/invisible_cities/cities/penthesilea_test.py
@@ -10,6 +10,7 @@ from .. core                 import system_of_units as units
 from .. core.core_functions  import in_range
 from .. core.testing_utils   import assert_dataframes_close
 from .. core.testing_utils   import assert_tables_equality
+from .. core.testing_utils   import ignore_warning
 from .. core.configure       import configure
 from .. io                   import dst_io as dio
 from .. io.mcinfo_io         import load_mchits_df
@@ -24,6 +25,7 @@ from .  penthesilea          import penthesilea
 #in order not to fail direct comparation tests when changing hit attribute we compare only the columns that penthesilea is using
 columns = ['event', 'time', 'npeak', 'Xpeak', 'Ypeak', 'nsipm', 'X', 'Y', 'Xrms', 'Yrms', 'Z', 'Q', 'E']
 
+@ignore_warning.no_config_group
 def test_penthesilea_KrMC(KrMC_pmaps_filename, KrMC_hdst, KrMC_kdst, config_tmpdir):
     PATH_IN   = KrMC_pmaps_filename
     PATH_OUT  = os.path.join(config_tmpdir,'Kr_HDST.h5')
@@ -54,6 +56,7 @@ def test_penthesilea_KrMC(KrMC_pmaps_filename, KrMC_hdst, KrMC_kdst, config_tmpd
                             check_dtype=False           , rtol=1e-4            )
 
 
+@ignore_warning.no_config_group
 def test_penthesilea_filter_events(config_tmpdir, Kr_pmaps_run4628_filename):
     PATH_IN =  Kr_pmaps_run4628_filename
 
@@ -121,6 +124,7 @@ def test_penthesilea_filter_events(config_tmpdir, Kr_pmaps_run4628_filename):
     assert np.all(df_penthesilea_dst.s2_peak.values == s2_peak_pass_dst)
 
 
+@ignore_warning.no_config_group
 def test_penthesilea_threshold_rebin(ICDATADIR, output_tmpdir):
     file_in     = os.path.join(ICDATADIR    ,            "Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts.PMP.h5")
     file_out    = os.path.join(output_tmpdir,                   "exact_result_penthesilea_rebin4000.h5")
@@ -145,6 +149,7 @@ def test_penthesilea_threshold_rebin(ICDATADIR, output_tmpdir):
     assert_dataframes_close(output_dst[columns], expected_dst[columns], check_dtype=False)
 
 
+@ignore_warning.no_config_group
 def test_penthesilea_signal_to_noise(ICDATADIR, output_tmpdir):
     file_in     = os.path.join(ICDATADIR    ,     "Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts.PMP.h5")
     file_out    = os.path.join(output_tmpdir,                   "exact_result_penthesilea_SN.h5")
@@ -175,6 +180,7 @@ def test_penthesilea_signal_to_noise(ICDATADIR, output_tmpdir):
     assert_dataframes_close(output_dst[columns], expected_dst[columns], check_dtype=False)
 
 
+@ignore_warning.no_config_group
 @mark.serial
 def test_penthesilea_produces_mcinfo(KrMC_pmaps_filename, KrMC_hdst, config_tmpdir):
     PATH_IN   = KrMC_pmaps_filename
@@ -204,6 +210,7 @@ def test_penthesilea_true_hits_are_correct(KrMC_true_hits, config_tmpdir):
     assert_dataframes_close(penthesilea_evts, true_evts)
 
 
+@ignore_warning.no_config_group
 def test_penthesilea_read_multiple_files(ICDATADIR, output_tmpdir):
     file_in     = os.path.join(ICDATADIR                                       ,
                                "Tl_v1_00_05_nexus_v5_02_08_7bar_pmaps_5evts_*.h5")
@@ -246,6 +253,7 @@ def test_penthesilea_read_multiple_files(ICDATADIR, output_tmpdir):
                             particles_out                                )
 
 
+@ignore_warning.no_config_group
 def test_penthesilea_exact_result(ICDATADIR, output_tmpdir):
     file_in     = os.path.join(ICDATADIR                                     ,
                                "Kr83_nexus_v5_03_00_ACTIVE_7bar_3evts.PMP.h5")
@@ -272,6 +280,7 @@ def test_penthesilea_exact_result(ICDATADIR, output_tmpdir):
                 expected = getattr(true_output_file.root, table)
                 assert_tables_equality(got, expected)
 
+@ignore_warning.no_config_group
 def test_penthesilea_exact_result_noS1(ICDATADIR, output_tmpdir):
     file_in     = os.path.join(ICDATADIR                                      ,
                                "Kr83_nexus_v5_03_00_ACTIVE_7bar_10evts_PMP.h5")
@@ -301,6 +310,7 @@ def test_penthesilea_exact_result_noS1(ICDATADIR, output_tmpdir):
                 assert_tables_equality(got, expected)
 
 # test for PR 628
+@ignore_warning.no_config_group
 def test_penthesilea_xyrecofail(config_tmpdir, Xe2nu_pmaps_mc_filename):
     PATH_IN =  Xe2nu_pmaps_mc_filename
 
@@ -345,6 +355,7 @@ def test_penthesilea_xyrecofail(config_tmpdir, Xe2nu_pmaps_mc_filename):
     penthesilea(**conf)
 
 
+@ignore_warning.no_config_group
 def test_penthesilea_empty_input_file(config_tmpdir, ICDATADIR):
     # Penthesilea must run on an empty file without raising any exception
     # The input file has the complete structure of a PMAP but no events.
@@ -363,7 +374,7 @@ def test_penthesilea_empty_input_file(config_tmpdir, ICDATADIR):
         penthesilea(**conf)
 
 
-
+@ignore_warning.no_config_group
 def test_penthesilea_global_xyreco_bias(config_tmpdir, ICDATADIR):
     # Make sure the global_reco_params are used for the columns Xpeak/Ypeak
     # This is done by running over an event that has many spurious sipm hits
@@ -391,6 +402,7 @@ def test_penthesilea_global_xyreco_bias(config_tmpdir, ICDATADIR):
     assert np.all(output_dst.Ypeak == -5)
 
 
+@ignore_warning.no_config_group
 @mark.parametrize('flags value counter'.split(),
                   (('-e all'   , 10, 'events_in'), # 10 events in the file
                    ('-e   9'   ,  9, 'events_in'), # [ 0,  9) -> 9

--- a/invisible_cities/cities/penthesilea_test.py
+++ b/invisible_cities/cities/penthesilea_test.py
@@ -389,3 +389,20 @@ def test_penthesilea_global_xyreco_bias(config_tmpdir, ICDATADIR):
     output_dst = dio.load_dst(PATH_OUT, 'RECO', 'Events')
     assert np.all(output_dst.Xpeak == -5)
     assert np.all(output_dst.Ypeak == -5)
+
+
+@mark.parametrize('flags value counter'.split(),
+                  (('-e all'   , 10, 'events_in'), # 10 events in the file
+                   ('-e   9'   ,  9, 'events_in'), # [ 0,  9) -> 9
+                   ('-e 5 9'   ,  4, 'events_in'), # [ 5,  9) -> 4
+                   ('-e 2 last',  8, 'events_in'), # events [2, 10) -> 8
+                  ))
+def test_config_penthesilea_counters(config_tmpdir, KrMC_pmaps_filename, flags, value, counter):
+    input_filename  = KrMC_pmaps_filename
+    config_filename = 'invisible_cities/config/penthesilea.conf'
+    flags_wo_spaces = flags.replace(" ", "_")
+    output_filename = os.path.join(config_tmpdir, f'penthesilea_counters_{flags_wo_spaces}.h5')
+
+    argv = f'penthesilea {config_filename} -i {input_filename} -o {output_filename} {flags}'.split()
+    counters = penthesilea(**configure(argv))
+    assert getattr(counters, counter) == value

--- a/invisible_cities/cities/phyllis_test.py
+++ b/invisible_cities/cities/phyllis_test.py
@@ -10,10 +10,12 @@ from pytest import mark
 from .  phyllis            import phyllis
 from .. core.configure     import configure
 from .. core.testing_utils import assert_tables_equality
+from .. core.testing_utils import ignore_warning
 from .. types.symbols      import all_events
 from .. types.symbols      import PMTCalibMode
 
 
+@ignore_warning.no_config_group
 @mark.parametrize("proc_opt", PMTCalibMode)
 def test_phyllis_pulsedata(config_tmpdir, ICDATADIR, proc_opt):
     PATH_IN   = os.path.join(ICDATADIR    , 'pmtledpulsedata.h5')
@@ -46,6 +48,7 @@ def test_phyllis_pulsedata(config_tmpdir, ICDATADIR, proc_opt):
         assert np.all(ch_in_sipm == ch_out_sipm)
 
 
+@ignore_warning.no_config_group
 @mark.parametrize("proc_opt", PMTCalibMode)
 def test_phyllis_exact_result(ICDATADIR, output_tmpdir, proc_opt):
     file_in     = os.path.join(ICDATADIR    ,                       "pmtledpulsedata.h5")

--- a/invisible_cities/cities/sophronia_test.py
+++ b/invisible_cities/cities/sophronia_test.py
@@ -4,10 +4,12 @@ import tables as tb
 from pytest import mark
 
 from .. core.testing_utils   import assert_tables_equality
+from .. core.testing_utils   import ignore_warning
 from .. core.system_of_units import pes
 from .  sophronia            import sophronia
 
 
+@ignore_warning.no_config_group
 def test_sophronia_runs(sophronia_config, config_tmpdir):
     path_out = os.path.join(config_tmpdir, 'sophronia_runs.h5')
     nevt_req = 1
@@ -19,6 +21,7 @@ def test_sophronia_runs(sophronia_config, config_tmpdir):
     assert cnt.events_in   == nevt_req
 
 
+@ignore_warning.no_config_group
 def test_sophronia_contains_all_tables(sophronia_config, config_tmpdir):
     path_out = os.path.join(config_tmpdir, "test_sophronia_contains_all_tables.h5")
     nevt_req = 1
@@ -46,6 +49,7 @@ def test_sophronia_contains_all_tables(sophronia_config, config_tmpdir):
         assert "Filters/valid_hit"    in h5out.root
 
 
+@ignore_warning.no_config_group
 @mark.slow
 def test_sophronia_exact_result(sophronia_config, Th228_hits, config_tmpdir):
     path_out = os.path.join(config_tmpdir, 'test_sophronia_exact_result.h5')
@@ -70,6 +74,7 @@ def test_sophronia_exact_result(sophronia_config, Th228_hits, config_tmpdir):
                 assert_tables_equality(got, expected)
 
 
+@ignore_warning.no_config_group
 def test_sophronia_filters_pmaps(sophronia_config, config_tmpdir):
     path_out = os.path.join(config_tmpdir, 'test_sophronia_filters_pmaps.h5')
     config   = dict(**sophronia_config)
@@ -85,6 +90,7 @@ def test_sophronia_filters_pmaps(sophronia_config, config_tmpdir):
     assert cnt.selection.n_failed == 2
 
 
+@ignore_warning.no_config_group
 def test_sophronia_filters_events_with_only_nn_hits(config_tmpdir, sophronia_config):
     """
     Run with a high q threshold so all hits are NN-hits.
@@ -111,6 +117,7 @@ def test_sophronia_filters_events_with_only_nn_hits(config_tmpdir, sophronia_con
         assert not output_file.root.Filters.valid_hit   [0][1]
 
 
+@ignore_warning.no_config_group
 def test_sophronia_keeps_hitless_events(config_tmpdir, sophronia_config):
     """
     Run with a high q threshold so all hits are discarded (turned into NN).

--- a/invisible_cities/cities/trude_test.py
+++ b/invisible_cities/cities/trude_test.py
@@ -10,10 +10,12 @@ from pytest import mark
 from .  trude              import trude
 from .. core.configure     import configure
 from .. core.testing_utils import assert_tables_equality
+from .. core.testing_utils import ignore_warning
 from .. types.symbols      import all_events
 from .. types.symbols      import SiPMCalibMode
 
 
+@ignore_warning.no_config_group
 @mark.slow
 @mark.parametrize("proc_opt", ( SiPMCalibMode.subtract_mode
                               , SiPMCalibMode.subtract_median))
@@ -48,6 +50,7 @@ def test_trude_pulsedata(config_tmpdir, ICDATADIR, proc_opt):
         assert np.all(ch_in_sipm == ch_out_sipm)
 
 
+@ignore_warning.no_config_group
 @mark.parametrize("proc_opt", ( SiPMCalibMode.subtract_mode
                               , SiPMCalibMode.subtract_median))
 def test_trude_exact_result(ICDATADIR, output_tmpdir, proc_opt):

--- a/invisible_cities/core/configure_test.py
+++ b/invisible_cities/core/configure_test.py
@@ -390,23 +390,6 @@ def test_config_CLI_flags(simple_conf_file_name, tmpdir_factory, name, flags, va
     assert getattr(conf_ns, name) == value
 
 
-@mark.parametrize('flags value counter'.split(),
-                  (('-e all'   , 10, 'events_in'), # 10 events in the file
-                   ('-e   9'   ,  9, 'events_in'), # [ 0,  9) -> 9
-                   ('-e 5 9'   ,  4, 'events_in'), # [ 5,  9) -> 4
-                   ('-e 2 last',  8, 'events_in'), # events [2, 10) -> 8
-                  ))
-def test_config_penthesilea_counters(config_tmpdir, KrMC_pmaps_filename, flags, value, counter):
-    input_filename  = KrMC_pmaps_filename
-    config_filename = 'invisible_cities/config/penthesilea.conf'
-    flags_wo_spaces = flags.replace(" ", "_")
-    output_filename = path.join(config_tmpdir,
-                                f'penthesilea_counters_output_{flags_wo_spaces}.h5')
-    argv = f'penthesilea {config_filename} -i {input_filename} -o {output_filename} {flags}'.split()
-    counters = penthesilea(**configure(argv))
-    assert getattr(counters, counter) == value
-
-
 def test_configure_numpy(config_tmpdir):
     config_filename = config_tmpdir.join("conf_with_numpy.conf")
     config_contents = "a_numpy_array = np.linspace(0, 1, 3)\n"

--- a/invisible_cities/core/testing_utils.py
+++ b/invisible_cities/core/testing_utils.py
@@ -1,7 +1,9 @@
 import numpy  as np
 import pandas as pd
 
+from dataclasses            import dataclass
 from pytest                 import approx
+from pytest                 import mark
 from numpy.testing          import assert_equal
 from numpy.testing          import assert_allclose
 from hypothesis.strategies  import integers
@@ -204,3 +206,16 @@ def assert_hit_equality(a_hit, b_hit):
     assert a_hit.Xpeak        == approx (b_hit.Xpeak      )
     assert a_hit.Ypeak        == approx (b_hit.Ypeak      )
     assert a_hit.peak_number  == exactly(b_hit.peak_number)
+
+
+@dataclass(frozen=True)
+class ignore_warning:
+    str_length      = mark.filterwarnings("ignore:dataframe contains strings longer than allowed")
+    not_kdst        = mark.filterwarnings("ignore:.*not of kdst type.*:UserWarning")
+    no_config_group = mark.filterwarnings("ignore:Input file does not contain /config group")
+    no_hits         = mark.filterwarnings("ignore:Event .* does not contain hits")
+    repeated_files  = mark.filterwarnings("ignore:files_in contains repeated values")
+    delayed_hits    = mark.filterwarnings("ignore:Delayed hits at event .*")
+    unphysical_rate = mark.filterwarnings("ignore:(Zero|Negative) rate")
+    max_time_short  = mark.filterwarnings("ignore:`max_time` shorter than `buffer_length`")
+    no_mc_tables    = mark.filterwarnings("ignore:File does not contain MC tables.( *)Use positve run numbers for data")

--- a/invisible_cities/io/hits_io.py
+++ b/invisible_cities/io/hits_io.py
@@ -44,12 +44,12 @@ def hits_from_df (dst : pd.DataFrame, skip_NN : bool = False) -> Dict[int, HitCo
                 Xrms  = row.Xrms
                 Xrms2 = Xrms**2
             else:
-                Xrms = Xrms2 = -1
+                Xrms = Xrms2 = 0
             if hasattr(row, 'Yrms'):
                 Yrms  = row.Yrms
                 Yrms2 = Yrms**2
             else:
-                Yrms = Yrms2 = -1
+                Yrms = Yrms2 = 0
             nsipm   = getattr(row, 'nsipm'   , -1   )     # for backwards compatibility
             Qc      = getattr(row, 'Qc'      , -1   )     # for backwards compatibility
             Xpeak   = getattr(row, 'Xpeak'   , -1000)     # for backwards compatibility

--- a/invisible_cities/io/indexation_test.py
+++ b/invisible_cities/io/indexation_test.py
@@ -3,9 +3,10 @@ import tables as tb
 import pandas as pd
 from pytest import mark
 
-from .. cities.components import city
-from .. core.configure import OneOrManyFiles
-from .. core.configure import EventRangeType
+from .. cities.components  import city
+from .. core.configure     import OneOrManyFiles
+from .. core.configure     import EventRangeType
+from .. core.testing_utils import ignore_warning
 
 from . hits_io   import     hits_writer
 from . kdst_io   import       kr_writer
@@ -34,6 +35,8 @@ def _df_writer(h5out):
     return df_writer(h5out, df, 'DUMMY', 'dummy', columns_to_index=['event'])
 
 
+@ignore_warning.no_config_group
+@ignore_warning.str_length
 @mark.parametrize("         writer  group      node      column   thing".split(),
                   [(   hits_writer, "RECO" , "Events"  , "event", "hits"),
                    (     kr_writer, "DST"  , "Events"  , "event", "kr"  ),

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,4 +6,3 @@ filterwarnings =
     ignore:can't resolve package from __spec__ or __package__, falling back on __name__ and __path__:ImportWarning
     ignore::FutureWarning:scipy.signal.signaltools:3463
     ignore::FutureWarning:scipy.signal.signaltools:1344
-    ignore::UserWarning:invisible_cities.io.dst_io:107

--- a/scripts/check_warnings
+++ b/scripts/check_warnings
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+import sys
+import re
+
+header = "(.*)(=+) warnings summary (=+)(.*)"   # <color> === title === <color>
+footer = "(.*)(=+) (.+) warnings (.+) (=+)(.*)" # <color> === x passed y warnings in z seconds === <color>
+
+found = False
+doit  = False
+for line in map(str.strip, open(sys.argv[1])):
+    if re.match(header, line): doit=True
+
+    if doit:
+        found = True
+        print(line)
+
+    if re.match(footer, line): doit=False


### PR DESCRIPTION
This was creating too much noise in the test suite output. This PR silences all warnings. For this, I introduced a `dataclass` holding all warning filters. This allows for the reuse of filters while giving them a meaningful name.

Closes #875.