### PR TITLE
Add links to readthedocs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,3 +41,10 @@ appropriate environment, creating it on the fly if necessary.
 
 .. |travis| image:: https://img.shields.io/travis/nextic/IC.png
         :target: https://travis-ci.org/nextic/IC
+
+Documentation 
+-------------
+
+The documentation for IC, including the individual cities, can be found here: https://next-exp-sw.readthedocs.io/en/latest/IC.html
+
+The above link is continuously updated in intervals. If however, there is no/little documentation for a particular city you need in the above link, check:  https://github.com/next-exp/sw-docs/pulls for the documentation on more recent updates.


### PR DESCRIPTION
The documentation was not findable in the readme before. I have now added the links to where the documentation can be found. 