### PR TITLE
Add more information to Data{PMT,SiPM} dataframes

### DIFF
--- a/invisible_cities/database/load_db.py
+++ b/invisible_cities/database/load_db.py
@@ -31,7 +31,7 @@ def DataPMT(db_file, run_number=1e5):
 
     sql = '''select pos.SensorID, map.ElecID "ChannelID", Label "PmtID",
 case when msk.SensorID is NULL then 1 else 0 end "Active",
-X, Y, coeff_blr, coeff_c, abs(Centroid) "adc_to_pes", noise_rms, Sigma
+X, Y, coeff_blr, coeff_c, abs(Centroid) "adc_to_pes", ErrorCentroid "adc_to_pes_err", noise_rms, Sigma, ErrorSigma
 from ChannelPosition as pos INNER JOIN ChannelMapping
 as map ON pos.SensorID = map.SensorID LEFT JOIN
 (select * from PmtNoiseRms where MinRun <= {0} and (MaxRun >= {0} or MaxRun is NULL))
@@ -62,7 +62,7 @@ def DataSiPM(db_file, run_number=1e5):
 
     sql='''select pos.SensorID, map.ElecID "ChannelID",
 case when msk.SensorID is NULL then 1 else 0 end "Active",
-X, Y, Centroid "adc_to_pes", Sigma
+X, Y, Centroid "adc_to_pes", ErrorCentroid "adc_to_pes_err", Sigma, ErrorSigma
 from ChannelPosition as pos INNER JOIN ChannelGain as gain
 ON pos.SensorID = gain.SensorID INNER JOIN ChannelMapping as map
 ON pos.SensorID = map.SensorID LEFT JOIN

--- a/invisible_cities/database/load_db_test.py
+++ b/invisible_cities/database/load_db_test.py
@@ -16,7 +16,7 @@ def test_pmts_pd(db):
     """Check that we retrieve the correct number of PMTs."""
     pmts = DB.DataPMT(db.detector)
     columns =['SensorID', 'ChannelID', 'PmtID', 'Active', 'X', 'Y',
-              'coeff_blr', 'coeff_c', 'adc_to_pes', 'noise_rms', 'Sigma']
+              'coeff_blr', 'coeff_c', 'adc_to_pes', 'adc_to_pes_err', 'noise_rms', 'Sigma', 'ErrorSigma']
     assert columns == list(pmts)
     assert pmts['PmtID'].str.startswith('PMT').all()
     assert pmts.shape[0] == db.npmts
@@ -27,7 +27,7 @@ def test_pmts_MC_pd(db):
     mc_run = 0
     pmts = DB.DataPMT(db.detector, mc_run)
     columns =['SensorID', 'ChannelID', 'PmtID', 'Active', 'X', 'Y',
-              'coeff_blr', 'coeff_c', 'adc_to_pes', 'noise_rms', 'Sigma']
+              'coeff_blr', 'coeff_c', 'adc_to_pes', 'adc_to_pes_err', 'noise_rms', 'Sigma', 'ErrorSigma']
     assert columns == list(pmts)
     assert pmts['PmtID'].str.startswith('PMT').all()
     assert pmts.shape[0] == db.npmts
@@ -36,7 +36,7 @@ def test_pmts_MC_pd(db):
 def test_sipm_pd(db):
     """Check that we retrieve the correct number of SiPMs."""
     sipms = DB.DataSiPM(db.detector)
-    columns = ['SensorID', 'ChannelID', 'Active', 'X', 'Y', 'adc_to_pes', 'Sigma']
+    columns = ['SensorID', 'ChannelID', 'Active', 'X', 'Y', 'adc_to_pes', 'adc_to_pes_err', 'Sigma', 'ErrorSigma']
     assert columns == list(sipms)
     assert sipms.shape[0] == db.nsipms
 


### PR DESCRIPTION
This PR extends the information provided by the `DataPMT` and `DataSiPM` functions that load the database. Specifically, it adds the fit error on the centroid (aka `adc_to_pes`) and width (aka `Sigma`) of the corresponding gaussians. The columns are named `adc_to_pes_err` and `ErrorSigma`.