### PR TITLE
Add more normalization strategies

### DIFF
--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -1515,11 +1515,11 @@ def hits_thresholder(threshold_charge : float, same_peak : bool ) -> Callable:
 
 
 @check_annotations
-def hits_corrector( filename   : str
-                  , apply_temp : bool
-                  , norm_strat : NormStrategy
-                  , norm_value : Optional[Union[float, NoneType]] = None
-                  , apply_z    : Optional[bool] = False
+def hits_corrector( filename     : str
+                  , apply_temp   : bool
+                  , norm_strat   : NormStrategy
+                  , norm_options : Optional[dict] = dict()
+                  , apply_z      : Optional[bool] = False
                   ) -> Callable:
     """
     Applies energy correction map and converts drift time to z.
@@ -1537,19 +1537,11 @@ def hits_corrector( filename   : str
     A function that takes a HitCollection as input and returns
     the same object with modified Ec and Z fields.
     """
-
-    if ( ((norm_strat is not NormStrategy.custom)  ^  (norm_value is None)) or
-          (norm_strat is     NormStrategy.custom) and (norm_value<= 0)):
-        raise ValueError(
-            "`NormStrategy.custom` requires `norm_value` to be greater than 0. "
-            "For all other `NormStrategy` options, `norm_value` must not be provided."
-        )
-
     maps      = read_maps(os.path.expandvars(filename))
     get_coef  = apply_all_correction( maps
                                     , apply_temp = apply_temp
                                     , norm_strat = norm_strat
-                                    , norm_value = norm_value)
+                                    , **norm_options)
     time_to_Z = get_df_to_z_converter(maps) if maps.t_evol is not None and apply_z else identity
 
     def correct(hitc : HitCollection) -> HitCollection:

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -533,6 +533,7 @@ def test_hits_Z_corrected_when_flagged( correction_map_filename
                   , (NormStrategy.mean  , dict())
                   , (NormStrategy.median, dict())
                   , (NormStrategy.region, dict(xrange=(-20, 20), yrange=(-20, 20)))
+                  , (NormStrategy.region, dict(origin=( -5,  5), radius=10))
                   , (NormStrategy.custom, dict(value=1e3))
                  ))
 @mark.parametrize("apply_temp", (False, True))

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -494,12 +494,12 @@ def test_hits_Z_uncorrected( correction_map_filename
     '''
     Test to ensure that z is uncorrected when `apply_z` is False
     '''
-    
+
     hc = random_hits_toy_data
     hz = [h.Z for h in hc.hits]
-    
+
     correct = hits_corrector(correction_map_filename,
-                             apply_temp = False, 
+                             apply_temp = False,
                              norm_strat = NormStrategy.kr,
                              norm_value = None,
                              apply_z    = False)
@@ -514,12 +514,12 @@ def test_hits_Z_corrected_when_flagged( correction_map_filename
     '''
     Test to ensure that the correction is applied when `apply_z` is True
     '''
-    
+
     hc = random_hits_toy_data
     hz = [h.Z for h in hc.hits]
-    
+
     correct = hits_corrector(correction_map_filename,
-                             apply_temp = False, 
+                             apply_temp = False,
                              norm_strat = NormStrategy.kr,
                              norm_value = None,
                              apply_z    = True)
@@ -527,7 +527,7 @@ def test_hits_Z_corrected_when_flagged( correction_map_filename
 
     # raise assertion error as expected
     assert_raises(AssertionError, assert_equal, corrected_z, hz)
-    
+
 
 @mark.parametrize( "norm_strat norm_value".split(),
                   ( (NormStrategy.kr    , None) # None marks the default value
@@ -550,7 +550,7 @@ def test_hits_corrector_valid_normalization_options( correction_map_filename
 
     hc = random_hits_toy_data
 
-    correct     = hits_corrector(correction_map_filename, apply_temp, norm_strat, norm_value)
+    correct     = hits_corrector(correction_map_filename, apply_temp, norm_strat, value=norm_value)
     corrected_e = np.array([h.Ec for h in correct(hc).hits])
 
     assert not np.any(np.isnan(corrected_e) )

--- a/invisible_cities/cities/components_test.py
+++ b/invisible_cities/cities/components_test.py
@@ -501,7 +501,6 @@ def test_hits_Z_uncorrected( correction_map_filename
     correct = hits_corrector(correction_map_filename,
                              apply_temp = False,
                              norm_strat = NormStrategy.kr,
-                             norm_value = None,
                              apply_z    = False)
     corrected_z = np.array([h.Z for h in correct(hc).hits])
 
@@ -521,7 +520,6 @@ def test_hits_Z_corrected_when_flagged( correction_map_filename
     correct = hits_corrector(correction_map_filename,
                              apply_temp = False,
                              norm_strat = NormStrategy.kr,
-                             norm_value = None,
                              apply_z    = True)
     corrected_z = np.array([h.Z for h in correct(hc).hits])
 
@@ -529,18 +527,21 @@ def test_hits_Z_corrected_when_flagged( correction_map_filename
     assert_raises(AssertionError, assert_equal, corrected_z, hz)
 
 
-@mark.parametrize( "norm_strat norm_value".split(),
-                  ( (NormStrategy.kr    , None) # None marks the default value
-                  , (NormStrategy.max   , None)
-                  , (NormStrategy.mean  , None)
-                  , (NormStrategy.custom,  1e3)
-                  ))
+@mark.parametrize( "norm_strat norm_options".split(),
+                  ( (NormStrategy.kr    , dict())
+                  , (NormStrategy.max   , dict())
+                  , (NormStrategy.mean  , dict())
+                  , (NormStrategy.median, dict())
+                  , (NormStrategy.region, dict(xrange=(-20, 20), yrange=(-20, 20)))
+                  , (NormStrategy.custom, dict(value=1e3))
+                 ))
 @mark.parametrize("apply_temp", (False, True))
 def test_hits_corrector_valid_normalization_options( correction_map_filename
                                                    , norm_strat
-                                                   , norm_value
                                                    , apply_temp
-                                                   , random_hits_toy_data ):
+                                                   , norm_options
+                                                   , random_hits_toy_data
+                                                   ):
     """
     Test that all valid normalization options work to some
     extent. Here we just check that the values make some sense: not
@@ -550,28 +551,11 @@ def test_hits_corrector_valid_normalization_options( correction_map_filename
 
     hc = random_hits_toy_data
 
-    correct     = hits_corrector(correction_map_filename, apply_temp, norm_strat, value=norm_value)
+    correct     = hits_corrector(correction_map_filename, apply_temp, norm_strat, norm_options=norm_options)
     corrected_e = np.array([h.Ec for h in correct(hc).hits])
 
     assert not np.any(np.isnan(corrected_e) )
     assert     np.all(         corrected_e>0)
-
-
-@mark.parametrize( "norm_strat norm_value".split(),
-                  ( (NormStrategy.kr    ,    0) # 0 doens't count as "not given"
-                  , (NormStrategy.max   ,    0)
-                  , (NormStrategy.mean  ,    0)
-                  , (NormStrategy.kr    ,    1) # any other value must not be given either
-                  , (NormStrategy.max   ,    1)
-                  , (NormStrategy.mean  ,    1)
-                  , (NormStrategy.custom, None) # with custom, `norm_value` must be given ...
-                  , (NormStrategy.custom,    0) # ... but not 0
-                  ))
-def test_hits_corrector_invalid_normalization_options_raises( correction_map_filename
-                                                            , norm_strat
-                                                            , norm_value):
-    with raises(ValueError):
-        hits_corrector(correction_map_filename, False, norm_strat, norm_value)
 
 
 def test_write_city_configuration(config_tmpdir):

--- a/invisible_cities/reco/corrections.py
+++ b/invisible_cities/reco/corrections.py
@@ -228,7 +228,7 @@ def get_normalization_factor(map_e0    : ASectorMap,
     if norm_strat is NormStrategy.max:
         norm_value =  map_e0.e0.max().max()
     elif norm_strat is NormStrategy.mean:
-        norm_value = np.mean(np.mean(map_e0.e0))
+        norm_value = np.nanmean(map_e0.e0.values.flatten())
     elif norm_strat is NormStrategy.kr:
         norm_value = 41.5575 * units.keV
     elif norm_strat is NormStrategy.custom:

--- a/invisible_cities/reco/corrections.py
+++ b/invisible_cities/reco/corrections.py
@@ -91,9 +91,7 @@ def maps_coefficient_getter(mapinfo : Series,
         for a given (X,Y) position
     """
 
-    binsx   = np.linspace(mapinfo.xmin, mapinfo.xmax, mapinfo.nx + 1)
-    binsy   = np.linspace(mapinfo.ymin, mapinfo.ymax, mapinfo.ny + 1)
-
+    binsx, binsy = get_xy_bins(mapinfo)
     def get_maps_coefficient(x : np.array, y : np.array) -> np.array:
         ix = np.digitize(x, binsx) - 1
         iy = np.digitize(y, binsy) - 1
@@ -206,6 +204,12 @@ def get_df_to_z_converter(map_te: ASectorMap) -> Callable:
 def get_normalization_factor(map_e0    : ASectorMap,
                              norm_strat: NormStrategy    = NormStrategy.max,
                              norm_value: Optional[float] = None
+def get_xy_bins(mapinfo):
+    binsx   = np.linspace(mapinfo.xmin, mapinfo.xmax, mapinfo.nx + 1)
+    binsy   = np.linspace(mapinfo.ymin, mapinfo.ymax, mapinfo.ny + 1)
+    return binsx, binsy
+
+
                              ) -> float:
     """
     For given map, it returns a factor that provides the conversion

--- a/invisible_cities/reco/corrections.py
+++ b/invisible_cities/reco/corrections.py
@@ -268,8 +268,8 @@ def get_normalization_factor(map_e0      : ASectorMap,
         norm_value = norm_options["value"]
 
     else:
-        s  = "None of the current available normalization"
-        s += " strategies was selected"
+        s  = "None of the currently available normalization strategies was selected. Valid options:\n"
+        s += " ".join(map(str, NormStrategy))
         raise ValueError(s)
 
     return norm_value

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -255,22 +255,35 @@ def test_get_normalization_factor_custom_norm_raises_exception_when_no_value(map
                   get_normalization_factor,
                   map_e, NormStrategy.custom)
 
-def test_get_normalization_factor_region(correction_map_filename):
+@mark.parametrize("options expected_value".split(),
+                  ( (dict(xrange=(-5, 5), yrange=(-10, 10)), 12653.831477479956)
+                  , (dict(origin=(-5, 5), radius=5        ), 12610.06515076242)
+                  ))
+def test_get_normalization_factor_region(correction_map_filename, options, expected_value):
     map_e  = read_maps(correction_map_filename)
     factor = get_normalization_factor(map_e,
                                       NormStrategy.region,
-                                      xrange=(-5, 5), yrange=(-10, 10))
-    norm   = 12653.831477479956
-    assert np.isclose(factor, norm)
+                                      **options)
+    assert np.isclose(factor, expected_value)
 
-def test_get_normalization_factor_region_invalid_region_raises(correction_map_filename):
+@mark.parametrize("options",
+                  ( dict(xrange=(0.1, 0.11), yrange=(0.20, 0.22))
+                  , dict(origin=(0.1, 0.11), radius=1e-3        )
+                  ))
+def test_get_normalization_factor_region_invalid_region_raises(correction_map_filename, options):
     map_e  = read_maps(correction_map_filename)
     with raises(ValueError):
         get_normalization_factor(map_e,
                                  NormStrategy.region,
-                                 xrange=(0.1, 0.11), yrange=(0.20, 0.22))
+                                 **options)
 
-@mark.parametrize("options", (dict(), dict(xrange=(1,2)), dict(yrange=(1,2))))
+@mark.parametrize("options",
+                  ( dict()
+                  , dict(xrange=(1,2))
+                  , dict(yrange=(1,2))
+                  , dict(origin=(1,2))
+                  , dict(radius=123)
+                  ))
 def test_get_normalization_factor_region_norm_raises_exception_when_no_range(map_filename, options):
     map_e = read_maps(map_filename)
     assert_raises(ValueError,

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -227,12 +227,12 @@ def test_get_normalization_factor_mean_norm(correction_map_filename):
 @few_examples
 @given(floats(min_value = 1,
               max_value = 1e4))
-def test_get_normalization_factor_custom_norm(correction_map_filename, custom_vaule):
+def test_get_normalization_factor_custom_norm(correction_map_filename, custom_value):
     map_e  = read_maps(correction_map_filename)
     factor = get_normalization_factor(map_e,
                                       NormStrategy.custom,
-                                      custom_vaule)
-    norm   = custom_vaule
+                                      value = custom_value)
+    norm   = custom_value
     assert factor == norm
 
 def test_get_normalization_factor_krscale(correction_map_filename):
@@ -326,6 +326,6 @@ def test_corrections_exact(toy_corrections, correction_map_filename):
     get_factor = apply_all_correction(maps       = maps,
                                       apply_temp = True,
                                       norm_strat = NormStrategy.custom,
-                                      norm_value = 1.)
+                                      value      = 1.)
     fac        = get_factor(xs, ys, zs, ts)
     assert_allclose (factor, fac, atol = 1e-13)

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -13,6 +13,8 @@ from . corrections import apply_all_correction_single_maps
 from . corrections import apply_all_correction
 
 from pytest                import fixture
+from pytest                import mark
+from pytest                import raises
 from numpy.testing         import assert_allclose
 from numpy.testing         import assert_array_equal
 from numpy.testing         import assert_raises
@@ -240,6 +242,34 @@ def test_get_normalization_factor_krscale(correction_map_filename):
     factor    = get_normalization_factor(map_e, NormStrategy.kr)
     kr_energy = 41.5575 * units.keV
     assert factor == kr_energy
+
+def test_get_normalization_factor_custom_norm_raises_exception_when_no_value(map_filename):
+    map_e = read_maps(map_filename)
+    assert_raises(ValueError,
+                  get_normalization_factor,
+                  map_e, NormStrategy.custom)
+
+def test_get_normalization_factor_region(correction_map_filename):
+    map_e  = read_maps(correction_map_filename)
+    factor = get_normalization_factor(map_e,
+                                      NormStrategy.region,
+                                      xrange=(-5, 5), yrange=(-10, 10))
+    norm   = 12653.831477479956
+    assert np.isclose(factor, norm)
+
+def test_get_normalization_factor_region_invalid_region_raises(correction_map_filename):
+    map_e  = read_maps(correction_map_filename)
+    with raises(ValueError):
+        get_normalization_factor(map_e,
+                                 NormStrategy.region,
+                                 xrange=(0.1, 0.11), yrange=(0.20, 0.22))
+
+@mark.parametrize("options", (dict(), dict(xrange=(1,2)), dict(yrange=(1,2))))
+def test_get_normalization_factor_region_norm_raises_exception_when_no_range(map_filename, options):
+    map_e = read_maps(map_filename)
+    assert_raises(ValueError,
+                  get_normalization_factor,
+                  map_e, NormStrategy.region, **options)
 
 def test_get_normalization_factor_custom_norm_raises_exception_when_no_value(map_filename):
     map_e = read_maps(map_filename)

--- a/invisible_cities/reco/corrections_test.py
+++ b/invisible_cities/reco/corrections_test.py
@@ -226,6 +226,12 @@ def test_get_normalization_factor_mean_norm(correction_map_filename):
     norm   = np.mean(np.mean(map_e.e0))
     assert factor == norm
 
+def test_get_normalization_factor_median_norm(correction_map_filename):
+    map_e  = read_maps(correction_map_filename)
+    factor = get_normalization_factor(map_e, NormStrategy.median)
+    norm   = np.nanmedian(map_e.e0.values.flatten())
+    assert factor == norm
+
 @few_examples
 @given(floats(min_value = 1,
               max_value = 1e4))

--- a/invisible_cities/types/symbols.py
+++ b/invisible_cities/types/symbols.py
@@ -76,8 +76,10 @@ class MCTableType(AutoNameEnumBase):
 
 class NormStrategy(AutoNameEnumBase):
     mean   = auto()
+    median = auto()
     max    = auto()
     kr     = auto()
+    region = auto()
     custom = auto()
 
 


### PR DESCRIPTION
Update normalization strategies to include more useful options:
- Median: less sensitive to outliers than mean
- Region: use a specific region of the chamber to compute the reference value. It uses the median for the values within the specified region. There are two different ways of specifying such region:
  - xrange + yrange: a rectangle
  - origin + radius: a circle
