### PR TITLE
add flag for Z correction 

### DIFF
--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -1519,6 +1519,7 @@ def hits_corrector( filename   : str
                   , apply_temp : bool
                   , norm_strat : NormStrategy
                   , norm_value : Optional[Union[float, NoneType]] = None
+                  , apply_z    : Optional[bool] = False
                   ) -> Callable:
     """
     Applies energy correction map and converts drift time to z.
@@ -1549,7 +1550,7 @@ def hits_corrector( filename   : str
                                     , apply_temp = apply_temp
                                     , norm_strat = norm_strat
                                     , norm_value = norm_value)
-    time_to_Z = get_df_to_z_converter(maps) if maps.t_evol is not None else identity
+    time_to_Z = get_df_to_z_converter(maps) if maps.t_evol is not None and apply_z == True else identity
 
     def correct(hitc : HitCollection) -> HitCollection:
         for hit in hitc.hits:

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -1550,7 +1550,7 @@ def hits_corrector( filename   : str
                                     , apply_temp = apply_temp
                                     , norm_strat = norm_strat
                                     , norm_value = norm_value)
-    time_to_Z = get_df_to_z_converter(maps) if maps.t_evol is not None and apply_z == True else identity
+    time_to_Z = get_df_to_z_converter(maps) if maps.t_evol is not None and apply_z else identity
 
     def correct(hitc : HitCollection) -> HitCollection:
         for hit in hitc.hits:

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -493,11 +493,8 @@ def test_read_wrong_pmt_ids(ICDATADIR):
 def test_hits_corrector_z_uncorrected_when_flagged( correction_map_filename
                                                   , apply_z):
     '''
-    Test that checks to ensure that z is uncorrected when `apply_z` is True
+    Test to ensure that z is uncorrected when `apply_z` is True
     '''
-    apply_temp = False
-    norm_strat = NormStrategy.kr
-    norm_value = None
 
     # create some hits to correct
     n  = 50
@@ -514,9 +511,9 @@ def test_hits_corrector_z_uncorrected_when_flagged( correction_map_filename
     hc = HitCollection(0, 1, hits)
 
     correct = hits_corrector(correction_map_filename,
-                             apply_temp, 
-                             norm_strat,
-                             norm_value = norm_value,
+                             apply_temp = False, 
+                             norm_strat = NormStrategy.kr,
+                             norm_value = None,
                              apply_z = apply_z)
     corrected_z = np.array([h.Z for h in correct(hc).hits])
 

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -10,6 +10,8 @@ from functools import partial
 from pytest import mark
 from pytest import raises
 from pytest import warns
+from numpy.testing import assert_equal
+from numpy.testing import assert_raises
 
 from .. core.configure     import configure
 from .. core.exceptions    import InvalidInputFileStructure
@@ -485,6 +487,44 @@ def test_read_wrong_pmt_ids(ICDATADIR):
     sns_gen = mcsensors_from_file([file_in], 'next100', run_number, rate)
     with raises(SensorIDMismatch):
         next(sns_gen)
+
+
+@mark.parametrize("apply_z", (True, False))
+def test_hits_corrector_z_uncorrected_when_flagged( correction_map_filename
+                                                  , apply_z):
+    '''
+    Test that checks to ensure that z is uncorrected when `apply_z` is True
+    '''
+    apply_temp = False
+    norm_strat = NormStrategy.kr
+    norm_value = None
+
+    # create some hits to correct
+    n  = 50
+    xs = np.random.uniform(-10, 10, n)
+    ys = np.random.uniform(-10, 10, n)
+    zs = np.random.uniform( 10, 50, n)
+
+    hits = []
+    for i, x, y, z in zip(range(n), xs, ys, zs):
+        c = Cluster(0, xy(x, y), xy.zero(), 1)
+        h = Hit(i, c, z, 1, xy.zero(), 0)
+        hits.append(h)
+
+    hc = HitCollection(0, 1, hits)
+
+    correct = hits_corrector(correction_map_filename,
+                             apply_temp, 
+                             norm_strat,
+                             norm_value = norm_value,
+                             apply_z = apply_z)
+    corrected_z = np.array([h.Z for h in correct(hc).hits])
+
+    # if we expect a change, assert a change and vice versa
+    if apply_z:
+        assert_raises(AssertionError, assert_equal, corrected_z, zs)
+    else:
+        assert_equal(corrected_z, zs)
 
 
 @mark.parametrize( "norm_strat norm_value".split(),

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -489,10 +489,10 @@ def test_read_wrong_pmt_ids(ICDATADIR):
         next(sns_gen)
 
 
-def test_hits_uncorrected_when_flagged( correction_map_filename
-                                      , random_hits_toy_data):
+def test_hits_Z_uncorrected( correction_map_filename
+                           , random_hits_toy_data):
     '''
-    Test to ensure that z is uncorrected when `apply_z` is True
+    Test to ensure that z is uncorrected when `apply_z` is False
     '''
     
     hc = random_hits_toy_data
@@ -502,17 +502,17 @@ def test_hits_uncorrected_when_flagged( correction_map_filename
                              apply_temp = False, 
                              norm_strat = NormStrategy.kr,
                              norm_value = None,
-                             apply_z = False)
+                             apply_z    = False)
     corrected_z = np.array([h.Z for h in correct(hc).hits])
 
     # no change to equal results
     assert_equal(corrected_z, hz)
 
 
-def test_hits_corrected_when_not_flagged( correction_map_filename
-                                        , random_hits_toy_data):
+def test_hits_Z_corrected_when_flagged( correction_map_filename
+                                      , random_hits_toy_data):
     '''
-    Test to ensure that the correction is applied when `apply_z` is False
+    Test to ensure that the correction is applied when `apply_z` is True
     '''
     
     hc = random_hits_toy_data
@@ -522,7 +522,7 @@ def test_hits_corrected_when_not_flagged( correction_map_filename
                              apply_temp = False, 
                              norm_strat = NormStrategy.kr,
                              norm_value = None,
-                             apply_z = True)
+                             apply_z    = True)
     corrected_z = np.array([h.Z for h in correct(hc).hits])
 
     # raise assertion error as expected

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -489,40 +489,45 @@ def test_read_wrong_pmt_ids(ICDATADIR):
         next(sns_gen)
 
 
-@mark.parametrize("apply_z", (True, False))
-def test_hits_corrector_z_uncorrected_when_flagged( correction_map_filename
-                                                  , apply_z):
+def test_hits_uncorrected_when_flagged( correction_map_filename
+                                      , random_hits_toy_data):
     '''
     Test to ensure that z is uncorrected when `apply_z` is True
     '''
-
-    # create some hits to correct
-    n  = 50
-    xs = np.random.uniform(-10, 10, n)
-    ys = np.random.uniform(-10, 10, n)
-    zs = np.random.uniform( 10, 50, n)
-
-    hits = []
-    for i, x, y, z in zip(range(n), xs, ys, zs):
-        c = Cluster(0, xy(x, y), xy.zero(), 1)
-        h = Hit(i, c, z, 1, xy.zero(), 0)
-        hits.append(h)
-
-    hc = HitCollection(0, 1, hits)
-
+    
+    hc = random_hits_toy_data
+    hz = [h.Z for h in hc.hits]
+    
     correct = hits_corrector(correction_map_filename,
                              apply_temp = False, 
                              norm_strat = NormStrategy.kr,
                              norm_value = None,
-                             apply_z = apply_z)
+                             apply_z = False)
     corrected_z = np.array([h.Z for h in correct(hc).hits])
 
-    # if we expect a change, assert a change and vice versa
-    if apply_z:
-        assert_raises(AssertionError, assert_equal, corrected_z, zs)
-    else:
-        assert_equal(corrected_z, zs)
+    # no change to equal results
+    assert_equal(corrected_z, hz)
 
+
+def test_hits_corrected_when_not_flagged( correction_map_filename
+                                        , random_hits_toy_data):
+    '''
+    Test to ensure that the correction is applied when `apply_z` is False
+    '''
+    
+    hc = random_hits_toy_data
+    hz = [h.Z for h in hc.hits]
+    
+    correct = hits_corrector(correction_map_filename,
+                             apply_temp = False, 
+                             norm_strat = NormStrategy.kr,
+                             norm_value = None,
+                             apply_z = True)
+    corrected_z = np.array([h.Z for h in correct(hc).hits])
+
+    # raise assertion error as expected
+    assert_raises(AssertionError, assert_equal, corrected_z, hz)
+    
 
 @mark.parametrize( "norm_strat norm_value".split(),
                   ( (NormStrategy.kr    , None) # None marks the default value
@@ -534,25 +539,16 @@ def test_hits_corrector_z_uncorrected_when_flagged( correction_map_filename
 def test_hits_corrector_valid_normalization_options( correction_map_filename
                                                    , norm_strat
                                                    , norm_value
-                                                   , apply_temp ):
+                                                   , apply_temp
+                                                   , random_hits_toy_data ):
     """
     Test that all valid normalization options work to some
     extent. Here we just check that the values make some sense: not
     nan and greater than 0. The more exhaustive tests are performed
     directly on the core functions.
     """
-    n  = 50
-    xs = np.random.uniform(-10, 10, n)
-    ys = np.random.uniform(-10, 10, n)
-    zs = np.random.uniform( 10, 50, n)
 
-    hits = []
-    for i, x, y, z in zip(range(n), xs, ys, zs):
-        c = Cluster(0, xy(x, y), xy.zero(), 1)
-        h = Hit(i, c, z, 1, xy.zero(), 0)
-        hits.append(h)
-
-    hc = HitCollection(0, 1, hits)
+    hc = random_hits_toy_data
 
     correct     = hits_corrector(correction_map_filename, apply_temp, norm_strat, norm_value)
     corrected_e = np.array([h.Ec for h in correct(hc).hits])

--- a/invisible_cities/config/beersheba.conf
+++ b/invisible_cities/config/beersheba.conf
@@ -40,4 +40,4 @@ corrections  = dict(
     filename   = "$ICDIR/database/test_data/kr_emap_xy_100_100_r_6573_time.h5",
     apply_temp = False,
     norm_strat = kr,
-    apply_z = False)
+    apply_z    = True)

--- a/invisible_cities/config/beersheba.conf
+++ b/invisible_cities/config/beersheba.conf
@@ -39,4 +39,5 @@ satellite_params = None
 corrections  = dict(
     filename   = "$ICDIR/database/test_data/kr_emap_xy_100_100_r_6573_time.h5",
     apply_temp = False,
-    norm_strat = kr)
+    norm_strat = kr,
+    apply_z = False)

--- a/invisible_cities/config/esmeralda.conf
+++ b/invisible_cities/config/esmeralda.conf
@@ -28,4 +28,4 @@ corrections = dict(
     filename   = "$ICDIR/database/test_data/kr_emap_xy_100_100_r_6573_time.h5",
     apply_temp = False,
     norm_strat = kr,
-    apply_z    = False)
+    apply_z    = True)

--- a/invisible_cities/config/esmeralda.conf
+++ b/invisible_cities/config/esmeralda.conf
@@ -27,4 +27,5 @@ paolina_params      = dict(
 corrections = dict(
     filename   = "$ICDIR/database/test_data/kr_emap_xy_100_100_r_6573_time.h5",
     apply_temp = False,
-    norm_strat = kr)
+    norm_strat = kr,
+    apply_z    = False)

--- a/invisible_cities/config/sophronia.conf
+++ b/invisible_cities/config/sophronia.conf
@@ -61,4 +61,5 @@ same_peak = True
 corrections = dict(
   filename   = "$ICDIR/database/test_data/kr_emap_xy_100_100_r_6573_time.h5",
   apply_temp = True,
-  norm_strat = kr)
+  norm_strat = kr,
+  apply_z    = False)

--- a/invisible_cities/conftest.py
+++ b/invisible_cities/conftest.py
@@ -25,6 +25,11 @@ from . types.symbols     import SiPMCharge
 from . types.symbols     import InterpolationMethod
 from . types.symbols     import NormStrategy
 
+from . evm.event_model    import Cluster
+from . evm.event_model    import Hit
+from . evm.event_model    import HitCollection
+from . types.ic_types     import xy
+
 tbl_data = namedtuple('tbl_data', 'filename group node')
 dst_data = namedtuple('dst_data', 'file_info config read true')
 pmp_dfs  = namedtuple('pmp_dfs' , 's1 s2 si, s1pmt, s2pmt')
@@ -754,6 +759,23 @@ def hits_toy_data(ICDATADIR):
 
     hits_filename = os.path.join(ICDATADIR, "toy_hits.h5")
     return hits_filename, (npeak, nsipm, x, y, xrms, yrms, z, q, e, x_peak, y_peak)
+
+
+@pytest.fixture(scope='session')
+def random_hits_toy_data():
+
+    n = 50
+    xs = np.random.uniform(-10, 10, n)
+    ys = np.random.uniform(-10, 10, n)
+    zs = np.random.uniform( 10, 50, n)
+
+    hits = []
+    for i, x, y, z in zip(range(n), xs, ys, zs):
+        c = Cluster(0, xy(x, y), xy.zero(), 1)
+        h = Hit(i, c, z, 1, xy.zero(), 0)
+        hits.append(h)
+
+    return HitCollection(0, 1, hits)
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
Currently, the `hits_corrector()` will indiscriminately apply Z corrections using a correction map if one is provided. 

Consequently if you provide a corrections map for energy correction purposes that includes an inaccurate `dv` value, it will be applied and alter the Z values of your hits.

This PR adds an optional flag (`apply_z`) that allows for this feature to be disabled when the corrections map is not meant to be applied to Z.