### PR TITLE
Implement scanning radius into `paolina_functions`

### DIFF
--- a/invisible_cities/cities/components.py
+++ b/invisible_cities/cities/components.py
@@ -1460,6 +1460,7 @@ def track_blob_info_creator_extractor(vox_size         : Tuple[float, float, flo
                                       energy_threshold : float                     ,
                                       min_voxels       : int                       ,
                                       blob_radius      : float                     ,
+                                      scan_radius      : Union[float, NoneType]    ,
                                       max_num_hits     : int
                                      ) -> Callable:
     """
@@ -1535,7 +1536,7 @@ def track_blob_info_creator_extractor(vox_size         : Tuple[float, float, flo
             extr1_pos = extr1.XYZ
             extr2_pos = extr2.XYZ
 
-            e_blob1, e_blob2, hits_blob1, hits_blob2, blob_pos1, blob_pos2 = plf.blob_energies_hits_and_centres(t, blob_radius)
+            e_blob1, e_blob2, hits_blob1, hits_blob2, blob_pos1, blob_pos2 = plf.blob_energies_hits_and_centres(t, blob_radius, scan_radius)
 
             common_hits = hits_blob1.merge(hits_blob2, how="inner")
             overlap     = common_hits.Ep.sum()

--- a/invisible_cities/config/esmeralda.conf
+++ b/invisible_cities/config/esmeralda.conf
@@ -22,6 +22,7 @@ paolina_params      = dict(
    energy_threshold = 10 * keV,
    min_voxels       = 2,
    blob_radius      = 21 * mm,
+   scan_radius      = None,
    max_num_hits     = 10000)
 
 corrections = dict(

--- a/invisible_cities/config/isaura.conf
+++ b/invisible_cities/config/isaura.conf
@@ -17,4 +17,5 @@ paolina_params      = dict(
    energy_threshold = 10 * keV,
    min_voxels       = 3,
    blob_radius      = 18 * mm,
+   scan_radius      = None,
    max_num_hits     = 10000)

--- a/invisible_cities/conftest.py
+++ b/invisible_cities/conftest.py
@@ -464,6 +464,7 @@ def esmeralda_config(Th228_hits, next100_mc_krmap):
                       energy_threshold = 20 * units.keV     ,
                       min_voxels       = 3                  ,
                       blob_radius      = 21 * units.mm      ,
+                      scan_radius      = None               ,
           	      max_num_hits     = 30000              )
                  , corrections = dict(
                       filename   = next100_mc_krmap,

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -279,26 +279,26 @@ def blob_energies_hits_and_centres(track_graph : Graph, small_radius : float, bi
         return (Ea, Eb, ha, hb, ca, cb)
 
 
-def blob_energies(track_graph : Graph, radius : float) -> Tuple[float, float]:
+def blob_energies(track_graph : Graph, small_radius : float, big_radius : Union[float, NoneType]) -> Tuple[float, float]:
     """Return the energies around the extrema of the track.
        The largest energy is returned first."""
-    E1, E2, _, _, _, _ = blob_energies_hits_and_centres(track_graph, radius)
+    E1, E2, _, _, _, _ = blob_energies_hits_and_centres(track_graph, small_radius, big_radius)
 
     return E1, E2
 
 
-def blob_energies_and_hits(track_graph : Graph, radius : float) -> Tuple[float, float, Sequence[BHit], Sequence[BHit]]:
+def blob_energies_and_hits(track_graph : Graph, small_radius: float, big_radius : Union[float, NoneType]) -> Tuple[float, float, Sequence[BHit], Sequence[BHit]]:
     """Return the energies and the hits around the extrema of the track.
        The largest energy is returned first, as well as its hits."""
-    E1, E2, h1, h2, _, _ = blob_energies_hits_and_centres(track_graph, radius)
+    E1, E2, h1, h2, _, _ = blob_energies_hits_and_centres(track_graph, small_radius, big_radius)
 
     return (E1, E2, h1, h2)
 
 
-def blob_centres(track_graph : Graph, radius : float) -> Tuple[Tuple[float, float, float], Tuple[float, float, float]]:
+def blob_centres(track_graph : Graph, small_radius : float, big_radius : Union[float, NoneType]) -> Tuple[Tuple[float, float, float], Tuple[float, float, float]]:
     """Return the positions of the blobs.
        The blob of largest energy is returned first."""
-    _, _, _, _, c1, c2 = blob_energies_hits_and_centres(track_graph, radius)
+    _, _, _, _, c1, c2 = blob_energies_hits_and_centres(track_graph, small_radius, big_radius)
 
     return (c1, c2)
 
@@ -314,8 +314,8 @@ def make_tracks(evt_number       : float,
     tc = TrackCollection(evt_number, evt_time) # type: TrackCollection
     track_graphs = make_track_graphs(voxels, contiguity) # type: Sequence[Graph]
     for trk in track_graphs:
-        energy_a, energy_b, hits_a, hits_b = blob_energies_and_hits(trk, blob_radius)
-        a, b                               = blob_centres(trk, blob_radius)
+        energy_a, energy_b, hits_a, hits_b = blob_energies_and_hits(trk, blob_radius, None)
+        a, b                               = blob_centres(trk, blob_radius, None)
         blob_a = Blob(a, hits_a, blob_radius, energy_type) # type: Blob
         blob_b = Blob(b, hits_b, blob_radius, energy_type)
         blobs = (blob_a, blob_b)

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -24,6 +24,7 @@ from typing import Sequence
 from typing import List
 from typing import Tuple
 from typing import Dict
+from typing import Union
 
 def bounding_box(hits: pd.DataFrame) -> Tuple[np.ndarray, np.ndarray]:
     """
@@ -244,7 +245,7 @@ def find_highest_encapsulating_node( track   : Graph
     return highest_encapsulating_node
 
 
-def blob_energies_hits_and_centres(track_graph : Graph, small_radius : float, big_radius : [float, NoneType]) -> Tuple[float, float, Sequence[BHit], Sequence[BHit], Tuple[float, float, float], Tuple[float, float, float]]:
+def blob_energies_hits_and_centres(track_graph : Graph, small_radius : float, big_radius : Union[float, NoneType]) -> Tuple[float, float, Sequence[BHit], Sequence[BHit], Tuple[float, float, float], Tuple[float, float, float]]:
     """Return the energies, the hits and the positions of the blobs.
        For each pair of observables, the one of the blob of largest energy is returned first."""
     distances = shortest_paths(track_graph)

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -224,6 +224,24 @@ def hits_in_blob(track_graph : Graph,
     return pd.concat(blob_hits, ignore_index=True)
 
 
+def find_highest_encapsulating_node( track   : Graph
+                                   , extreme : Voxel
+                                   , big_radius    : float
+                                   , small_radius  : float) -> Tuple[Voxel, dict]:
+    """
+    Find the voxel within a big radius for which the most energy
+    is captured within an equivalent smaller radius.
+    """
+    distances = shortest_paths(track)
+    nodes_within_radius = [node for node in track.nodes if distances[extreme][node] <= big_radius]
+
+    def energy_within_radius(node):
+        return energy_of_voxels_within_radius(distances[node], small_radius)
+
+    highest_encapsulating_node = max(nodes_within_radius, key=energy_within_radius)
+    return highest_encapsulating_node
+
+
 def blob_energies_hits_and_centres(track_graph : Graph, radius : float) -> Tuple[float, float, Sequence[BHit], Sequence[BHit], Tuple[float, float, float], Tuple[float, float, float]]:
     """Return the energies, the hits and the positions of the blobs.
        For each pair of observables, the one of the blob of largest energy is returned first."""

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -251,20 +251,14 @@ def blob_energies_hits_and_centres(track_graph : Graph, small_radius : float, bi
     distances = shortest_paths(track_graph)
     a, b, _   = find_extrema_and_length(distances)
 
+    if big_radius is not None:
+        a = find_highest_encapsulating_node(track_graph, a, distances, big_radius, small_radius)
+        b = find_highest_encapsulating_node(track_graph, b, distances, big_radius, small_radius)
 
-    if big_radius is None:
-        ha = hits_in_blob(track_graph, small_radius, a)
-        hb = hits_in_blob(track_graph, small_radius, b)
-        ca = blob_centre(a)
-        cb = blob_centre(b)
-    else:
-        va_highE = find_highest_encapsulating_node(track_graph, a, distances, big_radius, small_radius)
-        vb_highE = find_highest_encapsulating_node(track_graph, b, distances, big_radius, small_radius)
-
-        ha = hits_in_blob(track_graph, small_radius, va_highE)
-        hb = hits_in_blob(track_graph, small_radius, vb_highE)
-        ca = blob_centre(va_highE)
-        cb = blob_centre(vb_highE)
+    ha = hits_in_blob(track_graph, small_radius, a)
+    hb = hits_in_blob(track_graph, small_radius, b)
+    ca = blob_centre(a)
+    cb = blob_centre(b)
 
     voxels = list(track_graph.nodes())
     e_type = voxels[0].Etype

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -227,15 +227,15 @@ def hits_in_blob(track_graph : Graph,
     return pd.concat(blob_hits, ignore_index=True)
 
 
-def find_highest_encapsulating_node( track   : Graph
-                                   , extreme : Voxel
+def find_highest_encapsulating_node( track         : Graph
+                                   , extreme       : Voxel
+                                   , distances     : Dict[Voxel, Dict[Voxel, float]]
                                    , big_radius    : float
                                    , small_radius  : float) -> Tuple[Voxel, dict]:
     """
     Find the voxel within a big radius for which the most energy
     is captured within an equivalent smaller radius.
     """
-    distances = shortest_paths(track)
     nodes_within_radius = [node for node in track.nodes if distances[extreme][node] <= big_radius]
 
     def energy_within_radius(node):
@@ -258,8 +258,8 @@ def blob_energies_hits_and_centres(track_graph : Graph, small_radius : float, bi
         ca = blob_centre(a)
         cb = blob_centre(b)
     else:
-        va_highE = find_highest_encapsulating_node(track_graph, a, big_radius, small_radius)
-        vb_highE = find_highest_encapsulating_node(track_graph, b, big_radius, small_radius)
+        va_highE = find_highest_encapsulating_node(track_graph, a, distances, big_radius, small_radius)
+        vb_highE = find_highest_encapsulating_node(track_graph, b, distances, big_radius, small_radius)
 
         ha = hits_in_blob(track_graph, small_radius, va_highE)
         hb = hits_in_blob(track_graph, small_radius, vb_highE)

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -18,6 +18,8 @@ from .. core            import system_of_units as units
 from .. types.symbols   import Contiguity
 from .. types.symbols   import HitEnergy
 
+from .. types.ic_types  import NoneType
+
 from typing import Sequence
 from typing import List
 from typing import Tuple
@@ -242,24 +244,33 @@ def find_highest_encapsulating_node( track   : Graph
     return highest_encapsulating_node
 
 
-def blob_energies_hits_and_centres(track_graph : Graph, radius : float) -> Tuple[float, float, Sequence[BHit], Sequence[BHit], Tuple[float, float, float], Tuple[float, float, float]]:
+def blob_energies_hits_and_centres(track_graph : Graph, small_radius : float, big_radius : [float, NoneType]) -> Tuple[float, float, Sequence[BHit], Sequence[BHit], Tuple[float, float, float], Tuple[float, float, float]]:
     """Return the energies, the hits and the positions of the blobs.
        For each pair of observables, the one of the blob of largest energy is returned first."""
     distances = shortest_paths(track_graph)
     a, b, _   = find_extrema_and_length(distances)
-    ha = hits_in_blob(track_graph, radius, a)
-    hb = hits_in_blob(track_graph, radius, b)
+
+
+    if big_radius is None:
+        ha = hits_in_blob(track_graph, small_radius, a)
+        hb = hits_in_blob(track_graph, small_radius, b)
+        ca = blob_centre(a)
+        cb = blob_centre(b)
+    else:
+        va_highE = find_highest_encapsulating_node(track_graph, a, big_radius, small_radius)
+        vb_highE = find_highest_encapsulating_node(track_graph, b, big_radius, small_radius)
+
+        ha = hits_in_blob(track_graph, small_radius, va_highE)
+        hb = hits_in_blob(track_graph, small_radius, vb_highE)
+        ca = blob_centre(va_highE)
+        cb = blob_centre(vb_highE)
 
     voxels = list(track_graph.nodes())
     e_type = voxels[0].Etype
-
     # Consider the case where voxels are built without associated hits
     some_hits = len(ha) or len(hb)
-    Ea = ha[e_type].sum() if some_hits else energy_of_voxels_within_radius(distances[a], radius)
-    Eb = hb[e_type].sum() if some_hits else energy_of_voxels_within_radius(distances[b], radius)
-
-    ca = blob_centre(a)
-    cb = blob_centre(b)
+    Ea = ha[e_type].sum() if some_hits else energy_of_voxels_within_radius(distances[a], small_radius)
+    Eb = hb[e_type].sum() if some_hits else energy_of_voxels_within_radius(distances[b], small_radius)
 
     if Eb > Ea:
         return (Eb, Ea, hb, ha, cb, ca)

--- a/invisible_cities/reco/paolina_functions.py
+++ b/invisible_cities/reco/paolina_functions.py
@@ -245,9 +245,20 @@ def find_highest_encapsulating_node( track         : Graph
     return highest_encapsulating_node
 
 
-def blob_energies_hits_and_centres(track_graph : Graph, small_radius : float, big_radius : Union[float, NoneType]) -> Tuple[float, float, Sequence[BHit], Sequence[BHit], Tuple[float, float, float], Tuple[float, float, float]]:
+def blob_energies_hits_and_centres(track_graph  : Graph,
+                                   small_radius : float,
+                                   big_radius   : Union[float, NoneType]
+                                   ) -> Tuple[float,
+                                              float,
+                                              Sequence[BHit],
+                                              Sequence[BHit],
+                                              Tuple[float, float, float],
+                                              Tuple[float, float, float]]:
     """Return the energies, the hits and the positions of the blobs.
-       For each pair of observables, the one of the blob of largest energy is returned first."""
+       For each pair of observables, the one of the blob of largest energy is returned first.
+
+       If a big_radius is provided, the blob centre is chosen to be the voxel within the big
+       radius of the extrema that contains the most energy around it within the small_radius."""
     distances = shortest_paths(track_graph)
     a, b, _   = find_extrema_and_length(distances)
 

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -711,7 +711,7 @@ def test_blobs(radius, expected):
     tracks = make_track_graphs(voxels)
 
     assert len(tracks) == 1
-    assert blob_energies(tracks[0], radius) == expected
+    assert blob_energies(tracks[0], radius, None) == expected
 
 
 @settings(deadline=None)
@@ -720,8 +720,8 @@ def test_blob_hits_are_inside_radius(hits, voxel_dimensions, blob_radius):
     voxels = voxelize_hits(hits, voxel_dimensions)
     tracks = make_track_graphs(voxels)
     for t in tracks:
-        Ea, Eb, hits_a, hits_b   = blob_energies_and_hits(t, blob_radius)
-        centre_a, centre_b       = blob_centres(t, blob_radius)
+        Ea, Eb, hits_a, hits_b   = blob_energies_and_hits(t, blob_radius, None)
+        centre_a, centre_b       = blob_centres(t, blob_radius, None)
 
         assert all(np.linalg.norm(hits_a["X Y Z".split()] - centre_a, axis=1) < blob_radius)
         assert all(np.linalg.norm(hits_b["X Y Z".split()] - centre_b, axis=1) < blob_radius)
@@ -746,15 +746,15 @@ def test_paolina_functions_with_voxels_without_associated_hits(blob_radius, min_
         Eb = energy_of_voxels_within_radius(distances[b], blob_radius)
 
         if Ea < Eb:
-            assert np.allclose(blob_centres(t, blob_radius)[0], b.pos)
-            assert np.allclose(blob_centres(t, blob_radius)[1], a.pos)
+            assert np.allclose(blob_centres(t, blob_radius, None)[0], b.pos)
+            assert np.allclose(blob_centres(t, blob_radius, None)[1], a.pos)
         else:
-            assert np.allclose(blob_centres(t, blob_radius)[0], a.pos)
-            assert np.allclose(blob_centres(t, blob_radius)[1], b.pos)
+            assert np.allclose(blob_centres(t, blob_radius, None)[0], a.pos)
+            assert np.allclose(blob_centres(t, blob_radius, None)[1], b.pos)
 
-        assert blob_energies(t, blob_radius) != (0, 0)
+        assert blob_energies(t, blob_radius, None) != (0, 0)
 
-        assert blob_energies_and_hits(t, blob_radius) != (0, 0, [], [])
+        assert blob_energies_and_hits(t, blob_radius, None) != (0, 0, [], [])
 
     energies = [v.E for v in voxels]
     e_thr = min(energies) + fraction_zero_one * (max(energies) - min(energies))
@@ -843,7 +843,7 @@ def test_make_tracks_function(ICDATADIR):
             tc_blobs.sort(key=lambda x : x.E)
             tc_blob_energies = (tc.blobs[0].E, tc.blobs[1].E)
 
-            assert np.allclose(blob_energies(t, blob_radius), tc_blob_energies)
+            assert np.allclose(blob_energies(t, blob_radius, None), tc_blob_energies)
 
 
 @given(bunch_of_hits(), box_sizes)

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -879,18 +879,19 @@ def test_encapsulation_works_as_intended():
     for _x, _y, _z, _E in zip(x, y, z, E):
         hits.append([0, 1, _x, _y, _z, 1, _E, _E])
 
-    hits_df = pd.DataFrame(hits, columns = ['event', 'npeak', 'X', 'Y', 'Z', 'Q', 'E', 'Ep'])
+    hits_df   = pd.DataFrame(hits, columns = ['event', 'npeak', 'X', 'Y', 'Z', 'Q', 'E', 'Ep'])
 
-    voxels  = voxelize_hits(hits_df, vox_size, strict_vox_size, HitEnergy.Ep)
+    voxels    = voxelize_hits(hits_df, vox_size, strict_vox_size, HitEnergy.Ep)
 
-    tracks  = sorted(make_track_graphs(voxels), key = get_track_energy, reverse = True)
+    tracks    = sorted(make_track_graphs(voxels), key = get_track_energy, reverse = True)
 
+    distances = shortest_paths(tracks[0])
     # extract blob energies & positions in both cases
     a, b = find_extrema(tracks[0])
     ca = blob_centre(a)
     cb = blob_centre(b)
-    a_recalced = find_highest_encapsulating_node(tracks[0], a, big_radius, small_radius)
-    b_recalced = find_highest_encapsulating_node(tracks[0], b, big_radius, small_radius)
+    a_recalced = find_highest_encapsulating_node(tracks[0], a, distances, big_radius, small_radius)
+    b_recalced = find_highest_encapsulating_node(tracks[0], b, distances, big_radius, small_radius)
     ca_recalced = blob_centre(a_recalced)
     cb_recalced = blob_centre(b_recalced)
 

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -32,6 +32,7 @@ from networkx.generators.random_graphs import fast_gnp_random_graph
 from .. evm.event_model import Voxel
 
 from . paolina_functions import bounding_box
+from . paolina_functions import find_highest_encapsulating_node
 from . paolina_functions import round_hits_positions_in_place
 from . paolina_functions import energy_of_voxels_within_radius
 from . paolina_functions import find_extrema
@@ -852,3 +853,57 @@ def test_make_voxel_graph_keeps_energy_consistence(hits, voxel_dimensions):
     tracks = make_track_graphs(voxels)
     # assert sum of track energy equal to sum of hits energies
     assert_almost_equal(sum(get_track_energy(track) for track in tracks), hits.E.sum())
+
+
+def test_encapsulation_works_as_intended():
+    '''
+    test to ensure that setting a big/small radius
+    has the desired effect (capturing the most favourable
+    voxel for energy capture).
+    '''
+
+    # define general parameters
+    vox_size        = [1., 1., 1.]
+    strict_vox_size = True
+    big_radius = 2.83  # sqrt of 8    --> next to nearest neighbours in 2D
+    small_radius = 1.8 # sqrt of 3    --> nearest neighbours in 3D
+
+    # generate hits to make a track
+    x = [-4.5, -3.5, -2.5, -1.5, -0.5, 0.5, 1.5, 2.5, 3.5, 4.5, -4.5, -3.5, 3.5, 4.5, 5.5, 4.5, 5.5, -3.5, -2.5, 4.5]
+    y = [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 1.5, 1.5, 1.5, 1.5, 1.5, 2.5, 2.5, -0.5, -0.5, -0.5]
+    z = np.zeros(shape = len(x))
+    E = np.ones( shape = len(x))
+
+    # reshape
+    hits = []
+    for _x, _y, _z, _E in zip(x, y, z, E):
+        hits.append([0, 1, _x, _y, _z, 1, _E, _E])
+
+    hits_df = pd.DataFrame(hits, columns = ['event', 'npeak', 'X', 'Y', 'Z', 'Q', 'E', 'Ep'])
+
+    voxels  = voxelize_hits(hits_df, vox_size, strict_vox_size, HitEnergy.Ep)
+
+    tracks  = sorted(make_track_graphs(voxels), key = get_track_energy, reverse = True)
+
+    # extract blob energies & positions in both cases
+    a, b = find_extrema(tracks[0])
+    ca = blob_centre(a)
+    cb = blob_centre(b)
+    a_recalced = find_highest_encapsulating_node(tracks[0], a, big_radius, small_radius)
+    b_recalced = find_highest_encapsulating_node(tracks[0], b, big_radius, small_radius)
+    ca_recalced = blob_centre(a_recalced)
+    cb_recalced = blob_centre(b_recalced)
+
+    # ensure old extremes are where you expect
+    assert a.XYZ          == approx((-4, 1, 0), abs=1e-9)
+    assert b.XYZ          == approx(( 5, 2, 0), abs=1e-9)
+    # and centres calculated from them
+    assert ca             == approx((-4.5, 1, 0), abs=1e-9)
+    assert cb             == approx(( 5.5, 2.5, 0), abs=1e-9)
+
+    # find the central voxels
+    assert a_recalced.XYZ == approx((-3, 0, 0), abs=1e-9)
+    assert b_recalced.XYZ == approx(( 4, 1, 0), abs=1e-9)
+    # and the recalculated centres based on hit position
+    assert ca_recalced    == approx((-3.5, -0.5, 0), abs=1e-9)
+    assert cb_recalced    == approx(( 4.5, 1,    0), abs=1e-9)

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -891,12 +891,12 @@ def test_encapsulation_works_as_intended():
     ca_recalced = blob_centre(a_recalced)
     cb_recalced = blob_centre(b_recalced)
 
-    # ensure old extremes are where you expect
-    assert a.XYZ          == approx((-4, 1, 0), abs=1e-9)
-    assert b.XYZ          == approx(( 5, 2, 0), abs=1e-9)
-    # and centres calculated from them
-    assert ca             == approx((-4.5, 1, 0), abs=1e-9)
-    assert cb             == approx(( 5.5, 2.5, 0), abs=1e-9)
+    # ensure the old method doesn't match the new method
+    assert a.XYZ     != a_recalced.XYZ
+    assert b.XYZ     != b_recalced.XYZ
+
+    assert np.any(ca != ca_recalced)
+    assert np.any(cb != cb_recalced)
 
     # find the central voxels
     assert a_recalced.XYZ == approx((-3, 0, 0), abs=1e-9)

--- a/invisible_cities/reco/paolina_functions_test.py
+++ b/invisible_cities/reco/paolina_functions_test.py
@@ -875,11 +875,7 @@ def test_encapsulation_works_as_intended():
     E = np.ones( shape = len(x))
 
     # reshape
-    hits = []
-    for _x, _y, _z, _E in zip(x, y, z, E):
-        hits.append([0, 1, _x, _y, _z, 1, _E, _E])
-
-    hits_df   = pd.DataFrame(hits, columns = ['event', 'npeak', 'X', 'Y', 'Z', 'Q', 'E', 'Ep'])
+    hits_df = pd.DataFrame(dict(event=0, npeak=1, X=x, Y=y, Z=z, Q=1, E=E, Ep=E))
 
     voxels    = voxelize_hits(hits_df, vox_size, strict_vox_size, HitEnergy.Ep)
 


### PR DESCRIPTION
This PR introduces the function `find_highest_encapsulating_node()`, which is a slightly more intelligent method for identifying blob centres.

It takes the two track extrema, and iterates over all nodes within a radius (the `scan_radius`). Each node within this range is then taken as a 'centre' and the `blob_radius` is used to determine the energy encapsulated around the node. The node that captures the highest energy is determined the most favourable and as such becomes the blob centre.

The `scan_radius` parameter has been included in all topology cities and is backwards compatible (if it's set to None, paolina will run as it did previously).