### PR TITLE
Update beersheba config for NEXT-100 dataset

### DIFF
--- a/invisible_cities/config/beersheba.conf
+++ b/invisible_cities/config/beersheba.conf
@@ -6,22 +6,22 @@ event_range = 10
 run_number = 0
 
 # Detector database used
-detector_db = 'new'
+detector_db = 'next100'
 
 # How frequently to print events
 print_mod = 1
 
-threshold = 6 * pes
+threshold = 5 * pes
 same_peak = True
 
 deconv_params = dict(
   q_cut         = 10,
-  drop_dist     = (10., 10.),
-  psf_fname     = '$ICDIR/database/test_data/PSF_dst_sum_collapsed.h5',
-  e_cut         = 1e-3,
+  drop_dist     = (16., 16.),
+  psf_fname     = '$ICDIR/database/test_data/NEXT100_PSF_kr83m.h5',
+  e_cut         = 12e-3,
   n_iterations  = 100,
-  iteration_tol = 0.01,
-  sample_width  = (10., 10.),
+  iteration_tol = 1e-10,
+  sample_width  = (15.55, 15.55),
   bin_size      = ( 1.,  1.),
   energy_type   = Ec,
   diffusion     = (1.0, 1.0),
@@ -37,7 +37,7 @@ deconv_params = dict(
 satellite_params = None
 
 corrections  = dict(
-    filename   = "$ICDIR/database/test_data/kr_emap_xy_100_100_r_6573_time.h5",
+    filename   = "$ICDIR/database/test_data/map_NEXT100_MC.h5",
     apply_temp = False,
     norm_strat = kr,
     apply_z    = True)


### PR DESCRIPTION
The current beersheba config is built around the input data being NEW data, but the file it refers to is in fact NEXT-100 data. This results in a few odd behaviours:

- `drop_isolated_sensors()` drops all the hits, as the `drop_dist (= 10)` < `pitch (= 15.55)` 
- If this is fixed, the hits then occur outwith the accepted `det_grid`, crashing the beersheba interpolation.

This PR resolves this issue by updating the config to match the working config from the [tests](https://github.com/next-exp/IC/blob/master/invisible_cities/conftest.py#L831).