### PR TITLE
Rewrite paolina using DataFrames

### DIFF
--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -608,7 +608,8 @@ def pmap_from_files(paths):
 @check_annotations
 def hits_and_kdst_from_files( paths : List[str]
                             , group : str
-                            , node  : str ) -> Iterator[Dict[str,Union[HitCollection, pd.DataFrame, MCInfo, int, float]]]:
+                            , node  : str
+                            ) -> Iterator[Dict[str,Union[ pd.DataFrame , pd.DataFrame , MCInfo, int, float]]]:
     """
     Reader of hits files. For each event it produces a dictionary containing
     - hits        : a DataFrame
@@ -696,9 +697,8 @@ def MC_hits_from_files(files_in : List[str], rate: float) -> Generator:
 
 
 @check_annotations
-def dhits_from_files(paths: List[str]) -> Iterator[Dict[str,Union[HitCollection, pd.DataFrame, MCInfo, int, float]]]:
-    """Reader of the files, yields HitsCollection, pandas DataFrame with
-    run_number, event_number and timestamp."""
+def dhits_from_files(paths: List[str]) -> Iterator[Dict[str, Union[pd.DataFrame, pd.DataFrame, MCInfo, int, float]]]:
+    """Reader of the files, yields a hits dataframe, a kdst, run_number, event_number and timestamp."""
     for path in paths:
         try:
             dhits_df = load_dst (path, 'DECO', 'Events')
@@ -1372,8 +1372,8 @@ def make_event_summary(event_number  : int         ,
     topology_info : DataFrame
         Dataframe containing track information,
         output of track_blob_info_creator_extractor
-    paolina_hits  : HitCollection
-        Hits table passed through paolina functions,
+    paolina_hits  : pd.DataFrame
+        Hits passed through paolina functions,
         output of track_blob_info_creator_extractor
     kdst          : DataFrame
         Kdst information read from sophronia output
@@ -1446,7 +1446,8 @@ def track_blob_info_creator_extractor(vox_size         : Tuple[float, float, flo
                                       max_num_hits     : int
                                      ) -> Callable:
     """
-    For a given paolina parameters returns a function that extract tracks / blob information from a HitCollection.
+    For a given set of paolina parameters returns a function that extract tracks / blob
+    information from a set of hits.
 
     Parameters
     ----------
@@ -1465,9 +1466,12 @@ def track_blob_info_creator_extractor(vox_size         : Tuple[float, float, flo
 
     Returns
     ----------
-    A function that from a given HitCollection returns a pandas DataFrame with per track information.
+    A function that from a given set of hits returns
+      - general track information dataframe
+      - hits with associated track ids
+      - flag to indicate whether there are hits outside of the correction-map domain
     """
-    def create_extract_track_blob_info(hits):
+    def create_extract_track_blob_info(hits: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame, bool]:
         df = pd.DataFrame(columns=list(types_dict_tracks.keys()))
         hits = hits.assign(track_id=-1)
         if len(hits) > max_num_hits:
@@ -1650,7 +1654,7 @@ def hits_thresholder(threshold_charge : float, same_peak : bool ) -> Callable:
 
     Returns
     ----------
-    A function that takes HitCollection as input and returns another object with
+    A function that takes a set of hits as input and returns another object with
     only non NN hits of charge above threshold_charge.
     The energy of NN hits is redistributed among neighbors.
     """
@@ -1683,8 +1687,8 @@ def hits_corrector( filename     : str
 
     Returns
     ----------
-    A function that takes a HitCollection as input and returns
-    the same object with modified Ec and Z fields.
+    A function that takes a set of hits as input and returns another one with Ec
+    and Z fields assigned. Input data is not modified.
     """
     maps      = read_maps(os.path.expandvars(filename))
     get_coef  = apply_all_correction( maps

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -1349,19 +1349,9 @@ def calculate_and_save_buffers(buffer_length    : float        ,
 
 @check_annotations
 def Efield_copier(energy_type: HitEnergy):
-    def copy_Efield(hitc : HitCollection) -> HitCollection:
-        mod_hits = []
-        for hit in hitc.hits:
-            hit = Hit(hit.npeak,
-                      Cluster(hit.Q, xy(hit.X, hit.Y), hit.var, hit.nsipm),
-                      hit.Z,
-                      hit.E,
-                      xy(hit.Xpeak, hit.Ypeak),
-                      s2_energy_c=getattr(hit, energy_type.value),
-                      Ep=getattr(hit, energy_type.value))
-            mod_hits.append(hit)
-        mod_hitc = HitCollection(hitc.event, hitc.time, hits=mod_hits)
-        return mod_hitc
+    def copy_Efield(df: pd.DataFrame) -> pd.DataFrame:
+        return df.assign( Ec = df[energy_type.value]
+                        , Ep = df[energy_type.value])
     return copy_Efield
 
 
@@ -1582,7 +1572,7 @@ def hitc_to_df(hitc: HitCollection):
                                      , track_id = hit .track_id
                                      , Ep       = hit .Ep), index=[0]))
     df = pd.concat(hits, ignore_index=True)
-    df = df.astype(dict(event=np.int64, npeak=np.uint16, Ec=np.float64, Ep=np.float64))
+    df = df.astype(dict(event=np.int64, npeak=np.uint16, Ec=np.float64, track_id=np.int64, Ep=np.float64))
     return df
 
 
@@ -1600,7 +1590,7 @@ def compute_and_write_tracks_info(paolina_params, h5out,
                                   hit_type, filter_hits_table_name,
                                   hits_writer):
 
-    to_hitc            = fl.map(hitc_from_df, item="hits")
+    to_hitc            = fl.map(hitc_from_df, item="Ep_hits")
 
     filter_events_nohits = fl.map(lambda x : len(x) > 0,
                                       args = 'hits',
@@ -1652,8 +1642,8 @@ def compute_and_write_tracks_info(paolina_params, h5out,
     return pipe( filter_events_nohits
                , fl.branch(write_no_hits_filter)
                , hits_passed.filter
-               , to_hitc
                , copy_Efield
+               , to_hitc
                , create_extract_track_blob_info
                , sort_hits_
                , filter_events_topology

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -1548,27 +1548,6 @@ def sort_hits(hits):
     return hits.sort_values("Z X Y".split())
 
 
-def hitc_to_df(hitc: HitCollection):
-    hits = []
-    for hit in hitc.hits:
-        hits.append(pd.DataFrame(dict( event    = hitc.event
-                                     , time     = hitc.time
-                                     , npeak    = hit .npeak
-                                     , Xpeak    = hit .Xpeak
-                                     , Ypeak    = hit .Ypeak
-                                     , X        = hit .X
-                                     , Y        = hit .Y
-                                     , Z        = hit .Z
-                                     , Q        = hit .Q
-                                     , E        = hit .E
-                                     , Ec       = hit .Ec
-                                     , track_id = hit .track_id
-                                     , Ep       = hit .Ep), index=[0]))
-    df = pd.concat(hits, ignore_index=True)
-    df = df.astype(dict(event=np.int64, npeak=np.uint16, Ec=np.float64, track_id=np.int64, Ep=np.float64))
-    return df
-
-
 def compute_and_write_tracks_info(paolina_params, h5out,
                                   hit_type, filter_hits_table_name,
                                   hits_writer):

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -718,15 +718,15 @@ def dhits_from_files(paths: List[str]) -> Iterator[Dict[str,Union[HitCollection,
             for evt in dhits_df.event.unique():
                 this_event = lambda df: df.event==evt
                 timestamp = event_info[event_info.evt_number==evt].timestamp.values[0]
-                dhits = hits_from_df(dhits_df.loc[this_event])
-                kdst  =               kdst_df.loc[this_event] if isinstance(kdst_df, pd.DataFrame) \
+                dhits = dhits_df.loc[this_event]
+                kdst  =  kdst_df.loc[this_event] if isinstance(kdst_df, pd.DataFrame) \
                                                               else None
                 ### It makes no sense to use the 'io.hits_io.hits_from_df' function here
                 ### (as well as in 'hits_and_kdst_from_files') since the majority of the
                 ### 'evm.Hit' parameters don't appear in the dst (particularly running
                 ### Isaura) and must be set to -1. This proceure should be revisited and
                 ### rethought in the near future, with the aim of changing the event model.
-                yield dict(hits         = dhits[evt],
+                yield dict(hits         = dhits,
                            kdst         = kdst      ,
                            run_number   = run_number,
                            event_number = evt       ,
@@ -1586,9 +1586,21 @@ def hitc_to_df(hitc: HitCollection):
     return df
 
 
+# Temporary
+def hitc_from_df(hits : pd.DataFrame) -> HitCollection:
+    hitcs = hits_from_df(hits)
+    if len(hitcs) == 0:
+        return HitCollection(0, 0, []) # dummy HitCollection
+    assert len(hitcs) == 1
+    for hitc in hitcs.values():
+        return hitc
+
+
 def compute_and_write_tracks_info(paolina_params, h5out,
                                   hit_type, filter_hits_table_name,
                                   hits_writer):
+
+    to_hitc            = fl.map(hitc_from_df, item="hits")
 
     filter_events_nohits = fl.map(lambda x : len(x.hits) > 0,
                                       args = 'hits',
@@ -1637,7 +1649,8 @@ def compute_and_write_tracks_info(paolina_params, h5out,
                               , write_hits
                               , select_and_write_tracks))
 
-    return pipe( filter_events_nohits
+    return pipe( to_hitc
+               , filter_events_nohits
                , fl.branch(write_no_hits_filter)
                , hits_passed.filter
                , copy_Efield

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -724,7 +724,10 @@ def dhits_from_files(paths: List[str]) -> Iterator[Dict[str,Union[HitCollection,
 
                 # this are just patches, the hit architecture should be reviseted
                 dhits = dhits.assign(Q=dhits.E)
-                dhits = dhits.loc[:, "event time npeak Xpeak Ypeak X Y Z Q E Ec track_id Ep".split()]
+                if "Xpeak" in dhits:
+                    dhits = dhits.loc[:, "event time npeak Xpeak Ypeak X Y Z Q E Ec track_id Ep".split()]
+                else:
+                    dhits = dhits.loc[:, "event npeak X Y Z Q E".split()]
                 yield dict(hits         = dhits,
                            kdst         = kdst      ,
                            run_number   = run_number,
@@ -1607,7 +1610,9 @@ def compute_and_write_tracks_info(paolina_params, h5out,
     select_and_write_tracks = events_passed_topology.filter, write_tracks
 
     def change_type(df):
-        return df.astype(dict(Xpeak=float, Ypeak=float))
+        if "Xpeak" in df:
+            return df.astype(dict(Xpeak=float, Ypeak=float))
+        return df
 
     write_hits = ("paolina_hits", fl.map(change_type), fl.sink(hits_writer))
 

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -721,11 +721,10 @@ def dhits_from_files(paths: List[str]) -> Iterator[Dict[str,Union[HitCollection,
                 dhits = dhits_df.loc[this_event]
                 kdst  =  kdst_df.loc[this_event] if isinstance(kdst_df, pd.DataFrame) \
                                                               else None
-                ### It makes no sense to use the 'io.hits_io.hits_from_df' function here
-                ### (as well as in 'hits_and_kdst_from_files') since the majority of the
-                ### 'evm.Hit' parameters don't appear in the dst (particularly running
-                ### Isaura) and must be set to -1. This proceure should be revisited and
-                ### rethought in the near future, with the aim of changing the event model.
+
+                # this are just patches, the hit architecture should be reviseted
+                dhits = dhits.assign(Q=dhits.E)
+                dhits = dhits.loc[:, "event time npeak Xpeak Ypeak X Y Z Q E Ec track_id Ep".split()]
                 yield dict(hits         = dhits,
                            kdst         = kdst      ,
                            run_number   = run_number,
@@ -1619,7 +1618,10 @@ def compute_and_write_tracks_info(paolina_params, h5out,
     make_and_write_summary  = make_final_summary, write_summary
     select_and_write_tracks = events_passed_topology.filter, write_tracks
 
-    write_hits = ("paolina_hits", fl.sink(hits_writer))
+    def change_type(df):
+        return df.astype(dict(Xpeak=float, Ypeak=float))
+
+    write_hits = ("paolina_hits", fl.map(change_type), fl.sink(hits_writer))
 
     fork_pipes = filter(None, ( make_and_write_summary
                               , write_topology_filter

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -1356,9 +1356,9 @@ def Efield_copier(energy_type: HitEnergy):
 
 
 @check_annotations
-def make_event_summary(event_number  : int          ,
-                       topology_info : pd.DataFrame ,
-                       paolina_hits  : HitCollection,
+def make_event_summary(event_number  : int         ,
+                       topology_info : pd.DataFrame,
+                       hits          : pd.DataFrame,
                        out_of_map    : bool
                        ) -> pd.DataFrame:
     """
@@ -1383,26 +1383,22 @@ def make_event_summary(event_number  : int          ,
     DataFrame containing relevant per event information.
     """
     es = pd.DataFrame(columns=list(types_dict_summary.keys()))
-    if len(paolina_hits.hits) == 0: return es
+    if hits.empty: return es
 
     ntrks = len(topology_info.index)
-    nhits = len(paolina_hits.hits)
+    nhits = len(hits)
 
-    S2ec = sum(h.Ec for h in paolina_hits.hits)
+    S2ec = hits.Ec.sum()
     S2qc = -1 #not implemented yet
 
-    pos   = [h.pos for h in paolina_hits.hits]
-    x, y, z = map(np.array, zip(*pos))
-    r = np.sqrt(x**2 + y**2)
-
-    e     = [h.Ec  for h in paolina_hits.hits]
-    ave_pos = np.average(pos, weights=e, axis=0)
-    ave_r   = np.average(r  , weights=e, axis=0)
-
+    r       = np.sqrt(hits.X**2 + hits.Y**2)
+    ave_pos = np.average(hits["X Y Z".split()], weights=hits.Ec, axis=0)
+    ave_r   = np.average(r                    , weights=hits.Ec, axis=0)
 
     list_of_vars  = [event_number, S2ec, S2qc, ntrks, nhits,
                      *ave_pos, ave_r,
-                     min(x), min(y), min(z), min(r), max(x), max(y), max(z), max(r),
+                     hits.X.min(), hits.Y.min(), hits.Z.min(), r.min(),
+                     hits.X.max(), hits.Y.max(), hits.Z.max(), r.max(),
                      out_of_map]
 
     es.loc[0] = list_of_vars
@@ -1470,89 +1466,81 @@ def track_blob_info_creator_extractor(vox_size         : Tuple[float, float, flo
     ----------
     A function that from a given HitCollection returns a pandas DataFrame with per track information.
     """
-    def create_extract_track_blob_info(hitc):
+    def create_extract_track_blob_info(hits):
         df = pd.DataFrame(columns=list(types_dict_tracks.keys()))
-        if len(hitc.hits) > max_num_hits:
-            return df, hitc, True
-        plf.round_hits_positions_in_place(hitc.hits)
-        #track_hits is a new Hitcollection object that contains hits belonging to tracks, and hits that couldnt be corrected
-        track_hitc = HitCollection(hitc.event, hitc.time)
-        out_of_map = np.any(np.isnan([h.Ep for h in hitc.hits]))
-        if out_of_map:
-            #add nan hits to track_hits, the track_id will be -1
-            track_hitc.hits.extend  ([h for h in hitc.hits if np.isnan   (h.Ep)])
-            hits_without_nan       = [h for h in hitc.hits if np.isfinite(h.Ep)]
-            #create new Hitcollection object but keep the name hitc
-            hitc      = HitCollection(hitc.event, hitc.time)
-            hitc.hits = hits_without_nan
+        hits = hits.assign(track_id=-1)
+        if len(hits) > max_num_hits:
+            return df, hits, True
+        plf.round_hits_positions_in_place(hits, 5)
 
-        hit_energies = np.array([getattr(h, HitEnergy.Ep.value) for h in hitc.hits])
+        event      = int(hits.event.iloc[0])
+        out_of_map = hits.Ep.isna().values
+        hits_out   = hits.loc[ out_of_map]
+        hits       = hits.loc[~out_of_map]
+        if not len(hits) or not (hits.Ep>0).any():
+            return df, hits, out_of_map.any()
 
-        if len(hitc.hits) > 0 and (hit_energies>0).any():
-            voxels           = plf.voxelize_hits(hitc.hits, vox_size, strict_vox_size, HitEnergy.Ep)
-            (    mod_voxels,
-             dropped_voxels) = plf.drop_end_point_voxels(voxels, energy_threshold, min_voxels)
+        voxels            = plf.voxelize_hits(hits, vox_size, strict_vox_size, HitEnergy.Ep)
+        ( mod_voxels,
+          dropped_voxels) = plf.drop_end_point_voxels(voxels, energy_threshold, min_voxels)
 
-            for v in dropped_voxels:
-                track_hitc.hits.extend(v.hits)
+        tracks = plf.make_track_graphs(mod_voxels)
+        tracks = sorted(tracks, key=plf.get_track_energy, reverse=True)
 
-            tracks = plf.make_track_graphs(mod_voxels)
-            tracks = sorted(tracks, key=plf.get_track_energy, reverse=True)
+        vox_size_x = voxels[0].size[0]
+        vox_size_y = voxels[0].size[1]
+        vox_size_z = voxels[0].size[2]
+        del(voxels)
 
-            vox_size_x = voxels[0].size[0]
-            vox_size_y = voxels[0].size[1]
-            vox_size_z = voxels[0].size[2]
-            del(voxels)
+        track_hits = [v.hits for v in dropped_voxels]
+        for c, t in enumerate(tracks, 0):
+            tID = c
+            energy = plf.get_track_energy(t)
+            numb_of_hits   = sum(len(v.hits) for v in t.nodes())
+            numb_of_voxels = len(t.nodes())
+            numb_of_tracks = len(tracks   )
+            hits_from_track = ( pd.concat([v.hits for v in t.nodes()], ignore_index=True)
+                                  .assign(R = lambda df: np.sqrt(df.X**2 + df.Y**2))
+                              )
 
-            track_hits = []
-            for c, t in enumerate(tracks, 0):
-                tID = c
-                energy = plf.get_track_energy(t)
-                numb_of_hits   = len([h for vox in t.nodes() for h in vox.hits])
-                numb_of_voxels = len(t.nodes())
-                numb_of_tracks = len(tracks   )
-                pos   = [h.pos for v in t.nodes() for h in v.hits]
-                x, y, z = map(np.array, zip(*pos))
-                r = np.sqrt(x**2 + y**2)
+            ave_pos = np.average(hits_from_track["X Y Z".split()], weights=hits_from_track.Ep, axis=0)
+            ave_r   = np.average(hits_from_track.R               , weights=hits_from_track.Ep, axis=0)
+            distances = plf.shortest_paths(t)
+            extr1, extr2, length = plf.find_extrema_and_length(distances)
+            extr1_pos = extr1.XYZ
+            extr2_pos = extr2.XYZ
 
-                e     = [h.Ep for v in t.nodes() for h in v.hits]
-                ave_pos = np.average(pos, weights=e, axis=0)
-                ave_r   = np.average(r  , weights=e, axis=0)
-                distances = plf.shortest_paths(t)
-                extr1, extr2, length = plf.find_extrema_and_length(distances)
-                extr1_pos = extr1.XYZ
-                extr2_pos = extr2.XYZ
+            e_blob1, e_blob2, hits_blob1, hits_blob2, blob_pos1, blob_pos2 = plf.blob_energies_hits_and_centres(t, blob_radius)
 
-                e_blob1, e_blob2, hits_blob1, hits_blob2, blob_pos1, blob_pos2 = plf.blob_energies_hits_and_centres(t, blob_radius)
+            common_hits = hits_blob1.merge(hits_blob2, how="inner")
+            overlap     = common_hits.Ep.sum()
+            list_of_vars = [event, tID, energy, length, numb_of_voxels,
+                            numb_of_hits, numb_of_tracks,
+                            hits_from_track.X.min(), hits_from_track.Y.min(), hits_from_track.Z.min(), hits_from_track.R.min(),
+                            hits_from_track.X.max(), hits_from_track.Y.max(), hits_from_track.Z.max(), hits_from_track.R.max(),
+                            *ave_pos, ave_r, *extr1_pos,
+                            *extr2_pos, *blob_pos1, *blob_pos2,
+                            e_blob1, e_blob2, overlap,
+                            vox_size_x, vox_size_y, vox_size_z]
 
-                overlap = float(sum(h.Ep for h in set(hits_blob1).intersection(set(hits_blob2))))
-                list_of_vars = [hitc.event, tID, energy, length, numb_of_voxels,
-                                numb_of_hits, numb_of_tracks,
-                                min(x), min(y), min(z), min(r), max(x), max(y), max(z), max(r),
-                                *ave_pos, ave_r, *extr1_pos,
-                                *extr2_pos, *blob_pos1, *blob_pos2,
-                                e_blob1, e_blob2, overlap,
-                                vox_size_x, vox_size_y, vox_size_z]
+            df.loc[c] = list_of_vars
 
-                df.loc[c] = list_of_vars
+            for vox in t.nodes():
+                vox.hits.loc[:, "track_id"] = tID
+                track_hits.append(vox.hits)
 
-                for vox in t.nodes():
-                    for hit in vox.hits:
-                        hit.track_id = tID
-                        track_hits.append(hit)
-
-            #change dtype of columns to match type of variables
-            df = df.apply(lambda x : x.astype(types_dict_tracks[x.name]))
-            track_hitc.hits.extend(track_hits)
-        return df, track_hitc, out_of_map
+        #change dtype of columns to match type of variables
+        df = df.apply(lambda x : x.astype(types_dict_tracks[x.name]))
+        track_hits = ( pd.concat([hits_out] + track_hits, ignore_index=True)
+                         .astype(dict(event=int, npeak=np.uint16, track_id=int))
+                     )
+        return df, track_hits, out_of_map.any()
 
     return create_extract_track_blob_info
 
 
-def sort_hits(hitc):
-    # sort hits in z, then in x, then in y
-    sorted_hits = sorted(hitc.hits, key=lambda h: (h.Z, h.X, h.Y))
-    return HitCollection(hitc.event, hitc.time, sorted_hits)
+def sort_hits(hits):
+    return hits.sort_values("Z X Y".split())
 
 
 def hitc_to_df(hitc: HitCollection):
@@ -1631,8 +1619,7 @@ def compute_and_write_tracks_info(paolina_params, h5out,
     make_and_write_summary  = make_final_summary, write_summary
     select_and_write_tracks = events_passed_topology.filter, write_tracks
 
-    to_hits_df = fl.map(hitc_to_df)
-    write_hits = ("paolina_hits", to_hits_df, fl.sink(hits_writer))
+    write_hits = ("paolina_hits", fl.sink(hits_writer))
 
     fork_pipes = filter(None, ( make_and_write_summary
                               , write_topology_filter
@@ -1643,7 +1630,6 @@ def compute_and_write_tracks_info(paolina_params, h5out,
                , fl.branch(write_no_hits_filter)
                , hits_passed.filter
                , copy_Efield
-               , to_hitc
                , create_extract_track_blob_info
                , sort_hits_
                , filter_events_topology

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -697,8 +697,17 @@ def MC_hits_from_files(files_in : List[str], rate: float) -> Generator:
 
 
 @check_annotations
-def dhits_from_files(paths: List[str]) -> Iterator[Dict[str, Union[pd.DataFrame, pd.DataFrame, MCInfo, int, float]]]:
-    """Reader of the files, yields a hits dataframe, a kdst, run_number, event_number and timestamp."""
+def dhits_from_files(paths: List[str]) -> Iterator[Dict[str, Union[ pd.DataFrame # hits
+                                                                  , pd.DataFrame # kdst
+                                                                  , int          # run number
+                                                                  , int          # event number
+                                                                  , float        # timestamp
+                                                                  ]]]:
+    """
+    Reader for the output of beersheba (a.k.a. deconvolved hits).
+    For each event, it produces a dictionary with hits, a kdst, run_number,
+    event_number and timestamp.
+    """
     for path in paths:
         try:
             dhits_df = load_dst (path, 'DECO', 'Events')

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -6,6 +6,8 @@ from glob            import glob
 from os.path         import expandvars
 from itertools       import count
 from itertools       import repeat
+from warnings        import warn
+
 from typing          import Callable
 from typing          import Iterator
 from typing          import Mapping
@@ -1484,6 +1486,9 @@ def track_blob_info_creator_extractor(vox_size         : Tuple[float, float, flo
         df = pd.DataFrame(columns=list(types_dict_tracks.keys()))
         hits = hits.assign(track_id=-1)
         if len(hits) > max_num_hits:
+            event = hits.event.iloc[0]
+            warn("Event {event} has too many hits ({len(hits)})."
+                 " This event will not be processed.")
             return df, hits, True
         plf.round_hits_positions_in_place(hits, 5)
 

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -1563,21 +1563,9 @@ def hitc_to_df(hitc: HitCollection):
     return df
 
 
-# Temporary
-def hitc_from_df(hits : pd.DataFrame) -> HitCollection:
-    hitcs = hits_from_df(hits)
-    if len(hitcs) == 0:
-        return HitCollection(0, 0, []) # dummy HitCollection
-    assert len(hitcs) == 1
-    for hitc in hitcs.values():
-        return hitc
-
-
 def compute_and_write_tracks_info(paolina_params, h5out,
                                   hit_type, filter_hits_table_name,
                                   hits_writer):
-
-    to_hitc            = fl.map(hitc_from_df, item="Ep_hits")
 
     filter_events_nohits = fl.map(lambda x : len(x) > 0,
                                       args = 'hits',

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -66,7 +66,6 @@ from .. database                  import                   load_db
 from .. sierpe                    import                       blr
 from .. io                        import                 mcinfo_io
 from .. io     .pmaps_io          import                load_pmaps
-from .. io     .hits_io           import              hits_from_df
 from .. io     .dst_io            import                  load_dst
 from .. io     .event_filter_io   import       event_filter_writer
 from .. io     .pmaps_io          import               pmap_writer

--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -1602,7 +1602,7 @@ def compute_and_write_tracks_info(paolina_params, h5out,
 
     to_hitc            = fl.map(hitc_from_df, item="hits")
 
-    filter_events_nohits = fl.map(lambda x : len(x.hits) > 0,
+    filter_events_nohits = fl.map(lambda x : len(x) > 0,
                                       args = 'hits',
                                       out  = 'hits_passed')
     hits_passed          = fl.count_filter(bool, args="hits_passed")
@@ -1649,10 +1649,10 @@ def compute_and_write_tracks_info(paolina_params, h5out,
                               , write_hits
                               , select_and_write_tracks))
 
-    return pipe( to_hitc
-               , filter_events_nohits
+    return pipe( filter_events_nohits
                , fl.branch(write_no_hits_filter)
                , hits_passed.filter
+               , to_hitc
                , copy_Efield
                , create_extract_track_blob_info
                , sort_hits_

--- a/invisible_cities/cities/esmeralda.py
+++ b/invisible_cities/cities/esmeralda.py
@@ -53,7 +53,6 @@ from .  components import hits_thresholder
 from .  components import compute_and_write_tracks_info
 
 from .. io.         hits_io import hits_writer as hits_writer_
-from .. io.         hits_io import hits_from_df
 from .. io.         kdst_io import kdst_from_df_writer
 from .. io.run_and_event_io import run_and_event_writer
 
@@ -65,16 +64,6 @@ def hit_dropper(radius : float):
         return hits.loc[r2 < max_r2].reset_index(drop=True)
 
     return drop_hits
-
-# Temporary
-def hitc_from_df(hits : pd.DataFrame) -> evm.HitCollection:
-    hitcs = hits_from_df(hits)
-    if len(hitcs) == 0:
-        return evm.HitCollection(0, 0, []) # dummy HitCollection
-    assert len(hitcs) == 1
-    for hitc in hitcs.values():
-        return hitc
-
 
 @city
 def esmeralda( files_in         : OneOrManyFiles
@@ -160,7 +149,6 @@ def esmeralda( files_in         : OneOrManyFiles
     correct_hits       = fl.map(correct_hits, item="hits")
     drop_external_hits = fl.map(hit_dropper(fiducial_r), item="hits")
     threshold_hits     = fl.map(hits_thresholder(threshold, same_peak), item="hits")
-    to_hitc            = fl.map(hitc_from_df, item="hits")
     event_count_in     = fl.spy_count()
     event_count_out    = fl.count()
 
@@ -191,7 +179,6 @@ def esmeralda( files_in         : OneOrManyFiles
                                    , correct_hits
                                    , drop_external_hits
                                    , threshold_hits
-                                   , to_hitc
                                    , fl.fork( compute_tracks
                                             , write_kdst
                                             , write_event_info

--- a/invisible_cities/core/testing_utils.py
+++ b/invisible_cities/core/testing_utils.py
@@ -6,10 +6,11 @@ from pytest                 import approx
 from pytest                 import mark
 from numpy.testing          import assert_equal
 from numpy.testing          import assert_allclose
+from hypothesis             import given
+from hypothesis             import settings
 from hypothesis.strategies  import integers
 from hypothesis.strategies  import floats
 from hypothesis.extra.numpy import arrays
-
 from . core_functions import relative_difference
 
 
@@ -207,6 +208,13 @@ def assert_hit_equality(a_hit, b_hit):
     assert a_hit.Ypeak        == approx (b_hit.Ypeak      )
     assert a_hit.peak_number  == exactly(b_hit.peak_number)
 
+
+def an_instance_of(*given_args, **given_kwargs):
+    def the_test(f):
+        f = given(*given_args, **given_kwargs)(f)
+        f = settings(max_examples=1)(f)
+        return f
+    return the_test
 
 @dataclass(frozen=True)
 class ignore_warning:

--- a/invisible_cities/evm/event_model.py
+++ b/invisible_cities/evm/event_model.py
@@ -2,6 +2,7 @@
 
 import tables as tb
 import numpy  as np
+import pandas as pd
 
 from .. types.ic_types import NN
 from .. types.ic_types import xy
@@ -101,7 +102,7 @@ class Voxel(BHit):
     def size(self): return self._size
 
     @property
-    def Ehits(self): return sum(getattr(h, self.e_type) for h in self.hits)
+    def Ehits(self): return self.hits[self.e_type].sum()
 
     @property
     def Etype(self): return self.e_type
@@ -202,12 +203,12 @@ class VoxelCollection:
 class Blob:
     """A Blob is a collection of Hits with a seed and a radius. """
     def __init__(self, seed: Tuple[float, float, float],
-                       hits : List[BHit],
+                       hits : pd.DataFrame,
                        radius : float,
                        e_type : HitEnergy = HitEnergy.E) ->None:
         self.seed   = seed
         self.hits   = hits
-        self.E      = sum(getattr(h, e_type.value) for h in hits)
+        self.E      = hits[e_type.value].sum()
         self.radius = radius
         self.e_type = e_type.value
 

--- a/invisible_cities/io/hits_io.py
+++ b/invisible_cities/io/hits_io.py
@@ -44,6 +44,7 @@ def hits_from_df (dst : pd.DataFrame, skip_NN : bool = False) -> Dict[int, HitCo
             Ypeak   = getattr(row, 'Ypeak'   , -1000)     # for backwards compatibility
             Ec      = getattr(row, 'Ec'      , -1   )     # for backwards compatibility
             trackID = getattr(row, 'track_id', -1   )     # for backwards compatibility
+            Ep      = getattr(row, 'Ep'      , -1.  )     # for backwards compatibility
 
             hit = Hit(row.npeak            ,
                       Cluster(Q               ,
@@ -58,6 +59,7 @@ def hits_from_df (dst : pd.DataFrame, skip_NN : bool = False) -> Dict[int, HitCo
                       xy(Xpeak, Ypeak)     ,
                       s2_energy_c = Ec     ,
                       track_id    = trackID,
+                      Ep          = Ep
                       )
 
             hits.append(hit)

--- a/invisible_cities/museum/penthesilea/penthesilea.py
+++ b/invisible_cities/museum/penthesilea/penthesilea.py
@@ -51,7 +51,27 @@ from .  components import       pmap_from_files
 from .  components import           hit_builder
 from .  components import               collect
 from .  components import build_pointlike_event as build_pointlike_event_
-from .  components import            hitc_to_df
+
+
+def hitc_to_df(hitc: HitCollection):
+    hits = []
+    for hit in hitc.hits:
+        hits.append(pd.DataFrame(dict( event    = hitc.event
+                                     , time     = hitc.time
+                                     , npeak    = hit .npeak
+                                     , Xpeak    = hit .Xpeak
+                                     , Ypeak    = hit .Ypeak
+                                     , X        = hit .X
+                                     , Y        = hit .Y
+                                     , Z        = hit .Z
+                                     , Q        = hit .Q
+                                     , E        = hit .E
+                                     , Ec       = hit .Ec
+                                     , track_id = hit .track_id
+                                     , Ep       = hit .Ep), index=[0]))
+    df = pd.concat(hits, ignore_index=True)
+    df = df.astype(dict(event=np.int64, npeak=np.uint16, Ec=np.float64, track_id=np.int64, Ep=np.float64))
+    return df
 
 
 @city

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -4,6 +4,7 @@ from itertools   import combinations
 import copy
 
 import numpy    as np
+import pandas   as pd
 import networkx as nx
 
 from networkx           import Graph
@@ -23,14 +24,10 @@ from typing import List
 from typing import Tuple
 from typing import Dict
 
-MAX3D = np.array([float(' inf')] * 3)
-MIN3D = np.array([float('-inf')] * 3)
-
-def bounding_box(seq : BHit) -> Sequence[np.ndarray]:
+def bounding_box(hits: pd.DataFrame) -> Tuple[np.ndarray, np.ndarray]:
     """Returns two arrays defining the coordinates of a box that bounds the voxels"""
-    posns = [x.pos for x in seq]
-    return (reduce(np.minimum, posns, MAX3D),
-            reduce(np.maximum, posns, MIN3D))
+    xyz = hits["X Y Z".split()].values
+    return xyz.min(axis=0), xyz.max(axis=0)
 
 def round_hits_positions_in_place(hits, decimals=5):
     """
@@ -38,25 +35,28 @@ def round_hits_positions_in_place(hits, decimals=5):
     comparison issues. The operation is performed inplace to avoid an
     unnecessary copy.
     """
-    for hit in hits:
-        hit.xyz = np.round(hit.xyz, decimals)
+    hits.loc[:, "X Y Z".split()] = np.round(hits.loc[:, "X Y Z".split()], decimals)
 
-def voxelize_hits(hits             : Sequence[BHit],
+def voxelize_hits(hits             : pd.DataFrame,
                   voxel_dimensions : np.ndarray,
                   strict_voxel_size: bool = False,
                   energy_type      : HitEnergy = HitEnergy.E) -> List[Voxel]:
     # 1. Find bounding box of all hits.
     # 2. Allocate hits to regular sub-boxes within bounding box, using histogramdd.
     # 3. Calculate voxel energies by summing energies of hits within each sub-box.
-    if not hits:
+    if hits.empty:
         raise NoHits
+
     hlo, hhi = bounding_box(hits)
     bounding_box_centre = (hhi + hlo) / 2
     bounding_box_size   =  hhi - hlo
+
     number_of_voxels = np.ceil(bounding_box_size / voxel_dimensions).astype(int)
     number_of_voxels = np.clip(number_of_voxels, a_min=1, a_max=None)
+
     if strict_voxel_size: half_range = number_of_voxels * voxel_dimensions / 2
     else                : half_range =          bounding_box_size          / 2
+
     voxel_edges_lo = bounding_box_centre - half_range
     voxel_edges_hi = bounding_box_centre + half_range
 
@@ -66,12 +66,11 @@ def voxelize_hits(hits             : Sequence[BHit],
     voxel_edges_lo -= eps
     voxel_edges_hi += eps
 
-    hit_positions = np.array([h.pos                   for h in hits]).astype('float64')
-    hit_energies  =          [getattr(h, energy_type.value) for h in hits]
-    E, edges = np.histogramdd(hit_positions,
+    xyz = hits.loc[:, "X Y Z".split()].values
+    E, edges = np.histogramdd(xyz,
                               bins    = number_of_voxels,
                               range   = tuple(zip(voxel_edges_lo, voxel_edges_hi)),
-                              weights = hit_energies)
+                              weights = hits[energy_type.value])
 
     def centres(a : np.ndarray) -> np.ndarray:
         return (a[1:] + a[:-1]) / 2
@@ -81,31 +80,22 @@ def voxelize_hits(hits             : Sequence[BHit],
     (   cx,     cy,     cz) = map(centres, edges)
     size_x, size_y, size_z  = map(sizes  , edges)
 
-    nz = np.nonzero(E)
-    true_dimensions = np.array([size_x[0], size_y[0], size_z[0]])
-
-    hit_x = np.array([h.X for h in hits])
-    hit_y = np.array([h.Y for h in hits])
-    hit_z = np.array([h.Z for h in hits])
-    hit_coordinates = [hit_x, hit_y, hit_z]
-
-    indx_coordinates = []
-    for i in range(3):
-        # find the bins where hits fall into
-        # numpy.histogramdd() uses [,) intervals...
-        index = np.digitize(hit_coordinates[i], edges[i], right=False) - 1
-        # ...except for the last one, which is [,]: hits on the last edge,
-        # if any, must fall into the last bin
-        index[index == number_of_voxels[i]] = number_of_voxels[i] - 1
-        indx_coordinates.append(index)
-
-    h_indices = np.array([(i, j, k) for i, j, k in zip(indx_coordinates[0], indx_coordinates[1], indx_coordinates[2])])
+    # find the bins where hits fall into
+    # numpy.histogramdd() uses [,) intervals...
+    # ...except for the last one, which is [,]: hits on the last edge,
+    # if any, must fall into the last bin
+    # @gonzaponte: This should not happen, as we are increasing the voxel
+    # dimensions a few lines above
+    hits_indices = np.array([ np.clip(np.digitize(coords, bins, right=False) - 1, 0, n-1)
+                              for coords, bins, n in zip(xyz.T, edges, number_of_voxels)
+                            ]).T
 
     voxels = []
-    for (x,y,z) in np.stack(nz).T:
-
-        indx_comp = (h_indices == (x, y, z))
-        hits_in_bin = list(h for i, h in zip(indx_comp, hits) if all(i))
+    true_dimensions = np.array([size_x[0], size_y[0], size_z[0]])
+    for indices_voxel in np.stack(np.nonzero(E)).T:
+        x, y, z     = indices_voxel
+        indices     = np.where(np.all(hits_indices == indices_voxel, axis=1))[0]
+        hits_in_bin = hits.iloc[indices]
 
         voxels.append(Voxel(cx[x], cy[y], cz[z], E[x,y,z], true_dimensions, hits_in_bin, energy_type))
 
@@ -198,8 +188,8 @@ def voxels_within_radius(distances : Dict[Voxel, float],
 
 def blob_centre(voxel: Voxel) -> Tuple[float, float, float]:
     """Calculate the blob position, starting from the end-point voxel."""
-    positions = [h.pos              for h in voxel.hits]
-    energies  = [getattr(h, voxel.Etype) for h in voxel.hits]
+    positions = voxel.hits["X Y Z".split()]
+    energies  = voxel.hits[voxel.Etype]
     if sum(energies):
         bary_pos = np.average(positions, weights=energies, axis=0)
     # Consider the case where voxels are built without associated hits
@@ -226,12 +216,10 @@ def hits_in_blob(track_graph : Graph,
     for v in track_graph.nodes():
         voxel_distance = dist_from_extreme[v]
         if voxel_distance < radius + diag:
-            for h in v.hits:
-                hit_distance = np.linalg.norm(blob_pos - h.pos)
-                if hit_distance < radius:
-                    blob_hits.append(h)
+            hit_distances = np.linalg.norm(v.hits["X Y Z".split()] - blob_pos, axis=1)
+            blob_hits.append(v.hits.loc[hit_distances < radius])
 
-    return blob_hits
+    return pd.concat(blob_hits, ignore_index=True)
 
 
 def blob_energies_hits_and_centres(track_graph : Graph, radius : float) -> Tuple[float, float, Sequence[BHit], Sequence[BHit], Tuple[float, float, float], Tuple[float, float, float]]:
@@ -244,13 +232,11 @@ def blob_energies_hits_and_centres(track_graph : Graph, radius : float) -> Tuple
 
     voxels = list(track_graph.nodes())
     e_type = voxels[0].Etype
-    Ea = sum(getattr(h, e_type) for h in ha)
-    Eb = sum(getattr(h, e_type) for h in hb)
 
     # Consider the case where voxels are built without associated hits
-    if len(ha) == 0 and len(hb) == 0 :
-        Ea = energy_of_voxels_within_radius(distances[a], radius)
-        Eb = energy_of_voxels_within_radius(distances[b], radius)
+    some_hits = len(ha) or len(hb)
+    Ea = ha[e_type].sum() if some_hits else energy_of_voxels_within_radius(distances[a], radius)
+    Eb = hb[e_type].sum() if some_hits else energy_of_voxels_within_radius(distances[b], radius)
 
     ca = blob_centre(a)
     cb = blob_centre(b)
@@ -314,21 +300,20 @@ def drop_end_point_voxels(voxels           : Sequence[Voxel],
        if their energy is lower than a threshold. Returns 1 if the voxel
        has been deleted succesfully and 0 otherwise."""
 
+    xyz    = "X Y Z".split()
     e_type = voxels[0].Etype
 
-    def drop_voxel(voxels: Sequence[Voxel], the_vox: Voxel, contiguity: Contiguity = Contiguity.CORNER) -> int:
+    def drop_voxel(voxels: Sequence[Voxel], the_vox: Voxel, contiguity: Contiguity = Contiguity.CORNER):
         """Eliminate an individual voxel from a set of voxels and give its energy to the hit
            that is closest to the barycenter of the eliminated voxel hits, provided that it
            belongs to a neighbour voxel."""
         the_neighbour_voxels = [v for v in voxels if neighbours(the_vox, v, contiguity)]
 
-        pos = [h.pos              for h in the_vox.hits]
-        qs  = [getattr(h, e_type) for h in the_vox.hits]
-
         #if there are no hits associated to voxels the pos will be an empty list
-        if len(pos) == 0:
+        if len(the_vox.hits) == 0:
             min_dist  = min(np.linalg.norm(the_vox.pos-v.pos) for v in the_neighbour_voxels)
-            min_v     = [v for v in the_neighbour_voxels if  np.isclose(np.linalg.norm(the_vox.pos-v.pos), min_dist)]
+            min_v     = [v for v in the_neighbour_voxels
+                           if np.isclose(np.linalg.norm(the_vox.pos-v.pos), min_dist)]
 
             ### add dropped voxel energy to closest voxels, proportional to the  voxels energy
             sum_en_v = sum(v.E for v in min_v)
@@ -336,26 +321,31 @@ def drop_end_point_voxels(voxels           : Sequence[Voxel],
                 v.E += the_vox.E/sum_en_v * v.E
             return
 
-        bary_pos = np.average(pos, weights=qs, axis=0)
+        bary_pos = np.average(           the_vox.hits[xyz]
+                             , weights = the_vox.hits[e_type]
+                             , axis    =  0)
 
-        ### find hit with minimum distance, only among neighbours
-        min_dist = min(np.linalg.norm(bary_pos-hh.pos) for v in the_neighbour_voxels for hh in v.hits)
-        min_h_v  = [(h, v) for v in the_neighbour_voxels for h in v.hits if np.isclose(np.linalg.norm(bary_pos-h.pos), min_dist)]
-        min_hs   = set(h for (h,v) in min_h_v)
-        min_vs   = set(v for (h,v) in min_h_v)
+        distance_to_bary = lambda hs: np.linalg.norm(hs[xyz] - bary_pos, axis=1)
+        distances        = [(v, distance_to_bary(v.hits)) for v in the_neighbour_voxels]
+        min_dist         = min(ds.min() for (_, ds) in distances)
 
-        ### add dropped voxel energy to closest hits/voxels, proportional to the hits/voxels energy
-        sum_en_h = sum(getattr(h, e_type) for h in min_hs)
-        sum_en_v = sum(v.E                for v in min_vs)
-        for h in min_hs:
-            setattr(h, e_type, getattr(h, e_type) + getattr(h, e_type) * the_vox.E/sum_en_h)
-        for v in min_vs:
-            v.E = sum(getattr(h, e_type) for h in v.hits)
+        hits_at_min_dist = lambda ds: np.argwhere(np.isclose(ds, min_dist)).flatten()
+        min_hits         = [(v, hits_at_min_dist(ds)) for (v, ds) in distances]
+        min_hits         = [pair for pair in min_hits if pair[1].size]
 
-    def nan_energy(voxel):
+        total_closest_e = sum(v.hits.iloc[idx][e_type].sum() for (v, idx) in min_hits)
+        for (v, row_idx) in min_hits:
+            col_idx        = v.hits.columns.get_loc(e_type)
+            current_energy = v.hits.iloc[row_idx, col_idx].values
+            v.hits.iloc[row_idx, col_idx] = current_energy * (1 + the_vox.E/total_closest_e)
+
+        # recopmute voxel energy
+        for v in voxels:
+            v.E = v.hits[e_type].sum()
+
+    def set_nan_energies(voxel):
         voxel.E = np.nan
-        for hit in voxel.hits:
-            setattr(hit, e_type, np.nan)
+        voxel.hits.loc[:, e_type] = np.nan
 
     mod_voxels     = copy.deepcopy(voxels)
     dropped_voxels = []
@@ -378,7 +368,7 @@ def drop_end_point_voxels(voxels           : Sequence[Voxel],
                         mod_voxels    .remove(extreme)
                         dropped_voxels.append(extreme)
                         drop_voxel(mod_voxels, extreme)
-                        nan_energy(extreme)
+                        set_nan_energies(extreme)
                         modified = True
 
     return mod_voxels, dropped_voxels

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -31,7 +31,7 @@ def bounding_box(hits: pd.DataFrame) -> Tuple[np.ndarray, np.ndarray]:
     xyz = hits["X Y Z".split()].values
     return xyz.min(axis=0), xyz.max(axis=0)
 
-def round_hits_positions_in_place(hits, decimals=5):
+def round_hits_positions_in_place(hits, decimals):
     """
     Rounds the hits positions to `decimals` decimals to avoid floating point
     comparison issues. The operation is performed inplace to avoid an

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -327,6 +327,12 @@ def drop_end_point_voxels(voxels           : Sequence[Voxel],
                              , weights = the_vox.hits[e_type]
                              , axis    =  0)
 
+        # the energy of the dropped voxel is assigned to the closest hit.
+        # However, several hits be at exactly the same distance (this happens
+        # when hits are distributed in a regular pattern). We generalize this
+        # behaviour by determining all hits in neighbouring voxels within a
+        # minimum distance from the main voxels barycentre position and share
+        # the voxel energy among them, proportionally to each hit's energy
         distance_to_bary = lambda hs: np.linalg.norm(hs[xyz] - bary_pos, axis=1)
         distances        = [(v, distance_to_bary(v.hits)) for v in the_neighbour_voxels]
         min_dist         = min(ds.min() for (_, ds) in distances)
@@ -341,7 +347,7 @@ def drop_end_point_voxels(voxels           : Sequence[Voxel],
             current_energy = v.hits.iloc[row_idx, col_idx].values
             v.hits.iloc[row_idx, col_idx] = current_energy * (1 + the_vox.E/total_closest_e)
 
-        # recopmute voxel energy
+        # recompute voxel energy because we have modified the hits it contains
         for v in voxels:
             v.E = v.hits[e_type].sum()
 

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -1,4 +1,3 @@
-from functools   import reduce
 from itertools   import combinations
 
 import copy

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -24,7 +24,10 @@ from typing import Tuple
 from typing import Dict
 
 def bounding_box(hits: pd.DataFrame) -> Tuple[np.ndarray, np.ndarray]:
-    """Returns two arrays defining the coordinates of a box that bounds the voxels"""
+    """
+    Compute the (min, max) coordinates of the axis-aligned bounding box
+    enclosing the hits in X, Y, Z.
+    """
     xyz = hits["X Y Z".split()].values
     return xyz.min(axis=0), xyz.max(axis=0)
 

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -58,6 +58,7 @@ from .. core.core_functions import in_range
 from .. core.exceptions     import NoHits
 from .. core.exceptions     import NoVoxels
 from .. core.testing_utils  import assert_dataframes_close
+from .. core.testing_utils  import an_instance_of
 
 from .. io.mcinfo_io    import cast_mchits_to_dict
 from .. io.mcinfo_io    import load_mchits_df
@@ -123,8 +124,9 @@ min_n_of_voxels = integers(min_value = 3,
                            max_value = 10)
 
 
-def test_voxelize_hits_should_detect_no_hits():
-    empty = single_hits().example().iloc[:0]
+@an_instance_of(single_hits())
+def test_voxelize_hits_should_detect_no_hits_demoo(hits):
+    empty = hits.iloc[:0]
     with raises(NoHits):
         voxelize_hits(empty, None)
 
@@ -167,20 +169,21 @@ def test_round_hits_positions_in_place(hits):
     assert np.all(np.in1d(hits["X Y Z".split()], [0, 1e-5, -1e-5]))
 
 
-def test_round_hits_positions_in_place_empty_input():
+@an_instance_of(single_hits())
+def test_round_hits_positions_in_place_empty_input(hits):
     """
     It simply should not crash.
     """
-    hits = single_hits().example().iloc[:0]
+    hits = hits.iloc[:0]
     round_hits_positions_in_place(hits)
     assert len(hits) == 0
 
 
-def test_round_hits_positions_in_place_non_finite_values():
+@an_instance_of(single_hits())
+def test_round_hits_positions_in_place_non_finite_values(hit):
     """
     Override xyz with np.nan and np.inf, ensure values are not changed.
     """
-    hit = single_hits().example()
     hit.loc[:, "X"] =  np.nan
     hit.loc[:, "Y"] =  np.inf
     hit.loc[:, "Z"] = -np.inf
@@ -366,8 +369,7 @@ def track_extrema():
     return tracks[0], extrema
 
 
-@settings(max_examples=10)
-@given(single_hits())
+@an_instance_of(single_hits())
 def test_voxelize_single_hit(hit):
     vox_size = np.array([10,10,10], dtype=np.int16)
     assert len(voxelize_hits(hit, vox_size)) == 1

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -29,9 +29,6 @@ from hypothesis.strategies import builds
 
 from networkx.generators.random_graphs import fast_gnp_random_graph
 
-from .. evm.event_model import BHit
-from .. evm.event_model import Hit
-from .. evm.event_model import Cluster
 from .. evm.event_model import Voxel
 
 from . paolina_functions import bounding_box
@@ -60,11 +57,8 @@ from .. core.exceptions     import NoVoxels
 from .. core.testing_utils  import assert_dataframes_close
 from .. core.testing_utils  import an_instance_of
 
-from .. io.mcinfo_io    import cast_mchits_to_dict
-from .. io.mcinfo_io    import load_mchits_df
-from .. io.hits_io      import load_hits
+from .. io.mcinfo_io import load_mchits_df
 
-from .. types.ic_types import xy
 from .. types.symbols  import Contiguity
 from .. types.symbols  import HitEnergy
 

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -202,10 +202,12 @@ def test_voxels_from_track_return_node_voxels(graph):
     assert voxels_from_track_graph(graph) == graph.nodes()
 
 
-@mark.skip(reason="bounding box no longer works on voxels")
 @given(bunch_of_hits(), box_sizes)
 def test_voxelize_hits_keeps_bounding_box(hits, voxel_dimensions):
     voxels = voxelize_hits(hits, voxel_dimensions)
+    # hack to reuse bounding_box
+    voxels = np.array([v.pos for v in voxels])
+    voxels = pd.DataFrame(voxels, columns="X Y Z".split())
 
     hlo, hhi = bounding_box(hits)
     vlo, vhi = bounding_box(voxels)

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -4,6 +4,7 @@ from math      import sqrt
 from functools import partial
 
 import numpy    as np
+import pandas   as pd
 import networkx as nx
 
 from itertools import combinations
@@ -19,6 +20,7 @@ parametrize = mark.parametrize
 
 from hypothesis            import given
 from hypothesis            import settings
+from hypothesis            import assume
 from hypothesis.strategies import composite
 from hypothesis.strategies import lists
 from hypothesis.strategies import floats
@@ -51,10 +53,11 @@ from . paolina_functions import drop_end_point_voxels
 from . paolina_functions import make_tracks
 from . paolina_functions import get_track_energy
 
-from .. core               import system_of_units as units
-from .. core.exceptions    import NoHits
-from .. core.exceptions    import NoVoxels
-from .. core.testing_utils import assert_bhit_equality
+from .. core                import system_of_units as units
+from .. core.core_functions import in_range
+from .. core.exceptions     import NoHits
+from .. core.exceptions     import NoVoxels
+from .. core.testing_utils  import assert_dataframes_close
 
 from .. io.mcinfo_io    import cast_mchits_to_dict
 from .. io.mcinfo_io    import load_mchits_df
@@ -70,44 +73,40 @@ def big_enough(hits):
     bbsize = abs(hi-lo)
     return (bbsize > 0.1).all()
 
-posn = floats(min_value=10, max_value=100)
-ener = posn
-bunch_of_hits = lists(builds(BHit, posn, posn, posn, ener),
-                      min_size =  1,
-                      max_size = 30).filter(big_enough)
+@composite
+def single_hits(draw):
+    return pd.DataFrame(dict( event    = 0
+                            , time     = 0
+                            , npeak    = 0
+                            , x_peak   = draw(floats  (-10,  10))
+                            , y_peak   = draw(floats  (-10,  10))
+                            , X        = draw(floats  (-10,  10))
+                            , Y        = draw(floats  (-10,  10))
+                            , Z        = draw(floats  ( 50, 100))
+                            , Q        = draw(floats  (  1, 100))
+                            , E        = draw(floats  ( 50, 100))
+                            , Ec       = draw(floats  ( 50, 100))
+                            , track_id = draw(integers(  0,  10))
+                            , Ep       = draw(floats  ( 50, 100))
+                            ), index=[0])
 
 @composite
-def hit(draw, min_value=1, max_value=100):
-    x      = draw(floats  (-10,  10))
-    y      = draw(floats  (-10,  10))
-    xvar   = draw(floats  (.01,  .5))
-    yvar   = draw(floats  (.01,  .5))
-    Q      = draw(floats  (  1, 100))
-    nsipm  = draw(integers(  1,  20))
-    npeak  = 0
-    z      = draw(floats  ( 50, 100))
-    E      = draw(floats  ( 50, 100))
-    E_c    = draw(floats  ( 50, 100))
-    x_peak = draw(floats  (-10,  10))
-    y_peak = draw(floats  (-10,  10))
-    track  = draw(integers(  0,  10))
-    E_p    = draw(floats  ( 50, 100))
-
-    return Hit(npeak,
-               Cluster(Q, xy(x,y), xy(xvar,yvar), nsipm),
-               z,
-               E,
-               xy(x_peak, y_peak),
-               s2_energy_c = E_c,
-               track_id    = track,
-               Ep          = E_p)
-
+def bunch_of_hits(draw):
+    strat = lists(single_hits(), min_size=1, max_size=30)
+    hits  = draw(strat)
+    hits  = pd.concat(hits, ignore_index=True)
+    assume(big_enough(hits))
+    return hits
 
 @composite
-def bunch_of_corrected_hits(draw):
-    list_of_hits = draw(lists(hit(), min_size=2, max_size=10))
-    return list_of_hits
-
+def single_voxels(draw):
+    return Voxel( x = draw(integers(-5, 5)) * 15.55
+                , y = draw(integers(-5, 5)) * 15.55
+                , z = draw(integers(-5, 5)) *  4.00
+                , E = draw(floats(1.0, 234.0))
+                , size = [15.55, 15.55, 4.00]
+                , hits = []
+                )
 
 box_dimension = floats(min_value = 1,
                        max_value = 5)
@@ -125,45 +124,34 @@ min_n_of_voxels = integers(min_value = 3,
 
 
 def test_voxelize_hits_should_detect_no_hits():
+    empty = single_hits().example().iloc[:0]
     with raises(NoHits):
-        voxelize_hits([], None)
+        voxelize_hits(empty, None)
 
 
-@given(bunch_of_hits)
+@given(bunch_of_hits())
 def test_bounding_box(hits):
     lo, hi = bounding_box(hits)
 
-    mins = [float(' inf')] * 3
-    maxs = [float('-inf')] * 3
+    assert np.all(in_range(hits.X, lo[0], hi[0], right_closed=True))
+    assert np.all(in_range(hits.Y, lo[1], hi[1], right_closed=True))
+    assert np.all(in_range(hits.Z, lo[2], hi[2], right_closed=True))
 
-    for hit in hits:
-        assert lo[0] <= hit.pos[0] <= hi[0]
-        assert lo[1] <= hit.pos[1] <= hi[1]
-        assert lo[2] <= hit.pos[2] <= hi[2]
-
-        for d in range(3):
-            mins[d] = min(mins[d], hit.pos[d])
-            maxs[d] = max(maxs[d], hit.pos[d])
-
-    for d in range(3):
-        assert_almost_equal(mins[d], lo[d])
-        assert_almost_equal(maxs[d], hi[d])
+    for col, l, h in zip("X Y Z".split(), lo, hi):
+        assert_almost_equal(hits[col].min(), l)
+        assert_almost_equal(hits[col].max(), h)
 
 
-@given(bunch_of_hits, box_sizes)
+@given(bunch_of_hits(), box_sizes)
 def test_voxelize_hits_does_not_lose_energy(hits, voxel_dimensions):
     voxels = voxelize_hits(hits, voxel_dimensions, strict_voxel_size=False)
+    total_voxel_e = sum(v.E for v in voxels)
+    total_hits_e  = sum(hits.E)
 
-    if not hits:
-        assert voxels == []
-
-    def sum_energy(seq):
-        return sum(e.E for e in seq)
-
-    assert sum_energy(voxels) == approx(sum_energy(hits))
+    assert total_voxel_e == approx(total_hits_e)
 
 
-@given(bunch_of_hits)
+@given(bunch_of_hits())
 def test_round_hits_positions_in_place(hits):
     """
     Override xyz such that all values fall below the rounding decimal place. We
@@ -172,36 +160,33 @@ def test_round_hits_positions_in_place(hits):
     absolute value is 1e-5. After rounding, the only possible values are 0, 1e-5
     or -1e-5.
     """
-    for hit in hits:
-        hit.xyz = np.array(hit.xyz) * 0.999e-7 * [-1, 1, -1]
+    hits.loc[:, "X Y Z".split()] = hits["X Y Z".split()].values * 0.999e-7 * [-1, 1, -1]
 
     round_hits_positions_in_place(hits)
 
-    pos = np.asarray([h.pos for h in hits])
-    assert np.all(np.in1d(pos, [0, 1e-5, -1e-5]))
+    assert np.all(np.in1d(hits["X Y Z".split()], [0, 1e-5, -1e-5]))
 
 
 def test_round_hits_positions_in_place_empty_input():
     """
     It simply should not crash.
     """
-    hits = []
+    hits = single_hits().example().iloc[:0]
     round_hits_positions_in_place(hits)
-    assert hits == []
+    assert len(hits) == 0
 
 
-@settings(max_examples=1) # simple way of producing a single hit
-@given(hit())
-def test_round_hits_positions_in_place_non_finite_values(hit):
+def test_round_hits_positions_in_place_non_finite_values():
     """
     Override xyz with np.nan and np.inf, ensure values are not changed.
     """
-    values = np.nan, np.inf, -np.inf
-    hit.xyz = tuple(values) # ensure copy
+    hit = single_hits().example()
+    hit.loc[:, "X"] =  np.nan
+    hit.loc[:, "Y"] =  np.inf
+    hit.loc[:, "Z"] = -np.inf
 
-    round_hits_positions_in_place([hit])
-
-    assert np.all(np.isclose(hit.pos, values, equal_nan=True))
+    round_hits_positions_in_place(hit)
+    assert np.all(np.isclose(hit["X Y Z".split()].values[0], np.array([np.nan, np.inf, -np.inf]), equal_nan=True))
 
 
 
@@ -214,7 +199,8 @@ def test_voxels_from_track_return_node_voxels(graph):
     assert voxels_from_track_graph(graph) == graph.nodes()
 
 
-@given(bunch_of_hits, box_sizes)
+@mark.skip(reason="bounding box no longer works on voxels")
+@given(bunch_of_hits(), box_sizes)
 def test_voxelize_hits_keeps_bounding_box(hits, voxel_dimensions):
     voxels = voxelize_hits(hits, voxel_dimensions)
 
@@ -229,7 +215,7 @@ def test_voxelize_hits_keeps_bounding_box(hits, voxel_dimensions):
 
 
 @settings(deadline=None)
-@given(bunch_of_hits, box_sizes)
+@given(bunch_of_hits(), box_sizes)
 def test_voxelize_hits_respects_voxel_dimensions(hits, requested_voxel_dimensions):
     voxels = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=True)
     unit   =                     requested_voxel_dimensions
@@ -240,21 +226,21 @@ def test_voxelize_hits_respects_voxel_dimensions(hits, requested_voxel_dimension
                 np.isclose(off_by, unit)).all()
 
 
-@given(bunch_of_hits, box_sizes)
+@given(bunch_of_hits(), box_sizes)
 def test_voxelize_hits_gives_maximum_voxels_size(hits, requested_voxel_dimensions):
     voxels = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False)
     for v in voxels:
         assert (v.size <= requested_voxel_dimensions + 4 * eps).all()
 
 
-@given(bunch_of_hits, box_sizes)
+@given(bunch_of_hits(), box_sizes)
 def test_voxelize_hits_strict_gives_required_voxels_size(hits, requested_voxel_dimensions):
     voxels = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=True)
     for v in voxels:
         assert v.size == approx(requested_voxel_dimensions)
 
 
-@given(bunch_of_hits, box_sizes)
+@given(bunch_of_hits(), box_sizes)
 def test_voxelize_hits_flexible_gives_correct_voxels_size(hits, requested_voxel_dimensions):
     voxels = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False)
     positions = [v.pos for v in voxels]
@@ -268,11 +254,11 @@ def test_voxelize_hits_flexible_gives_correct_voxels_size(hits, requested_voxel_
         assert is_close_to_integer(separation_over_size).all()
 
 
-@given(bunch_of_hits, box_sizes)
+@given(bunch_of_hits(), box_sizes)
 def test_hits_energy_in_voxel_is_equal_to_voxel_energy(hits, requested_voxel_dimensions):
     voxels = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False)
     for v in voxels:
-        assert sum(h.E for h in v.hits) == v.E
+        assert v.hits.E.sum() == approx(v.E)
 
 def test_voxels_with_no_hits(ICDATADIR):
     hit_file = os.path.join(ICDATADIR, 'test_voxels_with_no_hits.h5')
@@ -280,61 +266,50 @@ def test_voxels_with_no_hits(ICDATADIR):
     size = 15.
     vox_size = np.array([size,size,size],dtype=np.float16)
 
-    hits_df   = load_mchits_df(hit_file)
-    hits_dict = cast_mchits_to_dict(hits_df)
-    hit_seq   = hits_dict[evt_number]
-    voxels    = voxelize_hits(hit_seq                  ,
-                              vox_size                 ,
-                              strict_voxel_size = False)
+    hits_df = load_mchits_df(hit_file)
+    hits_df = hits_df.loc[evt_number].rename(columns=dict(x="X", y="Y", z="Z", energy="E"))
+    voxels  = voxelize_hits(hits_df, vox_size, strict_voxel_size=True)
+
     for v in voxels:
-        assert sum(h.E for h in v.hits) == v.E
+        assert v.hits.E.sum() == approx(v.E)
 
 
-@given(bunch_of_hits, box_sizes)
+@given(bunch_of_hits(), box_sizes)
 def test_voxel_hits_are_same_as_original_ones(hits, requested_voxel_dimensions):
     voxels = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False)
-    hits_read_from_voxels = []
+    hits_from_voxels = []
     for v in voxels:
-        hits_read_from_voxels += v.hits
+        hits_from_voxels.append(v.hits)
 
-    hits_s_x   = sorted(hits,       key=lambda h: h.X)
-    hits_s_xy  = sorted(hits_s_x,   key=lambda h: h.Y)
-    hits_s_xyz = sorted(hits_s_xy,  key=lambda h: h.Z)
-    hits_s_all = sorted(hits_s_xyz, key=lambda h: h.E)
+    hits_from_voxels = pd.concat(hits_from_voxels, ignore_index=True)
 
-    hits_read_from_voxels_s_x   = sorted(hits_read_from_voxels,       key=lambda h: h.X)
-    hits_read_from_voxels_s_xy  = sorted(hits_read_from_voxels_s_x,   key=lambda h: h.Y)
-    hits_read_from_voxels_s_xyz = sorted(hits_read_from_voxels_s_xy,  key=lambda h: h.Z)
-    hits_read_from_voxels_s_all = sorted(hits_read_from_voxels_s_xyz, key=lambda h: h.E)
+    # need to sort and reset index for a reliable comparison
+    hits             = hits            .sort_values("X Y Z E".split()).reset_index(drop=True)
+    hits_from_voxels = hits_from_voxels.sort_values("X Y Z E".split()).reset_index(drop=True)
 
-    assert  hits_read_from_voxels_s_all == hits_s_all
+    assert_dataframes_close(hits, hits_from_voxels)
 
 
 def test_hits_on_border_are_assigned_to_correct_voxel():
     z = 10.
     energy = 1.
-    hits = [BHit( 5., 15., z, energy),
-            BHit(15.,  5., z, energy),
-            BHit(15., 15., z, energy),
-            BHit(15., 25., z, energy),
-            BHit(25., 15., z, energy)]
+    hits = pd.DataFrame(dict( X = [ 5, 15, 15, 15, 25]
+                            , Y = [15,  5, 15, 25, 15]
+                            , Z = z
+                            , E = energy
+                            ), dtype=float)
 
     vox_size = np.array([15,15,15], dtype=np.int16)
     voxels = voxelize_hits(hits, vox_size)
 
     assert len(voxels) == 3
 
-    expected_hits = [[BHit( 5., 15., z, energy)],
-                     [BHit(15.,  5., z, energy)],
-                     [BHit(15., 15., z, energy),
-                      BHit(15., 25., z, energy),
-                      BHit(25., 15., z, energy)]]
-    for v, hits in zip(voxels, expected_hits):
-        for v_hit, e_hit in zip(v.hits, hits):
-            assert_bhit_equality(v_hit, e_hit)
+    expected_hits = [ hits.iloc[0:1], hits.iloc[1:2], hits.loc[2:] ]
+    for v, exp_hits in zip(voxels, expected_hits):
+        assert_dataframes_close(v.hits, exp_hits)
 
 
-@given(bunch_of_hits, box_sizes)
+@given(bunch_of_hits(), box_sizes)
 def test_make_voxel_graph_keeps_all_voxels(hits, voxel_dimensions):
     voxels = voxelize_hits    (hits  , voxel_dimensions)
     tracks = make_track_graphs(voxels)
@@ -342,7 +317,7 @@ def test_make_voxel_graph_keeps_all_voxels(hits, voxel_dimensions):
     assert set(voxels) == voxels_in_tracks
 
 
-@given(builds(Voxel, posn, posn, posn, ener, box_sizes))
+@given(single_voxels())
 def test_find_extrema_single_voxel(voxel):
     g = nx.Graph()
     g.add_node(voxel)
@@ -391,10 +366,11 @@ def track_extrema():
     return tracks[0], extrema
 
 
-def test_voxelize_single_hit():
-    hits = [BHit(1, 1, 1, 100)]
+@settings(max_examples=10)
+@given(single_hits())
+def test_voxelize_single_hit(hit):
     vox_size = np.array([10,10,10], dtype=np.int16)
-    assert len(voxelize_hits(hits, vox_size)) == 1
+    assert len(voxelize_hits(hit, vox_size)) == 1
 
 
 @fixture(scope='module')
@@ -409,9 +385,10 @@ def voxels_without_hits():
                   (10,12,15,2),
                   (10,13,15,2),
                   (10,14,15,2),
-                  (10,15,15,2)
-    )
-    voxels = [Voxel(x,y,z, E, np.array([1,1,1])) for (x,y,z,E) in voxel_spec]
+                  (10,15,15,2))
+
+    hits   = pd.DataFrame(columns="X Y Z E Ep".split())
+    voxels = [Voxel(x,y,z, E, np.array([1,1,1]), hits=hits) for (x,y,z,E) in voxel_spec]
 
     return voxels
 
@@ -507,9 +484,9 @@ def test_contiguity(proximity, contiguity, are_neighbours):
     assert len(tracks) == expected_number_of_tracks
 
 
-@given(bunch_of_hits, box_sizes, min_n_of_voxels, fraction_zero_one)
+@given(bunch_of_hits(), box_sizes, min_n_of_voxels, fraction_zero_one)
 def test_energy_is_conserved_with_dropped_voxels(hits, requested_voxel_dimensions, min_voxels, fraction_zero_one):
-    tot_initial_energy = sum(h.E for h in hits)
+    tot_initial_energy = hits.E.sum()
     voxels = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False)
     ini_trks = make_track_graphs(voxels)
     ini_trk_energies = [sum(vox.E for vox in t.nodes()) for t in ini_trks]
@@ -528,7 +505,7 @@ def test_energy_is_conserved_with_dropped_voxels(hits, requested_voxel_dimension
 
 
 @mark.parametrize("energy_type", HitEnergy)
-@given(hits                       = bunch_of_corrected_hits(),
+@given(hits                       = bunch_of_hits(),
        requested_voxel_dimensions = box_sizes,
        min_voxels                 = min_n_of_voxels,
        fraction_zero_one          = fraction_zero_one)
@@ -539,19 +516,15 @@ def test_dropped_voxels_have_nan_energy(hits, requested_voxel_dimensions, min_vo
     _, dropped_voxels = drop_end_point_voxels(voxels, e_thr, min_voxels)
     for voxel in dropped_voxels:
         assert np.isnan(voxel.E)
-        for hit in voxel.hits:
-            assert np.isnan(getattr(hit, energy_type.value))
+        assert voxel.hits[energy_type.value].isna().all()
 
 
 @mark.parametrize("energy_type", HitEnergy)
-@given(hits                       = bunch_of_corrected_hits(),
+@given(hits                       = bunch_of_hits(),
        requested_voxel_dimensions = box_sizes,
        min_voxels                 = min_n_of_voxels,
        fraction_zero_one          = fraction_zero_one)
 def test_drop_end_point_voxels_doesnt_modify_other_energy_types(hits, requested_voxel_dimensions, min_voxels, fraction_zero_one, energy_type):
-    def energy_from_hits(voxel, e_type):
-        return [getattr(hit, e_type) for hit in voxel.hits]
-
     voxels     = voxelize_hits(hits, requested_voxel_dimensions, strict_voxel_size=False, energy_type=energy_type)
     voxels     = sorted(voxels, key=attrgetter("xyz"))
     energies   = [v.E for v in voxels]
@@ -563,13 +536,13 @@ def test_drop_end_point_voxels_doesnt_modify_other_energy_types(hits, requested_
         if e_type is energy_type: continue
 
         for v_before, v_after in zip(voxels, new_voxels):
-            for h_before, h_after in zip(v_before.hits, v_after.hits):
-                #assert sum(energy_from_hits(v_before, e_type.value)) == sum(energy_from_hits(v_after, e_type.value))
-                assert np.isclose(getattr(h_before, e_type.value), getattr(h_after, e_type.value))
+            e_before = v_before.hits[e_type.value]
+            e_after  = v_after .hits[e_type.value]
+            assert np.allclose(e_before, e_after)
 
 
 @mark.parametrize("energy_type", HitEnergy)
-@given(hits                       = bunch_of_corrected_hits(),
+@given(hits                       = bunch_of_hits(),
        requested_voxel_dimensions = box_sizes,
        min_voxels                 = min_n_of_voxels,
        fraction_zero_one          = fraction_zero_one)
@@ -579,12 +552,11 @@ def test_drop_voxels_voxel_energy_is_sum_of_hits_general(hits, requested_voxel_d
     e_thr         = min(energies) + fraction_zero_one * (max(energies) - min(energies))
     mod_voxels, _ = drop_end_point_voxels(voxels, e_thr, min_voxels)
     for v in mod_voxels:
-        assert np.isclose(v.E, sum(getattr(h, energy_type.value) for h in v.hits))
-
+        assert np.isclose(v.E, v.hits[energy_type.value].sum())
 
 
 @mark.parametrize("energy_type", HitEnergy)
-@given(hits                       = bunch_of_corrected_hits(),
+@given(hits                       = bunch_of_hits(),
        requested_voxel_dimensions = box_sizes,
        min_voxels                 = min_n_of_voxels,
        fraction_zero_one          = fraction_zero_one)
@@ -596,7 +568,7 @@ def test_drop_end_point_voxels_constant_number_of_voxels_and_hits(hits, requeste
     (mod_voxels,
      dropped_voxels) = new_voxels
     assert len(mod_voxels) + len(dropped_voxels) == len(voxels)
-    assert sum(1 for vs in new_voxels for v in vs for h in v.hits) == len(hits)
+    assert sum(len(v.hits) for v in mod_voxels + dropped_voxels) == len(hits)
 
 
 def test_initial_voxels_are_the_same_after_dropping_voxels(ICDATADIR):
@@ -608,8 +580,7 @@ def test_initial_voxels_are_the_same_after_dropping_voxels(ICDATADIR):
     min_voxels = 3
     size = 15.
     vox_size = np.array([size,size,size], dtype=np.float16)
-    all_hits = load_hits(hit_file)
-    hits = all_hits[evt_number].hits
+    hits = pd.read_hdf(hit_file, "/RECO/Events").set_index("event").loc[evt_number]
     voxels = voxelize_hits(hits, vox_size, strict_voxel_size=False)
 
     # This is the core of the test: collect data before/after ...
@@ -639,8 +610,7 @@ def test_tracks_with_dropped_voxels(ICDATADIR):
     size = 15.
     vox_size = np.array([size,size,size],dtype=np.float16)
 
-    all_hits = load_hits(hit_file)
-    hits = all_hits[evt_number].hits
+    hits = pd.read_hdf(hit_file, "/RECO/Events").set_index("event").loc[evt_number]
     voxels = voxelize_hits(hits, vox_size, strict_voxel_size=False)
     ini_trks = make_track_graphs(voxels)
     initial_n_of_tracks = len(ini_trks)
@@ -671,8 +641,7 @@ def test_drop_voxels_deterministic(ICDATADIR):
     min_voxels = 3
     vox_size   = [15.] * 3
 
-    all_hits        = load_hits(hit_file)
-    hits            = all_hits[evt_number].hits
+    hits            = pd.read_hdf(hit_file, "/RECO/Events").set_index("event").loc[evt_number]
     voxels          = voxelize_hits(hits, vox_size, strict_voxel_size=False)
     mod_voxels  , _ = drop_end_point_voxels(sorted(voxels, key = lambda v:v.E, reverse = False), e_thr, min_voxels)
     mod_voxels_r, _ = drop_end_point_voxels(sorted(voxels, key = lambda v:v.E, reverse = True ), e_thr, min_voxels)
@@ -682,7 +651,7 @@ def test_drop_voxels_deterministic(ICDATADIR):
 
 
 def test_voxel_drop_in_short_tracks():
-    hits = [BHit(10, 10, 10, 1), BHit(26, 10, 10, 1)]
+    hits = pd.DataFrame(dict(X=[10, 26], Y=[10,10], Z=[10,10], E=[1,1]))
     voxels = voxelize_hits(hits, [15,15,15], strict_voxel_size=True)
     e_thr = sum(v.E for v in voxels) + 1.
     min_voxels = 0
@@ -694,26 +663,23 @@ def test_voxel_drop_in_short_tracks():
 
 def test_drop_voxels_voxel_energy_is_sum_of_hits():
     def make_hit(x, y, z, e):
-        return Hit(peak_number = 0,
-                   cluster     = Cluster(0, xy(x, y), xy(0, 0), 1),
-                   z           = z,
-                   s2_energy   = e,
-                   peak_xy     = xy(0, 0),
-                   Ep          = e)
+        return pd.DataFrame(dict(X=x, Y=y, Z=z, E=e, Ep=e), index=[0])
 
+    def make_voxel(x, y, z, e, hits):
+        return Voxel(x, y, z, e, size=5, e_type=HitEnergy.Ep, hits=pd.concat(hits, ignore_index=True))
     # Create a track with an extreme to be dropped and two hits at the same
     # distance from the barycenter of the the voxel to be dropped with
     # different energies in the hits *and* in the voxels
-    voxels = [Voxel( 0,  0, 0, 0.1, size=5, e_type=HitEnergy.Ep, hits = [make_hit( 0,  0, 0, 0.1)                          ]),
-              Voxel( 5, -5, 0, 1.0, size=5, e_type=HitEnergy.Ep, hits = [make_hit( 5, -5, 0, 0.7), make_hit( 5, -8, 0, 0.3)]),
-              Voxel( 5,  5, 0, 1.5, size=5, e_type=HitEnergy.Ep, hits = [make_hit( 5,  5, 0, 0.9), make_hit( 5,  8, 0, 0.6)]),
-              Voxel(10,  0, 0, 2.0, size=5, e_type=HitEnergy.Ep, hits = [make_hit(10,  5, 0, 1.2), make_hit(11,  5, 0, 0.8)]),
-              Voxel(15,  0, 0, 2.5, size=5, e_type=HitEnergy.Ep, hits = [make_hit(15,  0, 0, 1.8), make_hit(11,  0, 0, 0.7)]),
-              Voxel(20,  0, 0, 3.0, size=5, e_type=HitEnergy.Ep, hits = [make_hit(20,  0, 0, 1.5), make_hit(11,  0, 0, 1.5)])]
+    voxels = [make_voxel( 0,  0, 0, 0.1, [make_hit( 0,  0, 0, 0.1)                          ]),
+              make_voxel( 5, -5, 0, 1.0, [make_hit( 5, -5, 0, 0.7), make_hit( 5, -8, 0, 0.3)]),
+              make_voxel( 5,  5, 0, 1.5, [make_hit( 5,  5, 0, 0.9), make_hit( 5,  8, 0, 0.6)]),
+              make_voxel(10,  0, 0, 2.0, [make_hit(10,  5, 0, 1.2), make_hit(11,  5, 0, 0.8)]),
+              make_voxel(15,  0, 0, 2.5, [make_hit(15,  0, 0, 1.8), make_hit(11,  0, 0, 0.7)]),
+              make_voxel(20,  0, 0, 3.0, [make_hit(20,  0, 0, 1.5), make_hit(11,  0, 0, 1.5)])]
 
     modified_voxels, _ = drop_end_point_voxels(voxels, energy_threshold = 0.5, min_vxls = 1)
     for v in modified_voxels:
-        assert np.isclose(v.E, sum(h.Ep for h in v.hits))
+        assert np.isclose(v.E, v.hits.Ep.sum())
 
 
 @parametrize('radius, expected',
@@ -726,20 +692,22 @@ def test_drop_voxels_voxel_energy_is_sum_of_hits():
               (22., (140, 100))
  ))
 def test_blobs(radius, expected):
-    hits = [BHit(105.0, 125.0, 77.7, 10),
-            BHit( 95.0, 125.0, 77.7, 10),
-            BHit( 95.0, 135.0, 77.7, 10),
-            BHit(105.0, 135.0, 77.7, 10),
-            BHit(105.0, 115.0, 77.7, 10),
-            BHit( 95.0, 115.0, 77.7, 10),
-            BHit( 95.0, 125.0, 79.5, 10),
-            BHit(105.0, 125.0, 79.5, 10),
-            BHit(105.0, 135.0, 79.5, 10),
-            BHit( 95.0, 135.0, 79.5, 10),
-            BHit( 95.0, 115.0, 79.5, 10),
-            BHit(105.0, 115.0, 79.5, 10),
-            BHit(115.0, 125.0, 79.5, 10),
-            BHit(115.0, 125.0, 85.2, 10)]
+    #           x       y     z   e
+    hits = [[105.0, 125.0, 77.7, 10],
+            [ 95.0, 125.0, 77.7, 10],
+            [ 95.0, 135.0, 77.7, 10],
+            [105.0, 135.0, 77.7, 10],
+            [105.0, 115.0, 77.7, 10],
+            [ 95.0, 115.0, 77.7, 10],
+            [ 95.0, 125.0, 79.5, 10],
+            [105.0, 125.0, 79.5, 10],
+            [105.0, 135.0, 79.5, 10],
+            [ 95.0, 135.0, 79.5, 10],
+            [ 95.0, 115.0, 79.5, 10],
+            [105.0, 115.0, 79.5, 10],
+            [115.0, 125.0, 79.5, 10],
+            [115.0, 125.0, 85.2, 10]]
+    hits = pd.DataFrame(hits, columns="X Y Z E".split())
     vox_size = np.array([15.,15.,15.],dtype=np.float16)
     voxels = voxelize_hits(hits, vox_size)
     tracks = make_track_graphs(voxels)
@@ -748,7 +716,7 @@ def test_blobs(radius, expected):
     assert blob_energies(tracks[0], radius) == expected
 
 
-@given(bunch_of_hits, box_sizes, radius)
+@given(bunch_of_hits(), box_sizes, radius)
 def test_blob_hits_are_inside_radius(hits, voxel_dimensions, blob_radius):
     voxels = voxelize_hits(hits, voxel_dimensions)
     tracks = make_track_graphs(voxels)
@@ -756,10 +724,8 @@ def test_blob_hits_are_inside_radius(hits, voxel_dimensions, blob_radius):
         Ea, Eb, hits_a, hits_b   = blob_energies_and_hits(t, blob_radius)
         centre_a, centre_b       = blob_centres(t, blob_radius)
 
-        for h in hits_a:
-            assert np.linalg.norm(h.XYZ - centre_a) < blob_radius
-        for h in hits_b:
-            assert np.linalg.norm(h.XYZ - centre_b) < blob_radius
+        assert all(np.linalg.norm(hits_a["X Y Z".split()] - centre_a, axis=1) < blob_radius)
+        assert all(np.linalg.norm(hits_b["X Y Z".split()] - centre_b, axis=1) < blob_radius)
 
 
 @given(blob_radius=radius, min_voxels=min_n_of_voxels, fraction_zero_one=fraction_zero_one)
@@ -804,7 +770,7 @@ def test_paolina_functions_with_voxels_without_associated_hits(blob_radius, min_
 
 
 @mark.parametrize("energy_type", (HitEnergy.Ec, HitEnergy.Ep))
-@given(hits                       = bunch_of_corrected_hits(),
+@given(hits                       = bunch_of_hits(),
        requested_voxel_dimensions = box_sizes,
        blob_radius                = radius,
        fraction_zero_one          = fraction_zero_one)
@@ -818,20 +784,20 @@ def test_paolina_functions_with_hit_energy_different_from_default_value(hits, re
     assert voxels_c[0].Etype == energy_type.value
 
     for voxel in voxels_c:
-        assert np.isclose(voxel.E, sum(getattr(h, energy_type.value) for h in voxel.hits))
+        assert np.isclose(voxel.E, voxel.hits[energy_type.value].sum())
 
     energies_c = [v.E for v in voxels_c]
     e_thr = min(energies_c) + fraction_zero_one * (max(energies_c) - min(energies_c))
     # Test that this function doesn't fail
     mod_voxels_c, _ = drop_end_point_voxels(voxels_c, e_thr, min_vxls=0)
 
-    tot_energy     = sum(getattr(h, energy_type.value) for v in voxels_c     for h in v.hits)
-    tot_mod_energy = sum(getattr(h, energy_type.value) for v in mod_voxels_c for h in v.hits)
+    tot_energy     = sum(v.hits[energy_type.value].sum() for v in     voxels_c)
+    tot_mod_energy = sum(v.hits[energy_type.value].sum() for v in mod_voxels_c)
 
     assert np.isclose(tot_energy, tot_mod_energy)
 
-    tot_default_energy     = sum(h.E for v in voxels_c     for h in v.hits)
-    tot_mod_default_energy = sum(h.E for v in mod_voxels_c for h in v.hits)
+    tot_default_energy     = sum(v.hits.E.sum() for v in     voxels_c)
+    tot_mod_default_energy = sum(v.hits.E.sum() for v in mod_voxels_c)
 
     # We don't want to modify the default energy of hits, if the voxels are made with energy_c
     if len(mod_voxels_c) < len(voxels_c):
@@ -848,11 +814,10 @@ def test_make_tracks_function(ICDATADIR):
     blob_radius = 21*units.mm
 
     # Read the hits and voxelize
-    all_hits = load_hits(hit_file)
+    all_hits = pd.read_hdf(hit_file, "/RECO/Events")
 
-    for evt_number, hit_coll in all_hits.items():
-        evt_hits = hit_coll.hits
-        evt_time = hit_coll.time
+    for evt_number, evt_hits in all_hits.groupby("event"):
+        evt_time = evt_hits.time.iloc[0]
         voxels   = voxelize_hits(evt_hits, voxel_size, strict_voxel_size=False, energy_type=HitEnergy.E)
 
         tracks   = list(make_track_graphs(voxels))
@@ -872,7 +837,7 @@ def test_make_tracks_function(ICDATADIR):
             t  = tracks[i]
             tc = tracks_from_coll[i]
 
-            assert len(t.nodes())                   == tc.number_of_voxels
+            assert len(t.nodes())              == tc.number_of_voxels
             assert sum(v.E for v in t.nodes()) == tc.E
 
             tc_blobs = list(tc.blobs)
@@ -882,9 +847,9 @@ def test_make_tracks_function(ICDATADIR):
             assert np.allclose(blob_energies(t, blob_radius), tc_blob_energies)
 
 
-@given(bunch_of_hits, box_sizes)
+@given(bunch_of_hits(), box_sizes)
 def test_make_voxel_graph_keeps_energy_consistence(hits, voxel_dimensions):
     voxels = voxelize_hits    (hits  , voxel_dimensions)
     tracks = make_track_graphs(voxels)
     # assert sum of track energy equal to sum of hits energies
-    assert_almost_equal(sum(get_track_energy(track) for track in tracks), sum(h.E for h in hits))
+    assert_almost_equal(sum(get_track_energy(track) for track in tracks), hits.E.sum())

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -158,7 +158,7 @@ def test_round_hits_positions_in_place(hits):
     """
     hits.loc[:, "X Y Z".split()] = hits["X Y Z".split()].values * 0.999e-7 * [-1, 1, -1]
 
-    round_hits_positions_in_place(hits)
+    round_hits_positions_in_place(hits, 5)
 
     assert np.all(np.in1d(hits["X Y Z".split()], [0, 1e-5, -1e-5]))
 
@@ -169,7 +169,7 @@ def test_round_hits_positions_in_place_empty_input(hits):
     It simply should not crash.
     """
     hits = hits.iloc[:0]
-    round_hits_positions_in_place(hits)
+    round_hits_positions_in_place(hits, 5)
     assert len(hits) == 0
 
 
@@ -182,7 +182,7 @@ def test_round_hits_positions_in_place_non_finite_values(hit):
     hit.loc[:, "Y"] =  np.inf
     hit.loc[:, "Z"] = -np.inf
 
-    round_hits_positions_in_place(hit)
+    round_hits_positions_in_place(hit, 5)
     assert np.all(np.isclose(hit["X Y Z".split()].values[0], np.array([np.nan, np.inf, -np.inf]), equal_nan=True))
 
 


### PR DESCRIPTION
Paolina functions were written using the `HitCollection` and `Hit` classes, which are cumbersome. Pandas' Dataframes are a much better tool to handle this type of data and, in practice, we always use them. This PR rewrites some of the paolina functionality avoiding these unnecessary intermediate objects.