### PR TITLE
Add git information to config file

### DIFF
--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -201,17 +201,27 @@ def create_timestamp(rate: float) -> float:
     return create_timestamp_
 
 
-def fetch_git_info(git_command : str, 
-                   git_parameter : str):
-    """Returns requested Git information, or None if not found."""
+def run_git_command(git_command   : str,
+                    git_parameter : str = ""):
+    """
+    Runs a git command and stores the output.
+    
+    Parameters
+    ----------
+    git_command              : the standard terminal git command the user would input
+    git_parameter (Optional) : a string input to specify what git parameter the user is fetching
+
+    Returns
+    -------
+    The standard git terminal output
+    """
     git_command = git_command.split() # turns the string input into a list of strings
     try:
-        var = subprocess.check_output(git_command, stderr=subprocess.DEVNULL).decode('ascii').strip()
-        if git_parameter == "upstream remote":
-            var = var.split('/')[0]
-        return var
-    except subprocess.CalledProcessError:
-        print(f"Warning: No {git_parameter} found.")
+        git_output = subprocess.run(git_command, text=True, capture_output=True, check=True).stdout.strip()
+        return git_output
+    except subprocess.CalledProcessError as e:
+        print(f"Following error encountered when running: " + ' '.join(git_command))
+        print(e.stderr)
         return None
     except Exception as e:
         print(traceback.format_exc())
@@ -219,10 +229,10 @@ def fetch_git_info(git_command : str,
 
 def add_git_info():
     git_info = dict(
-        IC_tag = fetch_git_info("git describe --tags --exact-match", "git tag"),
-        upstream_name = fetch_git_info("git rev-parse --abbrev-ref @{upstream}", "remote upstream"),
-        branch_name = fetch_git_info("git branch --show-current", "branch"),
-        commit_hash = fetch_git_info("git rev-parse HEAD", "commit hash")
+        IC_tag        = run_git_command("git describe --tags --exact-match", "git tag"),
+        upstream_name = run_git_command("git rev-parse --abbrev-ref @{upstream}", "remote upstream").split('/')[0],
+        branch_name   = run_git_command("git branch --show-current", "branch"),
+        commit_hash   = run_git_command("git rev-parse HEAD", "commit hash")
     )
     return git_info
 

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -201,28 +201,25 @@ def create_timestamp(rate: float) -> float:
     return create_timestamp_
 
 
-def run_git_command(git_command   : str,
-                    git_parameter : str = ""):
+def run_git_command(git_command: str):
     """
     Runs a git command and stores the output.
     
     Parameters
     ----------
-    git_command              : the standard terminal git command the user would input
-    git_parameter (Optional) : a string input to specify what git parameter the user is fetching
+    git_command : the standard terminal git command the user would input
 
     Returns
     -------
-    The standard git terminal output
+    git_output  : the standard git terminal output
     """
-    git_command = git_command.split() # turns the string input into a list of strings
     try:
-        git_output = subprocess.run(git_command, text=True, capture_output=True, check=True).stdout.strip()
+        git_output = subprocess.run(git_command.split(), text=True, capture_output=True, check=True).stdout.strip()
         return git_output
     except subprocess.CalledProcessError as e:
-        print(f"Following error encountered when running: " + ' '.join(git_command))
+        print(f"Following error encountered when running: {git_command}")
         print(e.stderr)
-        return None
+        return "None"
     except Exception as e:
         print(traceback.format_exc())
 

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -226,10 +226,10 @@ def run_git_command(git_command: str):
 
 def add_git_info():
     git_info = dict(
-        IC_tag        = run_git_command("git describe --tags --exact-match", "git tag"),
-        upstream_name = run_git_command("git rev-parse --abbrev-ref @{upstream}", "remote upstream").split('/')[0],
-        branch_name   = run_git_command("git branch --show-current", "branch"),
-        commit_hash   = run_git_command("git rev-parse HEAD", "commit hash")
+        IC_tag        = run_git_command("git describe --tags --exact-match"),
+        upstream_name = run_git_command("git rev-parse --abbrev-ref @{upstream}").split('/')[0],
+        branch_name   = run_git_command("git branch --show-current"),
+        commit_hash   = run_git_command("git rev-parse HEAD")
     )
     return git_info
 

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -138,15 +138,14 @@ def city(city_function):
         conf.files_in = input_files
         conf.file_out = expandvars(conf.file_out)
 
-        conf = add_git_info(conf)
-
         conf.event_range  = event_range(conf)
         # TODO There were deamons! self.daemons = tuple(map(summon_daemon, kwds.get('daemons', [])))
 
         args   = vars(conf)
         result = check_annotations(city_function)(**args)
         if os.path.exists(conf.file_out):
-            write_city_configuration(conf.file_out, city_function.__name__, args)
+            git_info = add_git_info()
+            write_city_configuration(conf.file_out, city_function.__name__, {**args, **git_info})
             copy_cities_configuration(conf.files_in[0], conf.file_out)
             index_tables(conf.file_out)
         return result
@@ -265,12 +264,14 @@ def get_git_commit_hash() -> str:
         print(traceback.format_exc())
 
 
-def add_git_info(conf):
-    conf.tag = get_git_tag()
-    conf.upstream = get_git_upstream_remote()
-    conf.branch = get_git_branch()
-    conf.hash = get_git_commit_hash()
-    return conf
+def add_git_info():
+    git_info = dict(
+        IC_tag = get_git_tag(),
+        upstream_name = get_git_upstream_remote(),
+        branch_name = get_git_branch(),
+        commit_hash = get_git_commit_hash()
+    )
+    return git_info
 
 
 def index_tables(file_out):


### PR DESCRIPTION
This PR addresses #945 by including Git information into city config files. A function `add_git_info(conf)` is introduced, which adds information about the IC tag, upstream remote name, branch name and commit hash to the city config file.