### PR TITLE
Bump ubuntu version for GHA

### DIFF
--- a/.github/workflows/check_db_calibration.yml
+++ b/.github/workflows/check_db_calibration.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build:
 
-    runs-on: [ubuntu-20.04]
+    runs-on: [ubuntu-24.04]
     strategy:
       matrix:
         python-version: [3.8]

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         python-version: [3.8]
         #platform: [ubuntu-18.04, macos-latest]
-        platform: [ubuntu-20.04]
+        platform: [ubuntu-24.04]
     runs-on: ${{ matrix.platform }}
 
     steps:


### PR DESCRIPTION
As announced in [this blog post](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/), the `ubuntu-20.04` runner image is being retired on the 1st of April 2025. I've bumped the version to `ubuntu-24.04` and everything seems to work as expected.

On an unrelated note, the `check_db_calibration.yml` workflow never runs, I'm unsure if that's intended.