### PR TITLE
Include cluster dropping functionality

### DIFF
--- a/invisible_cities/cities/beersheba.py
+++ b/invisible_cities/cities/beersheba.py
@@ -316,14 +316,14 @@ def drop_isolated( distance   : List[float],
                    redist_var : List[str],
                    nhits      : Optional[int] = None):
     """
-    Drops rogue/isolated hits (SiPMs) from hits,
-    can be configured to remove clusters 
+    Drops rogue/isolated hits (SiPMs) from hits, can be configured to remove 
+    isolated clusters below a certain threshold number of hits. 
 
     Parameters
     ----------
-    distance   : Sensor pitch in 2 or 3 dimensions
+    distance   : Distance between hits.
     redist_var : List with variables to be redistributed.
-    nhits      : Number of hits 
+    nhits      : Minimum number of hits for a cluster to be considered non-isolated.
     Returns
     ----------
     drop_isolated_sensors : Function that will drop the isolated sensors.

--- a/invisible_cities/cities/beersheba.py
+++ b/invisible_cities/cities/beersheba.py
@@ -492,7 +492,7 @@ def beersheba( files_in         : OneOrManyFiles
 
     cut_sensors           = fl.map(cut_over_Q   (deconv_params.pop("q_cut")    , ['E', 'Ec']),
                                    item = 'hits')
-    drop_sensors          = fl.map(drop_isolated(deconv_params.pop("drop_dist"), ['E', 'Ec'], deconv_params.pop("cluster_size")),
+    drop_sensors          = fl.map(drop_isolated(deconv_params.pop("drop_dist"), ['E', 'Ec'], deconv_params.pop("cluster_size", None)),
                                    item = 'hits')
     filter_events_no_hits = fl.map(check_nonempty_dataframe,
                                    args = 'hits',

--- a/invisible_cities/cities/beersheba.py
+++ b/invisible_cities/cities/beersheba.py
@@ -313,8 +313,8 @@ def cut_over_Q(q_cut, redist_var):
 
 
 def drop_isolated( distance   : List[float],
-                   nhits      : Optional[int] = 3,
-                   redist_var : Optional[List] = []):
+                   redist_var : List[str],
+                   nhits      : Optional[int] = None):
     """
     Drops rogue/isolated hits (SiPMs) from hits,
     can be configured to remove clusters 
@@ -333,7 +333,10 @@ def drop_isolated( distance   : List[float],
     if   len(distance) == 2:
         drop = drop_isolated_sensors(distance, redist_var)
     elif len(distance) == 3:
-        drop = drop_isolated_clusters(distance, nhits, redist_var)
+        if nhits is None:
+            raise TypeError(f"Applying 3-dimensional dropping of isolated hits requires parameter nhits which is missing.")    
+        else:
+            drop = drop_isolated_clusters(distance, nhits, redist_var)
     else:
         raise ValueError(f"Invalid drop_dist parameter: expected 2 or 3 entries, but got {len(distance)}.")
 
@@ -489,9 +492,7 @@ def beersheba( files_in         : OneOrManyFiles
 
     cut_sensors           = fl.map(cut_over_Q   (deconv_params.pop("q_cut")    , ['E', 'Ec']),
                                    item = 'hits')
-    #drop_sensors          = fl.map(drop_isolated(deconv_params.pop("drop_dist"), ['E', 'Ec']),
-    #                               item = 'hits')
-    drop_sensors          = fl.map(drop_isolated(deconv_params.pop("drop_dist"), deconv_params.pop("cluster_size"), ['E', 'Ec']),
+    drop_sensors          = fl.map(drop_isolated(deconv_params.pop("drop_dist"), ['E', 'Ec'], deconv_params.pop("cluster_size")),
                                    item = 'hits')
     filter_events_no_hits = fl.map(check_nonempty_dataframe,
                                    args = 'hits',

--- a/invisible_cities/reco/deconv_functions.py
+++ b/invisible_cities/reco/deconv_functions.py
@@ -189,11 +189,14 @@ def drop_isolated_clusters(distance   :  List[float],
                            nhits      :  int,
                            variables  :  List[str  ]) -> Callable:
     '''
-    Drops isolated clusters of hits (SiPMs).
+    Drop isolated hits/clusters, where a cluster is defined by the proximity 
+    between hits defined by  distance. A cluster is considered isolated if 
+    the number of hits within the cluster is less than or equal to nhits.
+    The method uses networkx's graph system to identify clusters.
 
     Parameters
     ----------
-    df       : Groupby ('event' and 'npeak') dataframe
+    df : Groupby ('event' and 'npeak') dataframe
 
     Initialisation parameters:
         distance  : Distance to check for other sensors, equal to sensor pitch and z rebinning.

--- a/invisible_cities/reco/deconv_functions.py
+++ b/invisible_cities/reco/deconv_functions.py
@@ -183,9 +183,9 @@ def drop_isolated_sensors(distance  : List[float]=[10., 10.],
     return drop_isolated_sensors
 
 
-def drop_isolated_clusters(distance   :  List[float]= [10., 10., 1.],
-                           nhits      :  int        = 3,
-                           variables  :  List[str  ]= [      ]) -> Callable:
+def drop_isolated_clusters(distance   :  List[float],
+                           nhits      :  int,
+                           variables  :  List[str  ]) -> Callable:
     '''
     Drops isolated clusters of hits (SiPMs).
 

--- a/invisible_cities/reco/deconv_functions.py
+++ b/invisible_cities/reco/deconv_functions.py
@@ -181,6 +181,65 @@ def drop_isolated_sensors(distance  : List[float]=[10., 10.],
     return drop_isolated_sensors
 
 
+def drop_isolated_clusters(distance   :  List[float]= [10., 10., 1.],
+                           nhits      :  int        = 3,
+                           variables  :  List[str  ]= [      ]) -> Callable:
+    '''
+    Drops isolated clusters of hits (SiPMs).
+
+    Parameters
+    ----------
+    df       : Groupby ('event' and 'npeak') dataframe
+
+    Initialisation parameters:
+        distance  : Distance to check for other sensors, equal to sensor pitch and z rebinning.
+        nhits     : Number of hits to classify a cluster.
+        variables : List of variables to be redistributed (generally the energies)
+    '''
+
+
+    def drop_event(df):
+        # normalise distances
+        x = df.X.values / distance[0]
+        y = df.Y.values / distance[1]
+        z = df.Z.values / distance[2]
+
+        xyz = np.column_stack((x, y, z))
+        dr3 = cdist(xyz, xyz)
+        # normalised, so distance square root of the dimensions
+        dist = np.sqrt(3)
+
+        # If there aren't any clusters, return empty df
+        if not np.any(dr3>0):
+            return df.iloc[:0] 
+        
+        # create mask for clusters by determining how many hits are within range.
+        closest = np.apply_along_axis(lambda d: len(d[d < dist]), 1, dr3)
+        mask_xyz = closest > nhits
+
+        # expand mask to include neighbors of neighbors etc to avoid removing edges
+        expanded_mask = mask_xyz.copy()
+        for _ in range(len(df)):
+            # find neighbors of currently included hits and combine
+            new_neighbors = np.any(dr3[:, expanded_mask] < dist, axis=1)
+            new_mask = expanded_mask | new_neighbors
+            # if no new neighbors are added break
+            if np.array_equal(new_mask, expanded_mask):
+                break
+            expanded_mask = new_mask
+        mask_xyz = expanded_mask
+
+        pass_df = df.loc[mask_xyz, :].copy()
+        # reweighting
+        with np.errstate(divide='ignore'):
+            columns = pass_df.loc[:, variables]
+            columns *= np.divide(df.loc[:,variables].sum().values,columns.sum())
+            pass_df.loc[:, variables] = columns
+
+        return pass_df
+    
+    return drop_event
+
 def deconvolution_input(sample_width : List[float     ],
                         det_grid     : List[np.ndarray],
                         inter_method : InterpolationMethod = InterpolationMethod.cubic

--- a/invisible_cities/reco/deconv_functions_test.py
+++ b/invisible_cities/reco/deconv_functions_test.py
@@ -144,7 +144,7 @@ def test_drop_isolated_clusters_retains_cluster():
     drop_function = drop_isolated_clusters(dist, nhits, ['E'])
     df_cut        = drop_function(df)
 
-    got           = df_cut[['X', 'Y', 'Z', 'Q']]
+    got           = df_cut    [['X', 'Y', 'Z', 'Q']]
     expected      = df.head(5)[['X', 'Y', 'Z', 'Q']]
     assert got.equals(expected)
 


### PR DESCRIPTION
This PR resolves the issue with clusters of spurious hits occurring within the data by introducing a function (`drop_isolated_clusters()`) that replaces the previous `drop_isolated_sensors()`.

This function first finds all hits with more than `cluster_size` neighbours within the `drop_dist` distances in [X.,Y.,Z.]. It then iterates over these hits, ensuring that their neighbours are also retained (avoiding the loss of edge hits with fewer neighbours than the `cluster_size`).

This addition does not break backwards compatibility, as the `drop_isolated_sensors()` function is still used if the `drop_dist` provided is 2 dimensional, rather than 3 dimensional. This is a lousy solution to the problem and an alternative would be appreciated.

A simple test to check the functionality has been written and runs as expected, but I believe more rigorous testing is required.