### PR TITLE
Bump actions/checkout version in GHA workflows

### DIFF
--- a/.github/workflows/check_db_calibration.yml
+++ b/.github/workflows/check_db_calibration.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: [3.8]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - id: files
       uses: jitterbit/get-changed-files@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Get LFS files
       run: git lfs pull
     # - name: Fix Conda permissions on macOS


### PR DESCRIPTION
The current version issues the following warning:

```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2.
For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```

Bumpng to the latest version seems to get rid of it.