### PR TITLE
Add database version

### DIFF
--- a/invisible_cities/database/db_connection.py
+++ b/invisible_cities/database/db_connection.py
@@ -17,3 +17,10 @@ def connect_mysql(dbname):
                                   user='nextreader',passwd='readonly', db=dbname)
     cursor_mysql  = conn_mysql .cursor()
     return connect_mysql, cursor_mysql
+
+@mark.skip(reason='server timeouts cause too many spurious test failures')
+def connect_dolt_mysql(dbname):
+    conn_mysql  = pymysql.connect(host="next.ific.uv.es", port=3307,
+                                  user='nextreader',passwd='readonly', db=dbname)
+    cursor_mysql  = conn_mysql .cursor()
+    return connect_mysql, cursor_mysql

--- a/invisible_cities/database/download.py
+++ b/invisible_cities/database/download.py
@@ -5,11 +5,13 @@ pymysql.install_as_MySQLdb()
 import os
 import re
 from os import path
+from datetime import datetime
 
 # Absolute imports to allow usage as standalone program:
 # python invisible_cities/database/download.py
 from invisible_cities.database.db_connection import connect_sqlite
 from invisible_cities.database.db_connection import connect_mysql
+from invisible_cities.database.db_connection import connect_dolt_mysql
 
 
 def create_table_sqlite(cursorSqlite, cursorMySql, table):
@@ -70,6 +72,27 @@ def loadDB(dbname : str, tables : list):
         # Copy data
         copy_all_rows(conn_sqlite, cursor_sqlite, cursor_mysql, table)
 
+def write_db_version(dbname: str):
+    dbfile = path.join(os.environ['ICDIR'], 'database/localdb.'+dbname+'.sqlite3')
+    try:
+        conn_mysql , cursor_mysql  = connect_dolt_mysql(dbname)
+    except pymysql.err.OperationalError:
+        print(f"DB versioning not implemented for database {dbname}")
+        return
+    conn_sqlite, cursor_sqlite = connect_sqlite(dbfile)
+    sql = 'select commit_hash, date from dolt_diff order by date desc limit 1'
+    cursor_mysql.execute(sql)
+    data = cursor_mysql.fetchall()
+    if len(data) == 1:
+        db_version = data[0][0]
+        date = data[0][1]
+        timestamp = datetime.timestamp(date)
+        sql_table = "create table db_version(version VARCHAR(20), date timestamp null)"
+        cursor_sqlite.execute(sql_table)
+        sql_value = f'insert into db_version (version, date) values ("{db_version}", {timestamp})'
+        cursor_sqlite.execute(sql_value)
+        conn_sqlite.commit()
+
 
 dbnames        = ('NEWDB', 'DEMOPPDB', 'NEXT100DB', 'Flex100DB')
 common_tables  = ('DetectorGeo','PmtBlr','ChannelGain','ChannelMapping','ChannelMask',
@@ -85,6 +108,8 @@ if __name__ == '__main__':
     if len(sys.argv) > 1:
         dbname = sys.argv[1]
         loadDB(dbname, table_dict[dbname])
+        write_db_version(dbname)
     else:
         for dbname, tables in table_dict.items():
             loadDB(dbname, tables)
+            write_db_version(dbname)

--- a/invisible_cities/database/load_db.py
+++ b/invisible_cities/database/load_db.py
@@ -163,3 +163,13 @@ def RadioactivityData(db_file, version=None):
 
     return ( activity  .drop(columns="MAX(Version)")
            , efficiency.drop(columns="MAX(Version)"))
+
+def read_db_version(db_file):
+    conn = sqlite3.connect(get_db(db_file))
+    sql = 'select * from db_version'
+    try:
+        data = pd.read_sql_query(sql, conn)
+        return data
+    except pd.io.sql.DatabaseError:
+        # Deal with this...
+        print("Database does not have db_version table")


### PR DESCRIPTION
We have had many issues with database recently and, many times, analysts needed to know exactly which database version was being used for files processed at LSC. They also needed to know whether any changes has happened at the DB server or not.

I have implemented a system to record a log of every change happening in our databases (currently only implemented for `DEMOPPDB` and `NEXT100DB`, the detectors in use). It is basically a mirror of our database using [Dolt](https://www.dolthub.com/). Whenever any update, delete or insert occurs, a hash and a timestamp will be generated associated to those changes. In this way, we can know for sure which tables and which rows have changed at any point in time.

This is already implemented and is transparent to our usual operations. I think it would be interesting to add the DB version to our local sqlite copy. This PR includes a function to do that, the download script will try to get the (hash, timestamp) of the database. It also includes a function to read the version from the local database. To have complete traceability I think all the files processed should include somewhere in the HDF5 file the corresponding hash. In this way we could know exactly which database was used for each file and there would not be any ambiguity anymore.

Doing all that is quite a bit of work and I am not volunteering at all to do it. If any of you think this is interesting, find a volunteer and get it implemented. I am already giving you all the required tools.

Some examples of what the current code does:
```
In [5]: db.read_db_version(db.get_db("next100"))
Out[5]: 
                            version        date
0  a6lq9jnaguhhvauqfs0p7ptjrtn1vl72  1740148188

In [7]: db.read_db_version(db.get_db("demopp"))
Out[7]: 
                            version        date
0  idbsfat3k116ihh981f0fa9in787q61g  1740147366

In [8]: db.read_db_version(db.get_db("flex100"))
Database does not have db_version table
```

Related to this, I am not sure where is the best place to comment this, but I would also like to implement a small change in the process done for calibrations (or any other database-changing procedure). Right now, whomever is updating the database is probably executing a bunch of `INSERT` SQL statements. That works perfectly, but to have a better use of the database changelog I would prefer it to be done using *transactions*.  The difference is that using transactions, even if there are many changes to some tables, they will be executed atomically and only one hash will be generated.

In the current way, each `INSERT` would generate a new DB version, so it would be also much more difficult trying to make sense of the changes if we need to investigate any issue sometime in the future.

The proposed change is very simple, it only requires adding one line at the beginning and one at the end. For instance:
```
START TRANSACTION;
INSERT INTO....
INSERT...
[...]
COMMIT;
```

So the idea is to include all the inserts together between `START TRANSACTION;` and `COMMIT;`. Thus, we would get only one new database version with the PMT calibration instead of 60. 